### PR TITLE
Websocket Handle other method from subscriptions

### DIFF
--- a/src/WebSockets/Abstractions/ISubscriptionDeterminator.cs
+++ b/src/WebSockets/Abstractions/ISubscriptionDeterminator.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GraphQL.Server.Transports.WebSockets.Abstractions
+{
+    public interface ISubscriptionDeterminator
+    {
+        bool IsSubscription(ExecutionOptions config);
+    }
+}

--- a/src/WebSockets/GraphQLWebSocketsOptions.cs
+++ b/src/WebSockets/GraphQLWebSocketsOptions.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using GraphQL.Server.Transports.WebSockets.Messages;
+using GraphQL.Validation;
 using Microsoft.AspNetCore.Http;
 
 namespace GraphQL.Server.Transports.WebSockets
@@ -9,5 +11,9 @@ namespace GraphQL.Server.Transports.WebSockets
         public PathString Path { get; set; } = "/graphql";
 
         public Func<OperationMessageContext, object> BuildUserContext { get; set; }
+
+        public bool ExposeExceptions { get; set; }
+
+        public IList<IValidationRule> ValidationRules { get; } = new List<IValidationRule>();
     }
 }

--- a/src/WebSockets/GraphQlWebSocketsExtensions.cs
+++ b/src/WebSockets/GraphQlWebSocketsExtensions.cs
@@ -14,6 +14,7 @@ namespace GraphQL.Server.Transports.WebSockets
         {
             services.TryAddSingleton<ISubscriptionExecuter, SubscriptionExecuter>();
             services.TryAddSingleton<IDocumentWriter, DocumentWriter>();
+            services.TryAddSingleton<ISubscriptionDeterminator, SubscriptionDeterminator>();
 
             services.TryAddSingleton<ISubscriptionProtocolHandler<TSchema>, SubscriptionProtocolHandler<TSchema>>();
             services.TryAddSingleton<GraphQLEndPoint<TSchema>>();

--- a/src/WebSockets/Messages/OperationMessage.cs
+++ b/src/WebSockets/Messages/OperationMessage.cs
@@ -12,6 +12,6 @@ namespace GraphQL.Server.Transports.WebSockets.Messages
         public string Id { get; set; }
 
         [JsonProperty("payload")]
-        public JObject Payload { get; set; }
+        public dynamic Payload { get; set; }
     }
 }

