### PR TITLE
MessageHandlingContext as user context

### DIFF
--- a/GraphQL.Server.sln
+++ b/GraphQL.Server.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{DD6938E1-E98D-4BD4-9882-FE1CE79F7306}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Transports.Subscriptions.WebSockets", "src\Transports.Subscriptions.WebSockets\Transports.Subscriptions.WebSockets.csproj", "{4DF1CB8E-30AA-4281-9056-D49FDBF4C496}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Schemas.Chat", "samples\Samples.Schemas.Chat\Samples.Schemas.Chat.csproj", "{EB56A378-89E5-4425-BFA6-6BA0F4A67432}"
@@ -37,7 +35,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Transports.Subscriptions.Ab
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Transports.Subscriptions.Abstractions.Tests", "tests\Transports.Subscriptions.Abstractions.Tests\Transports.Subscriptions.Abstractions.Tests.csproj", "{1D36AB04-82FD-4EDC-94C2-D1BA29E170EC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ui.Voyager", "src\Ui.Voyager\Ui.Voyager.csproj", "{B2C278E4-6A1A-4F83-AE53-C9469B4056EE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ui.Voyager", "src\Ui.Voyager\Ui.Voyager.csproj", "{B2C278E4-6A1A-4F83-AE53-C9469B4056EE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -88,9 +86,6 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{85FBD882-AC9F-419F-95ED-42BBBC199CC2} = {DD6938E1-E98D-4BD4-9882-FE1CE79F7306}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3FC7FA59-E938-453C-8C4A-9D5635A9489A}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 
 `UserContext` of your resolver will be type of `MessageHandlingContext`. You can
 access the properties including your actual `UserContext` by using the
-`Get<YourContextType>` method. This will read the context from the properties of
+`Get<YourContextType>("UserContext")` method. This will read the context from the properties of
 `MessageHandlingContext`. You can add any other properties as to the context in
 `IOperationMessageListeners`. See the sample for example of injecting `ClaimsPrincipal`.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For the UI middleware/s:
 >`dotnet add package GraphQL.Server.Ui.Playground`
 >`dotnet add package GraphQL.Server.Ui.Voyager`
 
+
 ### Configure
 
 ``` csharp
@@ -36,6 +37,7 @@ public void ConfigureServices(IServiceCollection services)
             {
                 options.EnableMetrics = true;
                 options.ExposeExceptions = true;
+                options.UserContext = "something";
             });
 
     // add websocket transport for ChatSchema
@@ -64,6 +66,15 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 }
 
 ```
+
+### UserContext and resolvers
+
+`UserContext` of your resolver will be type of `MessageHandlingContext`. You can
+access the properties including your actual `UserContext` by using the
+`Get<YourContextType>` method. This will read the context from the properties of
+`MessageHandlingContext`. You can add any other properties as to the context in
+`IOperationMessageListeners`. See the sample for example of injecting `ClaimsPrincipal`.
+
 
 ## Sample
 

--- a/samples/Samples.Schemas.Chat/ChatSubscriptions.cs
+++ b/samples/Samples.Schemas.Chat/ChatSubscriptions.cs
@@ -28,7 +28,7 @@ namespace GraphQL.Samples.Schemas.Chat
             {
                 Name = "messageAddedByUser",
                 Arguments = new QueryArguments(
-                    new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "id" }
+                    new QueryArgument<NonNullGraphType<StringGraphType>> {Name = "id"}
                 ),
                 Type = typeof(MessageType),
                 Resolver = new FuncFieldResolver<Message>(ResolveMessage),
@@ -40,8 +40,12 @@ namespace GraphQL.Samples.Schemas.Chat
         {
             var messageContext = context.UserContext.As<MessageHandlingContext>();
             var user = messageContext.Get<ClaimsPrincipal>("user");
-            var sub = user.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;    
-            var messages =  _chat.Messages(sub);
+
+            var sub = "Anonymous";
+            if (user != null)
+                sub = user.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
+
+            var messages = _chat.Messages(sub);
 
             var id = context.GetArgument<string>("id");
             return messages.Where(message => message.From.Id == id);
@@ -58,7 +62,10 @@ namespace GraphQL.Samples.Schemas.Chat
         {
             var messageContext = context.UserContext.As<MessageHandlingContext>();
             var user = messageContext.Get<ClaimsPrincipal>("user");
-            var sub = user.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
+
+            var sub = "Anonymous";
+            if (user != null)
+                sub = user.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
 
             return _chat.Messages(sub);
         }

--- a/samples/Samples.Schemas.Chat/IChat.cs
+++ b/samples/Samples.Schemas.Chat/IChat.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Samples.Schemas.Chat
 
         Message AddMessage(Message message);
 
-        IObservable<Message> Messages();
+        IObservable<Message> Messages(string user);
 
         Message AddMessage(ReceivedMessage message);
     }
@@ -61,9 +61,15 @@ namespace GraphQL.Samples.Schemas.Chat
             return message;
         }
 
-        public IObservable<Message> Messages()
+        public IObservable<Message> Messages(string user)
         {
-            return _messageStream.AsObservable();
+            return _messageStream
+                .Select(message =>
+                {
+                    message.Sub = user;
+                    return message;
+                })
+                .AsObservable();
         }
 
         public void AddError(Exception exception)

--- a/samples/Samples.Schemas.Chat/Message.cs
+++ b/samples/Samples.Schemas.Chat/Message.cs
@@ -6,6 +6,8 @@ namespace GraphQL.Samples.Schemas.Chat
     {
         public MessageFrom From { get; set; }
 
+        public string Sub { get; set; }
+
         public string Content { get; set; }
 
         public DateTime SentAt { get; set; }

--- a/samples/Samples.Schemas.Chat/MessageType.cs
+++ b/samples/Samples.Schemas.Chat/MessageType.cs
@@ -8,6 +8,7 @@ namespace GraphQL.Samples.Schemas.Chat
         {
             Field(o => o.Content);
             Field(o => o.SentAt);
+            Field(o => o.Sub);
             Field(o => o.From, false, typeof(MessageFromType)).Resolve(ResolveFrom);
         }
 

--- a/samples/Samples.Schemas.Chat/Samples.Schemas.Chat.csproj
+++ b/samples/Samples.Schemas.Chat/Samples.Schemas.Chat.csproj
@@ -9,4 +9,7 @@
         <PackageReference Include="GraphQL" Version="[2.0.0-alpha-868, 2.1)" />
         <PackageReference Include="System.Reactive" Version="3.1.1" />
     </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Transports.Subscriptions.Abstractions\Transports.Subscriptions.Abstractions.csproj" />
+    </ItemGroup>
 </Project>

--- a/samples/Samples.Server/AddAuthenticator.cs
+++ b/samples/Samples.Server/AddAuthenticator.cs
@@ -38,7 +38,7 @@ namespace GraphQL.Samples.Server
             _httpContextAccessor = httpContextAccessor;
         }
 
-        public Task<bool> BeforeHandleAsync(MessageHandlingContext context)
+        public Task BeforeHandleAsync(MessageHandlingContext context)
         {
             if (context.Message.Type == MessageType.GQL_CONNECTION_INIT)
             {

--- a/samples/Samples.Server/AddAuthenticator.cs
+++ b/samples/Samples.Server/AddAuthenticator.cs
@@ -1,0 +1,75 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using GraphQL.Samples.Schemas.Chat;
+using GraphQL.Server.Transports.Subscriptions.Abstractions;
+using GraphQL.Server.Transports.WebSockets;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using MessageType = GraphQL.Server.Transports.Subscriptions.Abstractions.MessageType;
+
+namespace GraphQL.Samples.Server
+{
+    public class AddAuthenticator : IPostConfigureOptions<ExecutionOptions<ChatSchema>>
+    {
+        private readonly IOperationMessageListener _authenticator;
+
+        public AddAuthenticator(ITokenListener tokenListener)
+        {
+            _authenticator = tokenListener;
+        }
+
+        public void PostConfigure(string name, ExecutionOptions<ChatSchema> options)
+        {
+            options.MessageListeners.Insert(0, _authenticator);
+        }
+    }
+
+    public interface ITokenListener : IOperationMessageListener
+    {
+    }
+
+    public class TokenListener : ITokenListener
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public TokenListener(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public Task<bool> BeforeHandleAsync(MessageHandlingContext context)
+        {
+            if (context.Message.Type == MessageType.GQL_CONNECTION_INIT)
+            {
+                var token = context.Message.Payload.Value<string>("token");
+
+                if (!string.IsNullOrEmpty(token))
+                {
+                    _httpContextAccessor.HttpContext
+                        .User = new ClaimsPrincipal(
+                        new ClaimsIdentity(
+                            new[]
+                            {
+                                new Claim(JwtRegisteredClaimNames.Sub, token)
+                            }
+                        ));
+                }
+            }
+
+            var user = _httpContextAccessor.HttpContext.User;
+            context.Properties["user"] = user;
+            return Task.FromResult(true);
+        }
+
+        public Task HandleAsync(MessageHandlingContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task AfterHandleAsync(MessageHandlingContext context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -1,15 +1,17 @@
+using System.Linq;
+using System.Threading.Tasks;
 using GraphQL.Samples.Schemas.Chat;
 using GraphQL.Server.Transports.AspNetCore;
-using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using GraphQL.Server.Transports.WebSockets;
 using GraphQL.Server.Ui.GraphiQL;
 using GraphQL.Server.Ui.Playground;
 using GraphQL.Server.Ui.Voyager;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using MessageType = GraphQL.Samples.Schemas.Chat.MessageType;
+using Microsoft.Extensions.Options;
 
 namespace GraphQL.Samples.Server
 {
@@ -25,6 +27,8 @@ namespace GraphQL.Samples.Server
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
             services.AddSingleton<IChat, Chat>();
             services.AddSingleton<ChatSchema>();
             services.AddSingleton<ChatQuery>();
@@ -42,6 +46,9 @@ namespace GraphQL.Samples.Server
                 options.EnableMetrics = true;
                 options.ExposeExceptions = true;
             });
+
+            services.AddSingleton<ITokenListener, TokenListener>();
+            services.AddSingleton<IPostConfigureOptions<ExecutionOptions<ChatSchema>>, AddAuthenticator>();
             
             // register default services for web socket. This will also add the protocol handler.
             services.AddGraphQLWebSocket<ChatSchema>();

--- a/src/Transports.Subscriptions.Abstractions/DefaultSchemaExecuter.cs
+++ b/src/Transports.Subscriptions.Abstractions/DefaultSchemaExecuter.cs
@@ -17,20 +17,23 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             Schema = schema;
         }
 
-        public virtual Task<ExecutionResult> ExecuteAsync(string operationName, string query, JObject variables)
+        public virtual Task<ExecutionResult> ExecuteAsync(string operationName, string query, JObject variables,
+            MessageHandlingContext context)
         {
-            var options = GetOptions(operationName, query, variables);
+            var options = GetOptions(operationName, query, variables, context);
             return _documentExecuter.ExecuteAsync(options);
         }
 
-        protected virtual ExecutionOptions GetOptions(string operationName, string query, JObject variables)
+        protected virtual ExecutionOptions GetOptions(string operationName, string query, JObject variables,
+            MessageHandlingContext context)
         {
             var options = new ExecutionOptions
             {
                 Schema = Schema,
                 OperationName = operationName,
                 Query = query,
-                Inputs = variables.ToInputs()
+                Inputs = variables.ToInputs(),
+                UserContext = context
             };
             return options;
         }

--- a/src/Transports.Subscriptions.Abstractions/IGraphQLExecuter.cs
+++ b/src/Transports.Subscriptions.Abstractions/IGraphQLExecuter.cs
@@ -14,7 +14,9 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         /// <param name="operationName"></param>
         /// <param name="query"></param>
         /// <param name="variables"></param>
+        /// <param name="context"></param>
         /// <returns></returns>
-        Task<ExecutionResult> ExecuteAsync(string operationName, string query, JObject variables);
+        Task<ExecutionResult> ExecuteAsync(string operationName, string query, JObject variables,
+            MessageHandlingContext context);
     }
 }

--- a/src/Transports.Subscriptions.Abstractions/IOperationMessageListener.cs
+++ b/src/Transports.Subscriptions.Abstractions/IOperationMessageListener.cs
@@ -7,6 +7,8 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     /// </summary>
     public interface IOperationMessageListener
     {
+        Task<bool> BeforeHandleAsync(MessageHandlingContext context);
+
         /// <summary>
         ///     Called to handle message
         /// </summary>

--- a/src/Transports.Subscriptions.Abstractions/IOperationMessageListener.cs
+++ b/src/Transports.Subscriptions.Abstractions/IOperationMessageListener.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     /// </summary>
     public interface IOperationMessageListener
     {
-        Task<bool> BeforeHandleAsync(MessageHandlingContext context);
+        Task BeforeHandleAsync(MessageHandlingContext context);
 
         /// <summary>
         ///     Called to handle message

--- a/src/Transports.Subscriptions.Abstractions/IServerOperations.cs
+++ b/src/Transports.Subscriptions.Abstractions/IServerOperations.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions
+{
+    public interface IServerOperations
+    {
+        Task Terminate();
+
+        IReaderPipeline TransportReader { get; }
+
+        IWriterPipeline TransportWriter { get; }
+
+        ISubscriptionManager Subscriptions { get; }
+    }
+}

--- a/src/Transports.Subscriptions.Abstractions/ISubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/ISubscriptionManager.cs
@@ -13,9 +13,9 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         /// </summary>
         /// <param name="id"></param>
         /// <param name="payload"></param>
-        /// <param name="writer"></param>
+        /// <param name="context"></param>
         /// <returns></returns>
-        Task SubscribeOrExecuteAsync(string id, OperationMessagePayload payload, IWriterPipeline writer);
+        Task SubscribeOrExecuteAsync(string id, OperationMessagePayload payload, MessageHandlingContext context);
 
         /// <summary>
         ///     Unsubscribe subscription

--- a/src/Transports.Subscriptions.Abstractions/LogMessagesListener.cs
+++ b/src/Transports.Subscriptions.Abstractions/LogMessagesListener.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             _logger = logger;
         }
 
-        public Task<bool> BeforeHandleAsync(MessageHandlingContext context)
+        public Task BeforeHandleAsync(MessageHandlingContext context)
         {
             return Task.FromResult(true);
         }

--- a/src/Transports.Subscriptions.Abstractions/MessageHandlingContext.cs
+++ b/src/Transports.Subscriptions.Abstractions/MessageHandlingContext.cs
@@ -30,6 +30,8 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public ConcurrentDictionary<string, object> Properties { get; protected set; } =
             new ConcurrentDictionary<string, object>();
 
+        public bool Terminated { get; set; }
+
         public void Dispose()
         {
             foreach (var property in Properties)
@@ -49,6 +51,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
 
         public Task Terminate()
         {
+            Terminated = true;
             return _server.Terminate();
         }
     }

--- a/src/Transports.Subscriptions.Abstractions/MessageHandlingContext.cs
+++ b/src/Transports.Subscriptions.Abstractions/MessageHandlingContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
-using GraphQL.Validation;
 
 namespace GraphQL.Server.Transports.Subscriptions.Abstractions
 {
@@ -31,6 +30,13 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public ConcurrentDictionary<string, object> Properties { get; protected set; } =
             new ConcurrentDictionary<string, object>();
 
+        public void Dispose()
+        {
+            foreach (var property in Properties)
+                if (property.Value is IDisposable disposable)
+                    disposable.Dispose();
+        }
+
         public T Get<T>(string key)
         {
             if (!Properties.TryGetValue(key, out var value)) return default(T);
@@ -39,15 +45,6 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
                 return variable;
 
             return default(T);
-        }
-
-        public void Dispose()
-        {
-            foreach (var property in Properties)
-            {
-                if (property.Value is IDisposable disposable)
-                    disposable.Dispose();
-            }
         }
 
         public Task Terminate()

--- a/src/Transports.Subscriptions.Abstractions/MessageHandlingContext.cs
+++ b/src/Transports.Subscriptions.Abstractions/MessageHandlingContext.cs
@@ -7,11 +7,10 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
 {
     public class MessageHandlingContext : IDisposable
     {
-        private readonly SubscriptionServer _server;
-
+        private readonly IServerOperations _server;
 
         public MessageHandlingContext(
-            SubscriptionServer server,
+            IServerOperations server,
             OperationMessage message)
         {
             _server = server;

--- a/src/Transports.Subscriptions.Abstractions/MessageType.cs
+++ b/src/Transports.Subscriptions.Abstractions/MessageType.cs
@@ -44,8 +44,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public const string GQL_CONNECTION_KEEP_ALIVE = "ka"; // Server -> Client
 
         /// <summary>
-        ///     Client sends this message in order to stop a running GraphQL operation execution (for example: unsubscribe)
-        ///     id: string : operation id
+        ///     Client sends this message to terminate the connection.
         /// </summary>
         public const string GQL_CONNECTION_TERMINATE = "connection_terminate"; // Client -> Server
 

--- a/src/Transports.Subscriptions.Abstractions/ProtocolMessageListener.cs
+++ b/src/Transports.Subscriptions.Abstractions/ProtocolMessageListener.cs
@@ -15,13 +15,16 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         }
 
 
-        public Task<bool> BeforeHandleAsync(MessageHandlingContext context)
+        public Task BeforeHandleAsync(MessageHandlingContext context)
         {
-            return Task.FromResult(true);
+            return Task.CompletedTask;
         }
 
         public async Task HandleAsync(MessageHandlingContext context)
         {
+            if (context.Terminated)
+                return;
+
             var message = context.Message;
             switch (message.Type)
             {

--- a/src/Transports.Subscriptions.Abstractions/ProtocolMessageListener.cs
+++ b/src/Transports.Subscriptions.Abstractions/ProtocolMessageListener.cs
@@ -85,7 +85,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             return context.Subscriptions.SubscribeOrExecuteAsync(
                 message.Id,
                 payload,
-                context.Writer);
+                context);
         }
 
         private Task HandleInitAsync(MessageHandlingContext context)

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
@@ -39,9 +39,9 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public async Task SubscribeOrExecuteAsync(
             string id,
             OperationMessagePayload payload,
-            IWriterPipeline writer)
+            MessageHandlingContext context)
         {
-            var subscription = await ExecuteAsync(id, payload, writer);
+            var subscription = await ExecuteAsync(id, payload, context);
 
             if (subscription == null)
                 return;
@@ -67,8 +67,9 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         private async Task<Subscription> ExecuteAsync(
             string id,
             OperationMessagePayload payload,
-            IWriterPipeline writer)
+            MessageHandlingContext context)
         {
+            var writer = context.Writer;
             _logger.LogDebug("Executing operation: {operationName} query: {query}",
                 payload.OperationName,
                 payload.Query);
@@ -76,7 +77,8 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             var result = await _executer.ExecuteAsync(
                 payload.OperationName,
                 payload.Query,
-                payload.Variables);
+                payload.Variables, 
+                context);
 
             if (result.Errors != null && result.Errors.Any())
             {

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -41,6 +42,10 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             OperationMessagePayload payload,
             MessageHandlingContext context)
         {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            if (payload == null) throw new ArgumentNullException(nameof(payload));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            
             var subscription = await ExecuteAsync(id, payload, context);
 
             if (subscription == null)

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
@@ -97,6 +97,10 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             using (var context = await BuildMessageHandlingContext(message))
             {
                 await OnBeforeHandleAsync(context);
+
+                if (context.Terminated)
+                    return;
+
                 await OnHandleAsync(context);
                 await OnAfterHandleAsync(context);
             }
@@ -106,12 +110,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         {
             foreach (var listener in _messageListeners)
             {
-                var continueProcessing = await listener.BeforeHandleAsync(context);
-
-                if (!continueProcessing)
-                {
-                    break;
-                }
+                await listener.BeforeHandleAsync(context);
             }
         }
 
@@ -123,13 +122,17 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         private async Task OnHandleAsync(MessageHandlingContext context)
         {
             foreach (var listener in _messageListeners)
+            {
                 await listener.HandleAsync(context);
+            }
         }
 
         private async Task OnAfterHandleAsync(MessageHandlingContext context)
         {
             foreach (var listener in _messageListeners)
+            {
                 await listener.AfterHandleAsync(context);
+            }
         }
 
         private void LinkToTransportWriter()

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     ///     Subscription server
     ///     Acts as a message pump reading, handling and writing messages
     /// </summary>
-    public class SubscriptionServer
+    public class SubscriptionServer : IServerOperations
     {
         private readonly ILogger<SubscriptionServer> _logger;
         private readonly IEnumerable<IOperationMessageListener> _messageListeners;

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
@@ -96,8 +96,22 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             _logger.LogDebug("Handling message: {id} of type: {type}", message.Id, message.Type);
             using (var context = await BuildMessageHandlingContext(message))
             {
+                await OnBeforeHandleAsync(context);
                 await OnHandleAsync(context);
                 await OnAfterHandleAsync(context);
+            }
+        }
+
+        private async Task OnBeforeHandleAsync(MessageHandlingContext context)
+        {
+            foreach (var listener in _messageListeners)
+            {
+                var continueProcessing = await listener.BeforeHandleAsync(context);
+
+                if (!continueProcessing)
+                {
+                    break;
+                }
             }
         }
 

--- a/src/Transports.Subscriptions.WebSockets/ConfigurableExecuter.cs
+++ b/src/Transports.Subscriptions.WebSockets/ConfigurableExecuter.cs
@@ -21,9 +21,10 @@ namespace GraphQL.Server.Transports.WebSockets
             _options = options.Value;
         }
 
-        protected override ExecutionOptions GetOptions(string operationName, string query, JObject variables)
+        protected override ExecutionOptions GetOptions(string operationName, string query, JObject variables,
+            MessageHandlingContext context)
         {
-            var options = base.GetOptions(operationName, query, variables);
+            var options = base.GetOptions(operationName, query, variables, context);
 
             if (_options.Listeners != null)
                 foreach (var listener in _options.Listeners)
@@ -35,8 +36,10 @@ namespace GraphQL.Server.Transports.WebSockets
             options.FieldMiddleware = _options.FieldMiddleware;
             options.FieldNameConverter = _options.FieldNameConverter;
             options.SetFieldMiddleware = _options.SetFieldMiddleware;
-            options.UserContext = _options.UserContext;
             options.ValidationRules = _options.ValidationRules;
+
+            // add customer UserContext as property to MessageHandlingContext
+            context.Properties["UserContext"] = _options.UserContext;
 
             return options;
         }

--- a/src/Transports.Subscriptions.WebSockets/ExecutionOptions.cs
+++ b/src/Transports.Subscriptions.WebSockets/ExecutionOptions.cs
@@ -1,6 +1,11 @@
 ﻿using System.Collections.Generic;
+using GraphQL.Conversion;
+using GraphQL.Execution;
+using GraphQL.Instrumentation;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
 
 namespace GraphQL.Server.Transports.WebSockets
 {
@@ -8,7 +13,7 @@ namespace GraphQL.Server.Transports.WebSockets
     ///     GraphQL execution options for TSchema
     /// </summary>
     /// <typeparam name="TSchema"></typeparam>
-    public class ExecutionOptions<TSchema> : ExecutionOptions where TSchema : ISchema
+    public class ExecutionOptions<TSchema> where TSchema : ISchema
     {
         public ExecutionOptions()
         {
@@ -18,5 +23,23 @@ namespace GraphQL.Server.Transports.WebSockets
         public List<IOperationMessageListener> MessageListeners { get; set; }
 
         public IGraphQLExecuterFactory<TSchema> ExecuterFactory { get; set; }
+
+        public IEnumerable<IValidationRule> ValidationRules { get; set; }
+
+        public object UserContext { get; set; }
+
+        public IFieldMiddlewareBuilder FieldMiddleware { get; set; } = (IFieldMiddlewareBuilder) new FieldMiddlewareBuilder();
+
+        public ComplexityConfiguration ComplexityConfiguration { get; set; }
+
+        public IList<IDocumentExecutionListener> Listeners { get; } = (IList<IDocumentExecutionListener>) new List<IDocumentExecutionListener>();
+
+        public IFieldNameConverter FieldNameConverter { get; set; } = (IFieldNameConverter) new CamelCaseFieldNameConverter();
+
+        public bool ExposeExceptions { get; set; }
+
+        public bool EnableMetrics { get; set; } = true;
+
+        public bool SetFieldMiddleware { get; set; } = true;
     }
 }

--- a/tests/Transports.Subscriptions.Abstractions.Tests/OperationMessageCollectorListener.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/OperationMessageCollectorListener.cs
@@ -9,6 +9,11 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
 
         public ConcurrentBag<OperationMessage> HandledMessages { get; } = new ConcurrentBag<OperationMessage>();
 
+        public Task<bool> BeforeHandleAsync(MessageHandlingContext context)
+        {
+            return Task.FromResult(true);
+        }
+
         public Task HandleAsync(MessageHandlingContext context)
         {
             HandleMessages.Add(context.Message);

--- a/tests/Transports.Subscriptions.Abstractions.Tests/OperationMessageCollectorListener.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/OperationMessageCollectorListener.cs
@@ -9,9 +9,9 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
 
         public ConcurrentBag<OperationMessage> HandledMessages { get; } = new ConcurrentBag<OperationMessage>();
 
-        public Task<bool> BeforeHandleAsync(MessageHandlingContext context)
+        public Task BeforeHandleAsync(MessageHandlingContext context)
         {
-            return Task.FromResult(true);
+            return Task.CompletedTask;
         }
 
         public Task HandleAsync(MessageHandlingContext context)

--- a/tests/Transports.Subscriptions.Abstractions.Tests/ProtocolHandlerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/ProtocolHandlerFacts.cs
@@ -25,7 +25,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             _transportReader = _transport.Reader as TestableReader;
             _transportWriter = _transport.Writer as TestableWriter;
             _documentExecuter = Substitute.For<IGraphQLExecuter>();
-            _documentExecuter.ExecuteAsync(null, null, null).ReturnsForAnyArgs(
+            _documentExecuter.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new SubscriptionExecutionResult
                 {
                     Streams = new Dictionary<string, IObservable<ExecutionResult>>
@@ -65,7 +65,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
         public async Task Receive_start_mutation()
         {
             /* Given */
-            _documentExecuter.ExecuteAsync(null, null, null).ReturnsForAnyArgs(
+            _documentExecuter.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new ExecutionResult());
             var expected = new OperationMessage
             {
@@ -102,7 +102,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
         public async Task Receive_start_query()
         {
             /* Given */
-            _documentExecuter.ExecuteAsync(null, null, null).ReturnsForAnyArgs(
+            _documentExecuter.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new ExecutionResult());
             var expected = new OperationMessage
             {

--- a/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionManagerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionManagerFacts.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
         {
             _writer = Substitute.For<IWriterPipeline>();
             _executer = Substitute.For<IGraphQLExecuter>();
-            _executer.ExecuteAsync(null, null, null).ReturnsForAnyArgs(
+            _executer.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new SubscriptionExecutionResult
                 {
                     Streams = new Dictionary<string, IObservable<ExecutionResult>>
@@ -38,7 +38,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             var id = "1";
             var payload = new OperationMessagePayload();
 
-            _executer.ExecuteAsync(null, null, null).ReturnsForAnyArgs(
+            _executer.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new SubscriptionExecutionResult
                 {
                     Errors = new ExecutionErrors
@@ -48,7 +48,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                 });
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, _writer);
+            await _sut.SubscribeOrExecuteAsync(id, payload, null);
 
             /* Then */
             Assert.Empty(_sut);
@@ -61,7 +61,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             var id = "1";
             var payload = new OperationMessagePayload();
 
-            _executer.ExecuteAsync(null, null, null).ReturnsForAnyArgs(
+            _executer.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new SubscriptionExecutionResult
                 {
                     Streams = new Dictionary<string, IObservable<ExecutionResult>>
@@ -71,7 +71,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                 });
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, _writer);
+            await _sut.SubscribeOrExecuteAsync(id, payload, null);
 
             /* Then */
             await _writer.Received().SendAsync(
@@ -87,7 +87,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             var id = "1";
             var payload = new OperationMessagePayload();
 
-            _executer.ExecuteAsync(null, null, null).ReturnsForAnyArgs(
+            _executer.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new SubscriptionExecutionResult
                 {
                     Errors = new ExecutionErrors
@@ -97,7 +97,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                 });
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, _writer);
+            await _sut.SubscribeOrExecuteAsync(id, payload, null);
 
             /* Then */
             await _writer.Received().SendAsync(
@@ -114,7 +114,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             var payload = new OperationMessagePayload();
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, _writer);
+            await _sut.SubscribeOrExecuteAsync(id, payload, null);
 
             /* Then */
             Assert.Single(_sut, sub => sub.Id == id);
@@ -128,13 +128,14 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             var payload = new OperationMessagePayload();
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, _writer);
+            await _sut.SubscribeOrExecuteAsync(id, payload, null);
 
             /* Then */
             await _executer.Received().ExecuteAsync(
                 Arg.Is(payload.OperationName),
                 Arg.Is(payload.Query),
-                Arg.Any<dynamic>());
+                Arg.Any<dynamic>(), 
+                null);
         }
 
         [Fact]
@@ -143,7 +144,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             /* Given */
             var id = "1";
             var payload = new OperationMessagePayload();
-            await _sut.SubscribeOrExecuteAsync(id, payload, _writer);
+            await _sut.SubscribeOrExecuteAsync(id, payload, null);
 
             /* When */
             await _sut.UnsubscribeAsync(id);
@@ -158,7 +159,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             /* Given */
             var id = "1";
             var payload = new OperationMessagePayload();
-            await _sut.SubscribeOrExecuteAsync(id, payload, _writer);
+            await _sut.SubscribeOrExecuteAsync(id, payload, null);
 
             /* When */
             await _sut.UnsubscribeAsync(id);

--- a/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionManagerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionManagerFacts.cs
@@ -25,11 +25,13 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                     }
                 });
             _sut = new SubscriptionManager(_executer, new NullLoggerFactory());
+            _server = new TestableServerOperations(null, _writer, _sut);
         }
 
         private readonly SubscriptionManager _sut;
         private readonly IGraphQLExecuter _executer;
         private readonly IWriterPipeline _writer;
+        private readonly IServerOperations _server;
 
         [Fact]
         public async Task Failed_Subscribe_does_not_add()
@@ -37,6 +39,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             /* Given */
             var id = "1";
             var payload = new OperationMessagePayload();
+            var context = new MessageHandlingContext(_server, null);
 
             _executer.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new SubscriptionExecutionResult
@@ -48,7 +51,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                 });
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, null);
+            await _sut.SubscribeOrExecuteAsync(id, payload, context);
 
             /* Then */
             Assert.Empty(_sut);
@@ -59,7 +62,8 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
         {
             /* Given */
             var id = "1";
-            var payload = new OperationMessagePayload();
+            var payload = new OperationMessagePayload();  
+            var context = new MessageHandlingContext(_server, null);
 
             _executer.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new SubscriptionExecutionResult
@@ -71,7 +75,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                 });
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, null);
+            await _sut.SubscribeOrExecuteAsync(id, payload, context);
 
             /* Then */
             await _writer.Received().SendAsync(
@@ -86,6 +90,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             /* Given */
             var id = "1";
             var payload = new OperationMessagePayload();
+            var context = new MessageHandlingContext(_server, null);
 
             _executer.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new SubscriptionExecutionResult
@@ -97,7 +102,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                 });
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, null);
+            await _sut.SubscribeOrExecuteAsync(id, payload, context);
 
             /* Then */
             await _writer.Received().SendAsync(
@@ -112,9 +117,10 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             /* Given */
             var id = "1";
             var payload = new OperationMessagePayload();
+            var context = new MessageHandlingContext(_server, null);
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, null);
+            await _sut.SubscribeOrExecuteAsync(id, payload, context);
 
             /* Then */
             Assert.Single(_sut, sub => sub.Id == id);
@@ -126,16 +132,17 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             /* Given */
             var id = "1";
             var payload = new OperationMessagePayload();
+            var context = new MessageHandlingContext(_server, null);
 
             /* When */
-            await _sut.SubscribeOrExecuteAsync(id, payload, null);
+            await _sut.SubscribeOrExecuteAsync(id, payload, context);
 
             /* Then */
             await _executer.Received().ExecuteAsync(
                 Arg.Is(payload.OperationName),
                 Arg.Is(payload.Query),
                 Arg.Any<dynamic>(), 
-                null);
+                context);
         }
 
         [Fact]
