### PR TITLE
Use MVC JsonSerializerSettings & Indent JSON in Development

### DIFF
--- a/src/AspNetCore/AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL" Version="2.0.0-alpha-864" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />

--- a/src/AspNetCore/GraphQLExtensions.cs
+++ b/src/AspNetCore/GraphQLExtensions.cs
@@ -1,10 +1,11 @@
 using GraphQL.Http;
-using GraphQL.Subscription;
 using GraphQL.Types;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 
 namespace GraphQL.Server.Transports.AspNetCore
 {
@@ -13,11 +14,19 @@ namespace GraphQL.Server.Transports.AspNetCore
         /// <summary>
         /// Adds the GraphQLHttp to services
         /// </summary>
-        /// <param name="services">The servicecollection to registrer the services on</param>
-        /// <returns>The <see cref="IServiceCollection"/> recieved as parameter</returns>
+        /// <param name="services">The service collection to register the services on</param>
+        /// <returns>The <see cref="IServiceCollection"/> received as parameter</returns>
         public static IServiceCollection AddGraphQLHttp(this IServiceCollection services)
         {
-            services.TryAddSingleton<IDocumentWriter, DocumentWriter>();
+            services.TryAddSingleton<IDocumentWriter>(
+                x =>
+                {
+                    var hostingEnvironment = x.GetRequiredService<IHostingEnvironment>();
+                    var jsonSerializerSettings = x.GetRequiredService<IOptions<JsonSerializerSettings>>();
+                    return new DocumentWriter(
+                        hostingEnvironment.IsDevelopment() ? Formatting.Indented : Formatting.None,
+                        jsonSerializerSettings.Value);
+                });
             services.TryAddSingleton<IDocumentExecuter, DocumentExecuter>();
 
             return services;
@@ -27,8 +36,8 @@ namespace GraphQL.Server.Transports.AspNetCore
         /// Adds the GraphQLHttp to services
         /// </summary>
         /// <typeparam name="TUserContextBuilder">The <see cref="IUserContextBuilder"/> to use for generating the userContext used for the GraphQL request</typeparam>
-        /// <param name="services">The servicecollection to registrer the services on</param>
-        /// <returns>The <see cref="IServiceCollection"/> recieved as parameter</returns>
+        /// <param name="services">The service collection to register the services on</param>
+        /// <returns>The <see cref="IServiceCollection"/> received as parameter</returns>
         public static IServiceCollection AddGraphQLHttp<TUserContextBuilder>(this IServiceCollection services)
             where TUserContextBuilder : class, IUserContextBuilder
         {


### PR DESCRIPTION
The `JsonSerializerSettings` is available in MVC via `IOptions<T>` that is very easy to configure via `.AddMvcCore(...).AddJsonOptions(...)`. So perhaps we should use it.

The second part of this PR is to indent the JSON when running in development mode for better readability.