### PR TITLE
Add More Options to GraphQLHttpOptions

### DIFF
--- a/src/AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/AspNetCore/GraphQLHttpMiddleware.cs
@@ -55,7 +55,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         private async Task ExecuteAsync(HttpContext context, ISchema schema)
         {
             var request = Deserialize<GraphQLQuery>(context.Request.Body);
-            
+
             object userContext = null;
             var userContextBuilder = context.RequestServices.GetService<IUserContextBuilder>();
             if (userContextBuilder != null)
@@ -66,16 +66,19 @@ namespace GraphQL.Server.Transports.AspNetCore
             {
                 userContext = _options.BuildUserContext?.Invoke(context);
             }
-            
-            var result = await _executer.ExecuteAsync(_ =>
+
+            var result = await _executer.ExecuteAsync(x =>
             {
-                _.Schema = schema;
-                _.Query = request.Query;
-                _.OperationName = request.OperationName;
-                _.Inputs = request.Variables.ToInputs();
-                _.UserContext = userContext;
-                _.ExposeExceptions = _options.ExposeExceptions;
-                _.ValidationRules = _options.ValidationRules.Concat(DocumentValidator.CoreRules()).ToList();
+                x.Schema = schema;
+                x.Query = request.Query;
+                x.OperationName = request.OperationName;
+                x.Inputs = request.Variables.ToInputs();
+                x.UserContext = userContext;
+                x.ComplexityConfiguration = _options.ComplexityConfiguration;
+                x.EnableMetrics = _options.EnableMetrics;
+                x.ExposeExceptions = _options.ExposeExceptions;
+                x.SetFieldMiddleware = _options.SetFieldMiddleware;
+                x.ValidationRules = _options.ValidationRules.Concat(DocumentValidator.CoreRules()).ToList();
             });
 
             await WriteResponseAsync(context, result);

--- a/src/AspNetCore/GraphQLHttpOptions.cs
+++ b/src/AspNetCore/GraphQLHttpOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
 using Microsoft.AspNetCore.Http;
 
 namespace GraphQL.Server.Transports.AspNetCore
@@ -11,7 +12,13 @@ namespace GraphQL.Server.Transports.AspNetCore
 
         public Func<HttpContext, object> BuildUserContext { get; set; }
 
+        public ComplexityConfiguration ComplexityConfiguration { get; set; }
+
+        public bool EnableMetrics { get; set; } = true;
+
         public bool ExposeExceptions { get; set; }
+
+        public bool SetFieldMiddleware { get; set; } = true;
 
         public IList<IValidationRule> ValidationRules { get; } = new List<IValidationRule>();
     }


### PR DESCRIPTION
This PR adds the following properties to `GraphQLHttpOptions` and copies them through to `ExecutionOptions` in the GraphQL core package so the `DocumentExecuter` can make use of them:

- `ComplexityConfiguration`
- `EnableMetrics`
- `SetFieldMiddleware`