### PR TITLE
#163 GraphiQL UI - Fix an issue where Â characters were displayed everywhere

### DIFF
--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -8,6 +8,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+	<meta charset="UTF-8">
 	<style>
 		body {
 			height: 100%;


### PR DESCRIPTION
Currently we are using your GraphQL.Server.Ui.GraphiQL package in a prototype for a graphql server application, but the GUI is filled by the character Â. The same symbol is blinking at the position of the cursor.

While trying to find a way to fix this issue I tried to download your repository myself and added the following line to the header of server/src/Ui.GraphiQL/Internal/graphiql.cshtml:

`<meta charset="UTF-8">`

With the encoding set to the UTF-8 charset, the Â characters disappeared. To do this manually is no really great solution as we have to change this on any update.

NPM package versions:
GraphQL v2.0.0
GraphQL.Server v1.1.0.1
GraphQL.Server.Ui.GraphiQL v3.2.0