### PR TITLE
Simplify configuration of ExecutionOptions

### DIFF
--- a/src/Transports.AspNetCore/Common/ExecutionOptionsFactory.cs
+++ b/src/Transports.AspNetCore/Common/ExecutionOptionsFactory.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using GraphQL.Execution;
+using GraphQL.Validation;
+
+namespace GraphQL.Server.Transports.AspNetCore.Common
+{
+    public class ExecutionOptionsFactory : IExecutionOptionsFactory
+    {
+        private readonly IEnumerable<IValidationRule> _validationRules;
+        private readonly IEnumerable<IDocumentExecutionListener> _documentListeners;
+
+        public ExecutionOptionsFactory(
+            IEnumerable<IValidationRule> validationRules,
+            IEnumerable<IDocumentExecutionListener> documentListeners
+            )
+        {
+            _validationRules = validationRules;
+            _documentListeners = documentListeners;
+        }
+
+        public virtual async Task<ExecutionOptions> CreateExecutionOptionsAsync()
+        {
+            var opts = new ExecutionOptions
+            {
+                EnableMetrics = true,
+                SetFieldMiddleware = true,
+                ValidationRules = _validationRules,
+            };
+
+            if (_documentListeners != null)
+            {
+                foreach (var listener in _documentListeners)
+                {
+                    opts.Listeners.Add(listener);
+                }
+            }
+
+            return await Task.FromResult(opts);
+        }
+    }
+}

--- a/src/Transports.AspNetCore/Common/ExecutionOptionsFactory.cs
+++ b/src/Transports.AspNetCore/Common/ExecutionOptionsFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Execution;
 using GraphQL.Validation;
@@ -15,7 +16,7 @@ namespace GraphQL.Server.Transports.AspNetCore.Common
             IEnumerable<IDocumentExecutionListener> documentListeners
             )
         {
-            _validationRules = validationRules;
+            _validationRules = DocumentValidator.CoreRules().Concat(validationRules);
             _documentListeners = documentListeners;
         }
 

--- a/src/Transports.AspNetCore/Common/IExecutionOptionsFactory.cs
+++ b/src/Transports.AspNetCore/Common/IExecutionOptionsFactory.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace GraphQL.Server.Transports.AspNetCore.Common
+{
+    public interface IExecutionOptionsFactory
+    {
+        Task<ExecutionOptions> CreateExecutionOptionsAsync();
+    }
+}

--- a/src/Transports.AspNetCore/GraphQLHttpOptions.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpOptions.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
-using GraphQL.Validation;
-using GraphQL.Validation.Complexity;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace GraphQL.Server.Transports.AspNetCore
@@ -10,16 +8,6 @@ namespace GraphQL.Server.Transports.AspNetCore
     {
         public PathString Path { get; set; } = "/graphql";
 
-        public Func<HttpContext, object> BuildUserContext { get; set; }
-
-        public ComplexityConfiguration ComplexityConfiguration { get; set; }
-
-        public bool EnableMetrics { get; set; } = true;
-
-        public bool ExposeExceptions { get; set; }
-
-        public bool SetFieldMiddleware { get; set; } = true;
-
-        public IList<IValidationRule> ValidationRules { get; } = new List<IValidationRule>();
+        public Func<ExecutionOptions, HttpContext, Task> ConfigureAsync { get; set; }
     }
 }


### PR DESCRIPTION
This removes the duplication of fields between `ExecutionOptions` and `GraphQLHttpOptions`, and offers direct customization of `ExecutionOptions` fields by way of a delegate function.

Here is an example of Configuration. Note that we no longer need a custom `BuildUserContext` function on `GraphQLHttpOptions` because `ConfigureAsync` also passes the current `HttpContext`.

```c#
app.UseGraphQLHttp<ISchema>(new GraphQLHttpOptions
{
    ConfigureAsync = async (opts, ctx) =>
    {
        opts.UserContext = new MyUserContext
        {
            User = ctx.User
        };
        opts.EnableMetrics = true;
        opts.ExposeExceptions = env.IsDevelopment();
        await Task.CompletedTask;
    },
});
```

Validators can be injected via the `IServiceCollection`:

```c#
services.AddSingleton(DocumentValidator.CoreRules().Concat(new[] {
    new MyCustomValidationRule(),
}));
```

Likewise, `IDocumentExecutionListener` instances can be injected via `IServiceCollection`, allowing, for example, DataLoader injection:

```c#
services.AddSingleton<IDocumentExecutionListener, DataLoaderDocumentListener>()
```