### PR TITLE
Make subscription URL follow the HTTP host

### DIFF
--- a/samples/Samples.Server/wwwroot/index.html
+++ b/samples/Samples.Server/wwwroot/index.html
@@ -136,7 +136,7 @@
         });
     }
 
-    var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient("ws://localhost:60341/graphql", { reconnect: true });
+    var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient("ws://" + window.location.host + "/graphql", { reconnect: true });
     var subscriptionsFetcher = window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
 
     // Render <GraphiQL /> into the body.


### PR DESCRIPTION
This makes it non-dependent on the IIS express port being selected. The host property includes the port, e.g. `localhost:60000`