### PR TITLE
Modified GraphQLHttpOptions to be fully mutable.

### DIFF
--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -111,7 +111,7 @@ namespace GraphQL.Server.Transports.AspNetCore
                 x.EnableMetrics = _options.EnableMetrics;
                 x.ExposeExceptions = _options.ExposeExceptions;
                 x.SetFieldMiddleware = _options.SetFieldMiddleware;
-                x.ValidationRules = _options.ValidationRules.Concat(DocumentValidator.CoreRules()).ToList();
+                x.ValidationRules = DocumentValidator.CoreRules().Concat(_options.ValidationRules ?? Enumerable.Empty<IValidationRule>()).ToList();
             });
 
             await WriteResponseAsync(context, result);

--- a/src/Transports.AspNetCore/GraphQLHttpOptions.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpOptions.cs
@@ -20,6 +20,6 @@ namespace GraphQL.Server.Transports.AspNetCore
 
         public bool SetFieldMiddleware { get; set; } = true;
 
-        public IList<IValidationRule> ValidationRules { get; } = new List<IValidationRule>();
+        public IEnumerable<IValidationRule> ValidationRules { get; set; }
     }
 }


### PR DESCRIPTION
This allows object initializer syntax to be used for setting the validation rules.