### PR TITLE
added IDocumentExecutionListener to IDocumentExecuter from IOC

### DIFF
--- a/src/AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/AspNetCore/GraphQLHttpMiddleware.cs
@@ -69,9 +69,9 @@ namespace GraphQL.Server.Transports.AspNetCore
                 _.UserContext = _options.BuildUserContext?.Invoke(context);
                 _.ExposeExceptions = _options.ExposeExceptions;
                 _.ValidationRules = _options.ValidationRules.Concat(DocumentValidator.CoreRules()).ToList();
-                _documentListeners
-                    .ToList()
-                    .ForEach(_.Listeners.Add);
+                foreach(var listener in _documentListeners){
+                   _.Listeners.Add(listener);
+                }
             });
 
             await WriteResponseAsync(context, result);

--- a/src/AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/AspNetCore/GraphQLHttpMiddleware.cs
@@ -22,7 +22,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         private readonly IDocumentExecuter _executer;
         private readonly IDocumentWriter _writer;
         private readonly TSchema _schema;
-        private readonly IEnumerable<IDocumentExecutionListener> _documentListners;
+        private readonly IEnumerable<IDocumentExecutionListener> _documentListeners;
 
         public GraphQLHttpMiddleware(
             RequestDelegate next,
@@ -30,14 +30,14 @@ namespace GraphQL.Server.Transports.AspNetCore
             IDocumentExecuter executer,
             IDocumentWriter writer,
             TSchema schema,
-            IEnumerable<IDocumentExecutionListener> documentListners)
+            IEnumerable<IDocumentExecutionListener> documentListeners)
         {
             _next = next;
             _options = options.Value;
             _executer = executer;
             _writer = writer;
             _schema = schema;
-            _documentListners = documentListners;
+            _documentListeners = documentListeners;
         }
 
         public async Task Invoke(HttpContext context)
@@ -69,7 +69,7 @@ namespace GraphQL.Server.Transports.AspNetCore
                 _.UserContext = _options.BuildUserContext?.Invoke(context);
                 _.ExposeExceptions = _options.ExposeExceptions;
                 _.ValidationRules = _options.ValidationRules.Concat(DocumentValidator.CoreRules()).ToList();
-                _documentListners
+                _documentListeners
                     .ToList()
                     .ForEach(_.Listeners.Add);
             });

--- a/src/WebSockets/SubscriptionProtocolHandler.cs
+++ b/src/WebSockets/SubscriptionProtocolHandler.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Server.Transports.WebSockets
     {
         private readonly IDocumentExecuter _documentExecuter;
         private readonly ILogger<SubscriptionProtocolHandler<TSchema>> _log;
-        private readonly IEnumerable<IDocumentExecutionListener> _documentListners;
+        private readonly IEnumerable<IDocumentExecutionListener> _documentListeners;
         private readonly ISubscriptionDeterminator _determinator;
         private readonly TSchema _schema;
         private readonly ISubscriptionExecuter _subscriptionExecuter;
@@ -29,13 +29,13 @@ namespace GraphQL.Server.Transports.WebSockets
             IDocumentExecuter documentExecuter,
             ISubscriptionDeterminator determinator,
             ILogger<SubscriptionProtocolHandler<TSchema>> log,
-            IEnumerable<IDocumentExecutionListener> documentListners)
+            IEnumerable<IDocumentExecutionListener> documentListeners)
         {
             _schema = schema;
             _subscriptionExecuter = subscriptionExecuter;
             _documentExecuter = documentExecuter;
             _log = log;
-            _documentListners = documentListners;
+            _documentListeners = documentListeners;
             _determinator = determinator;
         }
 
@@ -98,7 +98,7 @@ namespace GraphQL.Server.Transports.WebSockets
                 ValidationRules = options?.ValidationRules,
                 UserContext = options?.BuildUserContext?.Invoke(context)
             };
-            _documentListners
+            _documentListeners
                 .ToList()
                 .ForEach(exOptions.Listeners.Add);
 

--- a/src/WebSockets/SubscriptionProtocolHandler.cs
+++ b/src/WebSockets/SubscriptionProtocolHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +10,7 @@ using GraphQL.Server.Transports.WebSockets.Abstractions;
 using GraphQL.Server.Transports.WebSockets.Messages;
 using GraphQL.Subscription;
 using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace GraphQL.Server.Transports.WebSockets