@@ -144,7 +151,9 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             /* Given */
             var id = "1";
             var payload = new OperationMessagePayload();
-            await _sut.SubscribeOrExecuteAsync(id, payload, null);
+            var context = new MessageHandlingContext(_server, null);
+
+            await _sut.SubscribeOrExecuteAsync(id, payload, context);
 
             /* When */
             await _sut.UnsubscribeAsync(id);
@@ -159,7 +168,9 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             /* Given */
             var id = "1";
             var payload = new OperationMessagePayload();
-            await _sut.SubscribeOrExecuteAsync(id, payload, null);
+            var context = new MessageHandlingContext(_server, null);
+
+            await _sut.SubscribeOrExecuteAsync(id, payload, context);
 
             /* When */
             await _sut.UnsubscribeAsync(id);

--- a/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionServerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionServerFacts.cs
@@ -41,6 +41,29 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
         private readonly TestableReader _transportReader;
         private readonly TestableWriter _transportWriter;
 
+
+        [Fact]
+        public async Task Listener_BeforeHandle()
+        {
+            /* Given */
+            var expected = new OperationMessage
+            {
+                Type = MessageType.GQL_CONNECTION_INIT
+            };
+            _transportReader.AddMessageToRead(expected);
+            await _transportReader.Complete();
+
+            /* When */
+            await _sut.OnConnect();
+
+            /* Then */
+            await _messageListener.Received().BeforeHandleAsync(Arg.Is<MessageHandlingContext>(context =>
+                context.Writer == _transportWriter
+                && context.Reader == _transportReader
+                && context.Subscriptions == _subscriptionManager
+                && context.Message == expected));
+        }
+
         [Fact]
         public async Task Listener_Handle()
         {
@@ -64,7 +87,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
         }
 
         [Fact]