--- a/src/WebSockets/SubscriptionDeterminator.cs
+++ b/src/WebSockets/SubscriptionDeterminator.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GraphQL.Execution;
+using GraphQL.Instrumentation;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
+using GraphQLParser.AST;
+using OperationType = GraphQL.Language.AST.OperationType;
+
+namespace GraphQL.Server.Transports.WebSockets
+{
+    public class SubscriptionDeterminator
+    {
+        private readonly IDocumentBuilder _documentBuilder;
+
+        public SubscriptionDeterminator(): this(new GraphQLDocumentBuilder())
+        {
+        }
+
+        public SubscriptionDeterminator(IDocumentBuilder documentBuilder)
+        {
+            _documentBuilder = documentBuilder;
+        }
+
+        public bool IsSubscription(ExecutionOptions config)
+        {
+
+            config.Schema.FieldNameConverter = config.FieldNameConverter;
+
+            ValidateOptions(config);
+
+            if (!config.Schema.Initialized)
+            {
+                config.Schema.Initialize();
+            }
+
+            var document = config.Document ?? _documentBuilder.Build(config.Query);
+
+            return GetOperation(config.OperationName, document).OperationType == OperationType.Subscription;
+        }
+
+        private void ValidateOptions(ExecutionOptions options)
+        {
+            if (options.Schema == null)
+            {
+                throw new ExecutionError("A schema is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(options.Query))
+            {
+                throw new ExecutionError("A query is required.");
+            }
+        }
+
+        protected virtual Operation GetOperation(string operationName, Document document)
+        {
+            var operation = !string.IsNullOrWhiteSpace(operationName)
+                ? document.Operations.WithName(operationName)
+                : document.Operations.FirstOrDefault();
+
+            return operation;
+        }
+    }
+}

--- a/src/WebSockets/SubscriptionHandle.cs
+++ b/src/WebSockets/SubscriptionHandle.cs
@@ -53,12 +53,11 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public Task OnNext(object value)
         {
-            var json = _documentWriter.Write(value);
             return _messageWriter.WriteMessageAsync(new OperationMessage
             {
                 Id = Op.Id,
                 Type = MessageTypes.GQL_DATA,
-                Payload = JObject.Parse(json)
+                Payload = value
             });
         }
     }

--- a/src/WebSockets/SubscriptionProtocolHandler.cs
+++ b/src/WebSockets/SubscriptionProtocolHandler.cs
@@ -81,7 +81,8 @@ namespace GraphQL.Server.Transports.WebSockets
 
         protected async Task HandleStartAsync(OperationMessageContext context)
         {
-            var query = context.Op.Payload as GraphQLQuery;
+            var payload = context.Op.Payload;
+            var query = payload is GraphQLQuery ? payload : context.Op.Payload.ToObject<GraphQLQuery>();
             var options = context.Connection.Options;
             var exOptions = new ExecutionOptions
             {
@@ -111,7 +112,7 @@ namespace GraphQL.Server.Transports.WebSockets
                 {
                     Type = MessageTypes.GQL_DATA,
                     Id = context.Op.Id,
-                    Payload = result.Data
+                    Payload = result
                 });
                 await context.MessageWriter.WriteMessageAsync(new OperationMessage
                 {

--- a/tests/WebSockets.Tests/SubscriptionProtocolHandlerFacts.cs
+++ b/tests/WebSockets.Tests/SubscriptionProtocolHandlerFacts.cs
@@ -22,6 +22,7 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
             _documentExecuter = Substitute.For<IDocumentExecuter>();
             _subscriptionExecuter = Substitute.For<ISubscriptionExecuter>();
             _messageWriter = Substitute.For<IJsonMessageWriter>();
+            _determinator = Substitute.For<ISubscriptionDeterminator>();
 
             _connection = Substitute.For<IConnectionContext>();
             _connection.Writer.Returns(_messageWriter);
@@ -32,6 +33,7 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
                 _schema,
                 _subscriptionExecuter,
                 _documentExecuter,
+                _determinator,
                 logger);
         }
 
@@ -41,6 +43,7 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
         private readonly SubscriptionProtocolHandler<TestSchema> _sut;
         private readonly IJsonMessageWriter _messageWriter;
         private IConnectionContext _connection;
+        private readonly ISubscriptionDeterminator _determinator;
 
         private SubscriptionExecutionResult CreateStreamResult(CallInfo arg)
         {
@@ -58,7 +61,7 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
             {
                 Id = Guid.NewGuid().ToString(),
                 Type = type,
-                Payload = payload != null ? JObject.FromObject(payload) : null
+                Payload = payload
             };
 
             return new OperationMessageContext(_connection, op);
@@ -82,13 +85,13 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
         }
 
         [Fact]
-        public async Task should_handle_start()
+        public async Task should_handle_start_subscriptions()
         {
             /* Given */
             var query = new GraphQLQuery
             {
                 OperationName = "test",
-                Query = "query",
+                Query = "subscription",
                 Variables = JObject.FromObject(new {test = "variable"})
             };
 
@@ -97,6 +100,8 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
 
             _subscriptionExecuter.SubscribeAsync(Arg.Any<ExecutionOptions>())
                 .Returns(CreateStreamResult);
+
+            _determinator.IsSubscription(Arg.Any<ExecutionOptions>()).Returns(true);
 
             /* When */
             await _sut.HandleMessageAsync(messageContext).ConfigureAwait(false);
@@ -110,6 +115,43 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
                 .ConfigureAwait(false);
             var connectionSubscriptions = _sut.Subscriptions[messageContext.ConnectionId];
             Assert.True(connectionSubscriptions.ContainsKey(messageContext.Op.Id));
+        }
+
+        [Fact]
+        public async Task should_handle_start_others()
+        {
+            /* Given */
+            var query = new GraphQLQuery
+            {
+                OperationName = "test",
+                Query = "query",
+                Variables = JObject.FromObject(new { test = "variable" })
+            };
+            var messageContext = CreateMessage(MessageTypes.GQL_START, query);
+
+            var result = new object();
+            _documentExecuter.ExecuteAsync(Arg.Any<ExecutionOptions>()).Returns(new ExecutionResult{ Data = result});
+
+            _determinator.IsSubscription(Arg.Any<ExecutionOptions>()).Returns(false);
+
+            /* When */
+            await _sut.HandleMessageAsync(messageContext).ConfigureAwait(false);
+
+            /* Then */
+            await _documentExecuter.Received()
+                .ExecuteAsync(Arg.Is<ExecutionOptions>(
+                    context => context.Schema == _schema
+                               && context.Query == query.Query
+                               && context.Inputs.ContainsKey("test")))
+                .ConfigureAwait(false);
+
+            await _messageWriter.Received().WriteMessageAsync(Arg.Is<OperationMessage>(
+                context => context.Type == MessageTypes.GQL_DATA
+            )).ConfigureAwait(false);
+
+            await _messageWriter.Received().WriteMessageAsync(Arg.Is<OperationMessage>(
+                context => context.Type == MessageTypes.GQL_COMPLETE
+            )).ConfigureAwait(false);
         }
 
         [Fact]

--- a/tests/WebSockets.Tests/SubscriptionProtocolHandlerFacts.cs
+++ b/tests/WebSockets.Tests/SubscriptionProtocolHandlerFacts.cs
@@ -55,7 +55,7 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
             };
         }
 
-        private OperationMessageContext CreateMessage(string type, object payload)
+        private OperationMessageContext CreateMessage(string type, GraphQLQuery payload)
         {
             var op = new OperationMessage
             {


### PR DESCRIPTION
This is a quick implementation of how to handle allow the web socket protocol to handle not only subscriptions but queries and mutations as well. This is related to issue #51.

The main issue that I have with the implementation is that I need to parse the document to figure out what the operation type is. Any suggestions on how to work around this I would look into changing it. 

If this implementation methodology is acceptable, I will look at cleaning it up and adding in the necessary tests.