@@ -17,7 +19,7 @@ namespace GraphQL.Server.Transports.WebSockets
     {
         private readonly IDocumentExecuter _documentExecuter;
         private readonly ILogger<SubscriptionProtocolHandler<TSchema>> _log;
-        private readonly IEnumerable<IDocumentExecutionListener> _documentListeners;
+        private readonly IServiceProvider _serviceProvider;
         private readonly ISubscriptionDeterminator _determinator;
         private readonly TSchema _schema;
         private readonly ISubscriptionExecuter _subscriptionExecuter;
@@ -29,13 +31,13 @@ namespace GraphQL.Server.Transports.WebSockets
             IDocumentExecuter documentExecuter,
             ISubscriptionDeterminator determinator,
             ILogger<SubscriptionProtocolHandler<TSchema>> log,
-            IEnumerable<IDocumentExecutionListener> documentListeners)
+            IServiceProvider serviceProvider)
         {
             _schema = schema;
             _subscriptionExecuter = subscriptionExecuter;
             _documentExecuter = documentExecuter;
             _log = log;
-            _documentListeners = documentListeners;
+            _serviceProvider = serviceProvider;
             _determinator = determinator;
         }
 
@@ -98,7 +100,7 @@ namespace GraphQL.Server.Transports.WebSockets
                 ValidationRules = options?.ValidationRules,
                 UserContext = options?.BuildUserContext?.Invoke(context)
             };
-            foreach(var listener in _documentListeners){
+            foreach(var listener in _serviceProvider.GetServices<IDocumentExecutionListener>()){
                    exOptions.Listeners.Add(listener);
             }
 

--- a/src/WebSockets/SubscriptionProtocolHandler.cs
+++ b/src/WebSockets/SubscriptionProtocolHandler.cs
@@ -98,9 +98,9 @@ namespace GraphQL.Server.Transports.WebSockets
                 ValidationRules = options?.ValidationRules,
                 UserContext = options?.BuildUserContext?.Invoke(context)
             };
-            _documentListeners
-                .ToList()
-                .ForEach(exOptions.Listeners.Add);
+            foreach(var listener in _documentListeners){
+                   exOptions.Listeners.Add(listener);
+            }
 
             var isSubscription = _determinator.IsSubscription(exOptions);
 

--- a/tests/WebSockets.Tests/SubscriptionProtocolHandlerFacts.cs
+++ b/tests/WebSockets.Tests/SubscriptionProtocolHandlerFacts.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
@@ -25,6 +26,9 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
             _subscriptionExecuter = Substitute.For<ISubscriptionExecuter>();
             _messageWriter = Substitute.For<IJsonMessageWriter>();
             _determinator = Substitute.For<ISubscriptionDeterminator>();
+            _serviceProvider = Substitute.For<IServiceProvider>();
+            _serviceProvider.GetService(typeof(IEnumerable<IDocumentExecutionListener>))
+                .Returns(Enumerable.Empty<IDocumentExecutionListener>());
 
             _connection = Substitute.For<IConnectionContext>();
             _connection.Writer.Returns(_messageWriter);
@@ -37,7 +41,7 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
                 _documentExecuter,
                 _determinator,
                 logger,
-                Enumerable.Empty<IDocumentExecutionListener>()
+                _serviceProvider
                 );
         }
 
@@ -48,6 +52,7 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
         private readonly IJsonMessageWriter _messageWriter;
         private IConnectionContext _connection;
         private readonly ISubscriptionDeterminator _determinator;
+        private IServiceProvider _serviceProvider;
 
         private SubscriptionExecutionResult CreateStreamResult(CallInfo arg)
         {

--- a/tests/WebSockets.Tests/SubscriptionProtocolHandlerFacts.cs
+++ b/tests/WebSockets.Tests/SubscriptionProtocolHandlerFacts.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
+using GraphQL.Execution;
 using GraphQL.Server.Transports.AspNetCore.Common;
 using GraphQL.Server.Transports.WebSockets.Abstractions;
 using GraphQL.Server.Transports.WebSockets.Messages;
@@ -34,7 +36,9 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
                 _subscriptionExecuter,
                 _documentExecuter,
                 _determinator,
-                logger);
+                logger,
+                Enumerable.Empty<IDocumentExecutionListener>()
+                );
         }
 
         private readonly TestSchema _schema;


### PR DESCRIPTION
Because Dateloaders in grapgl-dotnet i we need to add IDocumentExecutionListener to the execution listners to handle the scope of the request.


Then it is just to add IDocumentExecutionListener implementations to the service collection