-        public async Task Listener_Handled()
+        public async Task Listener_AfterHandle()
         {
             /* Given */
             var expected = new OperationMessage

--- a/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionServerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionServerFacts.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             _transportReader = _transport.Reader as TestableReader;
             _transportWriter = _transport.Writer as TestableWriter;
             _documentExecuter = Substitute.For<IGraphQLExecuter>();
-            _documentExecuter.ExecuteAsync(null, null, null).ReturnsForAnyArgs(
+            _documentExecuter.ExecuteAsync(null, null, null, null).ReturnsForAnyArgs(
                 new SubscriptionExecutionResult
                 {
                     Streams = new Dictionary<string, IObservable<ExecutionResult>>

--- a/tests/Transports.Subscriptions.Abstractions.Tests/TestableServerOperations.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/TestableServerOperations.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
+{
+    public class TestableServerOperations : IServerOperations
+    {
+        public TestableServerOperations(
+            IReaderPipeline reader,
+            IWriterPipeline writer,
+            ISubscriptionManager subscriptions)
+        {
+            TransportReader = reader;
+            TransportWriter = writer;
+            Subscriptions = subscriptions;
+        }
+
+        public Task Terminate()
+        {
+            IsTerminated = true;
+            return Task.CompletedTask;
+        }
+
+        public bool IsTerminated { get; set; }
+
+        public IReaderPipeline TransportReader { get; }
+        public IWriterPipeline TransportWriter { get; }
+        public ISubscriptionManager Subscriptions { get; }
+    }
+}


### PR DESCRIPTION
* MessageHandlingContext set as UserContext for document execution (available in resolvers)
* Can add custom properties to MessageHandlingContext in IOperationMessageListener
* Update sample to include authentication example