### PR TITLE
Add index.html to be served by default

### DIFF
--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -43,12 +43,14 @@ namespace GraphQL.Samples.Server
         {
             if (env.IsDevelopment())
                 app.UseDeveloperExceptionPage();
-
+            
+            app.UseDefaultFiles();
             app.UseStaticFiles();
 
             app.UseWebSockets();
             app.UseGraphQLEndPoint<ChatSchema>("/graphql");
-
+            
+            app.UseDefaultFiles();
             app.UseMvc();
         }
     }

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -50,7 +50,6 @@ namespace GraphQL.Samples.Server
             app.UseWebSockets();
             app.UseGraphQLEndPoint<ChatSchema>("/graphql");
             
-            app.UseDefaultFiles();
             app.UseMvc();
         }
     }


### PR DESCRIPTION
This will enable the graphiql editor to show by default rather than requiring to specify the path.