### PR TITLE
Removed static ui cshtml and moved into instance instead

### DIFF
--- a/src/Ui.GraphiQL/GraphiQLMiddleware.cs
+++ b/src/Ui.GraphiQL/GraphiQLMiddleware.cs
@@ -17,7 +17,12 @@ namespace GraphQL.Server.Ui.GraphiQL {
         /// The Next Middleware
         /// </summary>
         private readonly RequestDelegate nextMiddleware;
-
+        
+        /// <summary>
+        /// The page model used to render GraphiQL
+        /// </summary>
+        private GraphiQLPageModel _pageModel;
+        
         /// <summary>
         /// Create a new GraphiQLMiddleware
         /// </summary>
@@ -53,9 +58,11 @@ namespace GraphQL.Server.Ui.GraphiQL {
 			httpResponse.ContentType = "text/html";
 			httpResponse.StatusCode = 200;
 
-			var graphiQLPageModel = new GraphiQLPageModel(this.settings);
+		    // Initilize page model if null
+		    if (_pageModel == null)
+		        _pageModel = new GraphiQLPageModel(this.settings);
 
-			var data = Encoding.UTF8.GetBytes(graphiQLPageModel.Render());
+            var data = Encoding.UTF8.GetBytes(_pageModel.Render());
 			await httpResponse.Body.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
 		}
 

--- a/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
+++ b/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Server.Ui.GraphiQL.Internal {
 	// https://docs.microsoft.com/en-us/aspnet/core/mvc/razor-pages/?tabs=netcore-cli
 	internal class GraphiQLPageModel {
 
-		private static string graphiQLCSHtml;
+		private string graphiQLCSHtml;
 
 		private readonly GraphiQLOptions settings;
 

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Server.Ui.Playground.Internal {
 	// https://docs.microsoft.com/en-us/aspnet/core/mvc/razor-pages/?tabs=netcore-cli
 	internal class PlaygroundPageModel {
 
-		private static string playgroundCSHtml;
+		private string playgroundCSHtml;
 
 		private readonly GraphQLPlaygroundOptions settings;
 

--- a/src/Ui.Playground/PlaygroundMiddleware.cs
+++ b/src/Ui.Playground/PlaygroundMiddleware.cs
@@ -19,6 +19,11 @@ namespace GraphQL.Server.Ui.Playground {
         private readonly RequestDelegate nextMiddleware;
 
         /// <summary>
+        /// The page model used to render Playground
+        /// </summary>
+        private PlaygroundPageModel _pageModel;
+
+        /// <summary>
         /// Create a new PlaygroundMiddleware
         /// </summary>
         /// <param name="nextMiddleware">The Next Middleware</param>
@@ -53,9 +58,11 @@ namespace GraphQL.Server.Ui.Playground {
             httpResponse.ContentType = "text/html";
             httpResponse.StatusCode = 200;
 
-            var playgroundPageModel = new PlaygroundPageModel(this.settings);
+            // Initilize page model if null
+            if (_pageModel == null)
+                _pageModel = new PlaygroundPageModel(this.settings);
 
-            var data = Encoding.UTF8.GetBytes(playgroundPageModel.Render());
+            var data = Encoding.UTF8.GetBytes(_pageModel.Render());
             await httpResponse.Body.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
         }
 

--- a/src/Ui.Voyager/Internal/VoyagerPageModel.cs
+++ b/src/Ui.Voyager/Internal/VoyagerPageModel.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Server.Ui.Voyager.Internal
     // https://docs.microsoft.com/en-us/aspnet/core/mvc/razor-pages/?tabs=netcore-cli
     internal class VoyagerPageModel
     {
-        private static string voyagerCSHtml;
+        private string voyagerCSHtml;
 
         private readonly GraphQLVoyagerOptions settings;
 

--- a/src/Ui.Voyager/VoyagerMiddleware.cs
+++ b/src/Ui.Voyager/VoyagerMiddleware.cs
@@ -19,6 +19,11 @@ namespace GraphQL.Server.Ui.Voyager
         private readonly RequestDelegate nextMiddleware;
 
         /// <summary>
+        /// The page model used to render Voyager
+        /// </summary>
+        private VoyagerPageModel _pageModel;
+
+        /// <summary>
         /// Create a new VoyagerMiddleware
         /// </summary>
         /// <param name="nextMiddleware">The Next Middleware</param>
@@ -57,9 +62,11 @@ namespace GraphQL.Server.Ui.Voyager
             httpResponse.ContentType = "text/html";
             httpResponse.StatusCode = 200;
 
-            var playgroundPageModel = new VoyagerPageModel(this._settings);
+            // Initilize page model if null
+            if (_pageModel == null)
+                _pageModel = new VoyagerPageModel(this._settings);
 
-            var data = Encoding.UTF8.GetBytes(playgroundPageModel.Render());
+            var data = Encoding.UTF8.GetBytes(_pageModel.Render());
             await httpResponse.Body.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
This is done such that multiple instances of playground, graphiql or voyager is supported.

Right now the same html is used if multiple middlewares is added, however it still responds to the request however with the output which the first request generated.