### PR TITLE
GraphiQL Support

### DIFF
--- a/GraphQL.Server.Transports.sln
+++ b/GraphQL.Server.Transports.sln
@@ -32,6 +32,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ui.Playground", "src\Ui.Pla
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL.Server.AspNetCore.GraphiQL", "src\GraphQL.Server.AspNetCore.GraphiQL\GraphQL.Server.AspNetCore.GraphiQL.csproj", "{B83414A2-F9E3-44CC-982F-5D830F54BED3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{77C56C3B-519A-45E3-BA59-88C6367154F9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{EB56A378-89E5-4425-BFA6-6BA0F4A67432} = {DD6938E1-E98D-4BD4-9882-FE1CE79F7306}
 		{85FBD882-AC9F-419F-95ED-42BBBC199CC2} = {DD6938E1-E98D-4BD4-9882-FE1CE79F7306}
+		{B83414A2-F9E3-44CC-982F-5D830F54BED3} = {77C56C3B-519A-45E3-BA59-88C6367154F9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3FC7FA59-E938-453C-8C4A-9D5635A9489A}

--- a/GraphQL.Server.Transports.sln
+++ b/GraphQL.Server.Transports.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+VisualStudioVersion = 15.0.27130.2024
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{DD6938E1-E98D-4BD4-9882-FE1CE79F7306}"
 EndProject
@@ -28,7 +28,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore", "src\AspNetCor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSockets.Tests", "tests\WebSockets.Tests\WebSockets.Tests.csproj", "{63AF8BD1-95F4-4443-9C30-891E3DBEB7AE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ui.Playground", "src\Ui.Playground\Ui.Playground.csproj", "{C6DA4A1C-867A-4633-B15B-12A2EEE9F405}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ui.Playground", "src\Ui.Playground\Ui.Playground.csproj", "{C6DA4A1C-867A-4633-B15B-12A2EEE9F405}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQL.Server.AspNetCore.GraphiQL", "src\GraphQL.Server.AspNetCore.GraphiQL\GraphQL.Server.AspNetCore.GraphiQL.csproj", "{B83414A2-F9E3-44CC-982F-5D830F54BED3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,6 +62,10 @@ Global
 		{C6DA4A1C-867A-4633-B15B-12A2EEE9F405}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C6DA4A1C-867A-4633-B15B-12A2EEE9F405}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C6DA4A1C-867A-4633-B15B-12A2EEE9F405}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B83414A2-F9E3-44CC-982F-5D830F54BED3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B83414A2-F9E3-44CC-982F-5D830F54BED3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B83414A2-F9E3-44CC-982F-5D830F54BED3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B83414A2-F9E3-44CC-982F-5D830F54BED3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/Samples.Server/Samples.Server.csproj
+++ b/samples/Samples.Server/Samples.Server.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AspNetCore\AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\GraphQL.Server.AspNetCore.GraphiQL\GraphQL.Server.AspNetCore.GraphiQL.csproj" />
     <ProjectReference Include="..\..\src\Ui.Playground\Ui.Playground.csproj" />
     <ProjectReference Include="..\..\src\WebSockets\WebSockets.csproj" />
     <ProjectReference Include="..\Samples.Schemas.Chat\Samples.Schemas.Chat.csproj" />

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -1,4 +1,5 @@
 using GraphQL.Samples.Schemas.Chat;
+using GraphQL.Server.AspNetCore.GraphiQL;
 using GraphQL.Server.Transports.AspNetCore;
 using GraphQL.Server.Transports.WebSockets;
 using GraphQL.Server.Transports.WebSockets.Events;
@@ -51,6 +52,7 @@ namespace GraphQL.Samples.Server
             app.UseGraphQLWebSocket<ChatSchema>(new GraphQLWebSocketsOptions());
             app.UseGraphQLHttp<ChatSchema>(new GraphQLHttpOptions());
             app.UseGraphQLPlayground(new GraphQLPlaygroundOptions());
+            app.UseGraphiQLServer(new GraphiQLMiddlewareSettings { GraphQLEndPoint = "/graphql" });
             app.UseMvc();
         }
     }

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/GraphQL.Server.AspNetCore.GraphiQL.csproj
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/GraphQL.Server.AspNetCore.GraphiQL.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<!--<Import Project="../src.props" />-->
+
+	<PropertyGroup>
+		<Description>A GraphiQL Integration for AspNetCore</Description>
+		<TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
+	</PropertyGroup>
+
+	<ItemGroup>
+	  <EmbeddedResource Include="Internal\graphiql.cshtml" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
+	</ItemGroup>
+	
+</Project>

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddleware.cs
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddleware.cs
@@ -47,7 +47,6 @@ namespace GraphQL.Server.AspNetCore.GraphiQL {
 			httpResponse.ContentType = "text/html";
 			httpResponse.StatusCode = 200;
 
-			// TODO: use RazorPageGenerator when ASP.NET Core 1.1 is out...?
 			var graphiQLPageModel = new GraphiQLPageModel(this.settings);
 
 			var data = Encoding.UTF8.GetBytes(graphiQLPageModel.Render());

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddleware.cs
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddleware.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using GraphQL.Server.AspNetCore.GraphiQL.Internal;
+using Microsoft.AspNetCore.Http;
+
+namespace GraphQL.Server.AspNetCore.GraphiQL {
+
+	/// <summary>
+	/// A middleware for GraphiQL
+	/// </summary>
+	public class GraphiQLMiddleware : BaseMiddleware {
+
+		private readonly GraphiQLMiddlewareSettings settings;
+
+		/// <summary>
+		/// Create a new GraphiQLMiddleware
+		/// </summary>
+		/// <param name="nextMiddleware">The Next Middleware</param>
+		/// <param name="settings">The Settings of the Middleware</param>
+		public GraphiQLMiddleware(RequestDelegate nextMiddleware, GraphiQLMiddlewareSettings settings) : base(nextMiddleware) {
+			this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+		}
+
+		/// <summary>
+		/// Try to execute the logic of the middleware
+		/// </summary>
+		/// <param name="httpContext">The HttpContext</param>
+		/// <returns></returns>
+		public async override Task Invoke(HttpContext httpContext) {
+			if (httpContext == null) { throw new ArgumentNullException(nameof(httpContext)); }
+
+			if (this.IsGraphiQLRequest(httpContext.Request)) {
+				await this.InvokeGraphiQL(httpContext.Response).ConfigureAwait(false);
+				return;
+			}
+
+			await this.NextMiddleware(httpContext).ConfigureAwait(false);
+		}
+
+		private bool IsGraphiQLRequest(HttpRequest httpRequest) {
+			return httpRequest.Path.StartsWithSegments(this.settings.GraphiQLPath)
+				&& string.Equals(httpRequest.Method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase);
+		}
+
+		private async Task InvokeGraphiQL(HttpResponse httpResponse) {
+			httpResponse.ContentType = "text/html";
+			httpResponse.StatusCode = 200;
+
+			// TODO: use RazorPageGenerator when ASP.NET Core 1.1 is out...?
+			var graphiQLPageModel = new GraphiQLPageModel(this.settings);
+
+			var data = Encoding.UTF8.GetBytes(graphiQLPageModel.Render());
+			await httpResponse.Body.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
+		}
+
+	}
+
+}

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddlewareExtensions.cs
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddlewareExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+
+namespace GraphQL.Server.AspNetCore.GraphiQL {
+
+	/// <summary>
+	/// Extension methods for <see cref="GraphiQLMiddleware"/>
+	/// </summary>
+	public static class GraphiQLMiddlewareExtensions {
+
+		/// <summary>
+		/// Enables a GraphiQLServer using the specified settings
+		/// </summary>
+		/// <param name="applicationBuilder"></param>
+		/// <param name="settings">The settings of the Middleware</param>
+		/// <returns></returns>
+		public static IApplicationBuilder UseGraphiQLServer(this IApplicationBuilder applicationBuilder, GraphiQLMiddlewareSettings settings) {
+			if (settings == null) { throw new ArgumentNullException(nameof(settings)); }
+
+			applicationBuilder.UseMiddleware<GraphiQLMiddleware>(settings);
+			return applicationBuilder;
+		}
+
+	}
+
+}

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddlewareExtensions.cs
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddlewareExtensions.cs
@@ -1,12 +1,12 @@
 using System;
-using Microsoft.AspNetCore.Builder;
+using GraphQL.Server.AspNetCore.GraphiQL;
 
-namespace GraphQL.Server.AspNetCore.GraphiQL {
+namespace Microsoft.AspNetCore.Builder {
 
-	/// <summary>
-	/// Extension methods for <see cref="GraphiQLMiddleware"/>
-	/// </summary>
-	public static class GraphiQLMiddlewareExtensions {
+    /// <summary>
+    /// Extension methods for <see cref="GraphiQLMiddleware"/>
+    /// </summary>
+    public static class GraphiQLMiddlewareExtensions {
 
 		/// <summary>
 		/// Enables a GraphiQLServer using the specified settings

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddlewareSettings.cs
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/GraphiQLMiddlewareSettings.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http;
+
+namespace GraphQL.Server.AspNetCore.GraphiQL {
+
+	/// <summary>
+	/// The Settings of the <see cref="GraphiQLMiddleware"/>
+	/// </summary>
+	public class GraphiQLMiddlewareSettings {
+
+		/// <summary>
+		/// The GraphiQL Endpoint to listen
+		/// </summary>
+		public PathString GraphiQLPath { get; set; } = "/graphiql";
+
+		/// <summary>
+		/// The GraphQL EndPoint
+		/// </summary>
+		public PathString GraphQLEndPoint { get; set; } = "/api/graphql";
+
+	}
+
+}

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/IMiddleware.cs
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/IMiddleware.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace GraphQL.Server.AspNetCore.GraphiQL {
+
+	/// <summary>
+	/// Represents a Middleware for AspNetCore
+	/// </summary>
+	public interface IMiddleware {
+
+		/// <summary>
+		/// Invoke the action of a Middleware
+		/// </summary>
+		/// <param name="httpContext"></param>
+		/// <returns></returns>
+		Task Invoke(HttpContext httpContext);
+
+	}
+
+	/// <summary>
+	/// Base Class for implement Middlewares
+	/// </summary>
+	public abstract class BaseMiddleware : IMiddleware {
+
+		/// <summary>
+		/// The Next Middleware
+		/// </summary>
+		protected RequestDelegate NextMiddleware { get; }
+
+		/// <summary>
+		/// Initialize an instance of a Middleware
+		/// </summary>
+		/// <param name="nextMiddleware"></param>
+		public BaseMiddleware(RequestDelegate nextMiddleware) {
+			this.NextMiddleware = nextMiddleware ?? throw new ArgumentNullException(nameof(nextMiddleware));
+		}
+
+		/// <summary>
+		/// Invoke the action of a Middleware
+		/// </summary>
+		/// <param name="httpContext"></param>
+		/// <returns></returns>
+		public abstract Task Invoke(HttpContext httpContext);
+
+	}
+
+}

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/Internal/GraphiQLPageModel.cs
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/Internal/GraphiQLPageModel.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace GraphQL.Server.AspNetCore.GraphiQL.Internal {
+
+	// https://docs.microsoft.com/en-us/aspnet/core/mvc/razor-pages/?tabs=netcore-cli
+	internal class GraphiQLPageModel {
+
+		private static string graphiQLCSHtml;
+
+		private readonly GraphiQLMiddlewareSettings settings;
+
+		public GraphiQLPageModel(GraphiQLMiddlewareSettings settings) {
+			this.settings = settings;
+		}
+
+		public string Render() {
+			if (graphiQLCSHtml != null) {
+				return graphiQLCSHtml;
+			}
+			var assembly = typeof(GraphiQLPageModel).GetTypeInfo().Assembly;
+			var resource = assembly.GetManifestResourceStream("GraphQL.Server.AspNetCore.GraphiQL.Internal.graphiql.cshtml");
+
+			var builder = new StringBuilder(new StreamReader(resource).ReadToEnd());
+			builder.Replace("@Model.GraphQLEndPoint", this.settings.GraphQLEndPoint);
+			graphiQLCSHtml = builder.ToString();
+
+			return this.Render();
+		}
+
+	}
+
+}

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/Internal/graphiql.cshtml
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/Internal/graphiql.cshtml
@@ -1,0 +1,150 @@
+<!--
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+	<style>
+		body {
+			height: 100%;
+			margin: 0;
+			width: 100%;
+			overflow: hidden;
+		}
+
+		#graphiql {
+			height: 100vh;
+		}
+	</style>
+
+	<!--
+	  This GraphiQL example depends on Promise and fetch, which are available in
+	  modern browsers, but can be "polyfilled" for older browsers.
+	  GraphiQL itself depends on React DOM.
+	  If you do not want to rely on a CDN, you can host these files locally or
+	  include them directly in your favored resource bunder.
+	-->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.production.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.production.min.js"></script>
+
+	<!--
+	  These two files can be found in the npm module, however you may wish to
+	  copy them directly into your environment, or perhaps include them in your
+	  favored resource bundler.
+	 -->
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.css" />
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.min.js"></script>
+
+</head>
+<body>
+	<div id="graphiql">Loading...</div>
+	<script>
+
+		/**
+		 * This GraphiQL example illustrates how to use some of GraphiQL's props
+		 * in order to enable reading and updating the URL parameters, making
+		 * link sharing of queries a little bit easier.
+		 *
+		 * This is only one example of this kind of feature, GraphiQL exposes
+		 * various React params to enable interesting integrations.
+		 */
+
+		// Parse the search string to get url parameters.
+		var search = window.location.search;
+		var parameters = {};
+		search.substr(1).split('&').forEach(function (entry) {
+			var eq = entry.indexOf('=');
+			if (eq >= 0) {
+				parameters[decodeURIComponent(entry.slice(0, eq))] =
+					decodeURIComponent(entry.slice(eq + 1));
+			}
+		});
+
+		// if variables was provided, try to format it.
+		if (parameters.variables) {
+			try {
+				parameters.variables =
+					JSON.stringify(JSON.parse(parameters.variables), null, 2);
+			} catch (e) {
+				// Do nothing, we want to display the invalid JSON as a string, rather
+				// than present an error.
+			}
+		}
+
+		// When the query and variables string is edited, update the URL bar so
+		// that it can be easily shared
+		function onEditQuery(newQuery) {
+			parameters.query = newQuery;
+			updateURL();
+		}
+
+		function onEditVariables(newVariables) {
+			parameters.variables = newVariables;
+			updateURL();
+		}
+
+		function onEditOperationName(newOperationName) {
+			parameters.operationName = newOperationName;
+			updateURL();
+		}
+
+		function updateURL() {
+			var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+				return Boolean(parameters[key]);
+			}).map(function (key) {
+				return encodeURIComponent(key) + '=' +
+					encodeURIComponent(parameters[key]);
+			}).join('&');
+			history.replaceState(null, null, newSearch);
+		}
+
+		// Defines a GraphQL fetcher using the fetch API. You're not required to
+		// use fetch, and could instead implement graphQLFetcher however you like,
+		// as long as it returns a Promise or Observable.
+		function graphQLFetcher(graphQLParams) {
+			// This example expects a GraphQL server at the path /graphql.
+			// Change this to point wherever you host your GraphQL server.
+			return fetch('@Model.GraphQLEndPoint', {
+				method: 'post',
+				headers: {
+					'Accept': 'application/json',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify(graphQLParams),
+				credentials: 'include',
+			}).then(function (response) {
+				return response.text();
+			}).then(function (responseBody) {
+				try {
+					return JSON.parse(responseBody);
+				} catch (error) {
+					return responseBody;
+				}
+			});
+		}
+
+		// Render <GraphiQL /> into the body.
+		// See the README in the top level of this module to learn more about
+		// how you can customize GraphiQL by providing different values or
+		// additional child elements.
+		ReactDOM.render(
+			React.createElement(GraphiQL, {
+				fetcher: graphQLFetcher,
+				query: parameters.query,
+				variables: parameters.variables,
+				operationName: parameters.operationName,
+				onEditQuery: onEditQuery,
+				onEditVariables: onEditVariables,
+				onEditOperationName: onEditOperationName
+			}),
+			document.getElementById('graphiql')
+		);
+	</script>
+</body>
+</html>

--- a/src/GraphQL.Server.AspNetCore.GraphiQL/Internal/graphiql.cshtml
+++ b/src/GraphQL.Server.AspNetCore.GraphiQL/Internal/graphiql.cshtml
@@ -38,8 +38,8 @@
 	  copy them directly into your environment, or perhaps include them in your
 	  favored resource bundler.
 	 -->
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.css" />
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.min.js"></script>
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.css" />
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.js"></script>
 
 </head>
 <body>


### PR DESCRIPTION
This PR adds a new Package that enables GraphiQL

Features:
- NetStandard1.3 (AspNetCore1.0)
- NetStandard2.0 (AspNetCore2.0)
- Specify GraphiQL EndPoint
- Specify GraphQL EndPoint target