### PR TITLE
Add More Options to GraphQLHttpOptions

### DIFF
--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -62,7 +62,7 @@ namespace GraphQL.Server.Transports.AspNetCore
             // Handle requests as per recommendation at http://graphql.org/learn/serving-over-http/
             var httpRequest = context.Request;
             var gqlRequest = new GraphQLRequest();
-            
+
             if (HttpMethods.IsGet(httpRequest.Method) || (HttpMethods.IsPost(httpRequest.Method) && httpRequest.Query.ContainsKey(GraphQLRequest.QueryKey)))
             {
                 ExtractGraphQLRequestFromQueryString(httpRequest.Query, gqlRequest);
@@ -100,15 +100,18 @@ namespace GraphQL.Server.Transports.AspNetCore
                 userContext = _options.BuildUserContext?.Invoke(context);
             }
 
-            var result = await _executer.ExecuteAsync(_ =>
+            var result = await _executer.ExecuteAsync(x =>
             {
-                _.Schema = schema;
-                _.Query = gqlRequest.Query;
-                _.OperationName = gqlRequest.OperationName;
-                _.Inputs = gqlRequest.Variables.ToInputs();
-                _.UserContext = userContext;
-                _.ExposeExceptions = _options.ExposeExceptions;
-                _.ValidationRules = _options.ValidationRules.Concat(DocumentValidator.CoreRules()).ToList();
+                x.Schema = schema;
+                x.Query = gqlRequest.Query;
+                x.OperationName = gqlRequest.OperationName;
+                x.Inputs = gqlRequest.Variables.ToInputs();
+                x.UserContext = userContext;
+                x.ComplexityConfiguration = _options.ComplexityConfiguration;
+                x.EnableMetrics = _options.EnableMetrics;
+                x.ExposeExceptions = _options.ExposeExceptions;
+                x.SetFieldMiddleware = _options.SetFieldMiddleware;
+                x.ValidationRules = _options.ValidationRules.Concat(DocumentValidator.CoreRules()).ToList();
             });
 
             await WriteResponseAsync(context, result);

--- a/src/Transports.AspNetCore/GraphQLHttpOptions.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using GraphQL.Validation;
+using GraphQL.Validation.Complexity;
 using Microsoft.AspNetCore.Http;
 
 namespace GraphQL.Server.Transports.AspNetCore
@@ -11,7 +12,13 @@ namespace GraphQL.Server.Transports.AspNetCore
 
         public Func<HttpContext, object> BuildUserContext { get; set; }
 
+        public ComplexityConfiguration ComplexityConfiguration { get; set; }
+
+        public bool EnableMetrics { get; set; } = true;
+
         public bool ExposeExceptions { get; set; }
+
+        public bool SetFieldMiddleware { get; set; } = true;
 
         public IList<IValidationRule> ValidationRules { get; } = new List<IValidationRule>();
     }


### PR DESCRIPTION
Reraised for develop branch from https://github.com/graphql-dotnet/server/pull/116

This PR adds the following properties to `GraphQLHttpOptions` and copies them through to `ExecutionOptions` in the GraphQL core package so the `DocumentExecuter` can make use of them:

- `ComplexityConfiguration`
- `EnableMetrics`
- `SetFieldMiddleware`