### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ public void ConfigureServices(IServiceCollection services)
     services.AddGraphQLHttp();
     
     // setup execution options for ChatSchema
-    services.Configure<ExecutionOptions<ChatSchema>>(options =>
+    services.Configure<ExecutionOptions>(options =>
             {
                 options.EnableMetrics = true;
                 options.ExposeExceptions = true;


### PR DESCRIPTION
ExecutionOptions is no longer generic in latest version of graphql-dotnet.