### PR TITLE
Add GraphQL.Server.Authorization.AspNetCore NuGet package

### DIFF
--- a/GraphQL.Server.sln
+++ b/GraphQL.Server.sln
@@ -37,7 +37,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Transports.Subscriptions.Ab
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ui.Voyager", "src\Ui.Voyager\Ui.Voyager.csproj", "{B2C278E4-6A1A-4F83-AE53-C9469B4056EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "src\Core\Core.csproj", "{4872A0F3-FA1B-410B-834C-8A5653621E56}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "src\Core\Core.csproj", "{4872A0F3-FA1B-410B-834C-8A5653621E56}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Authorization.AspNetCore", "src\Authorization.AspNetCore\Authorization.AspNetCore.csproj", "{7A71AF0D-FE5F-4607-A6F6-960FD98CF840}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Authorization.AspNetCore.Tests", "tests\Authorization.AspNetCore.Tests\Authorization.AspNetCore.Tests.csproj", "{741DEEE6-FD0B-4F99-8A6F-43584B3E8D5F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -89,6 +93,14 @@ Global
 		{4872A0F3-FA1B-410B-834C-8A5653621E56}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4872A0F3-FA1B-410B-834C-8A5653621E56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4872A0F3-FA1B-410B-834C-8A5653621E56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A71AF0D-FE5F-4607-A6F6-960FD98CF840}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A71AF0D-FE5F-4607-A6F6-960FD98CF840}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A71AF0D-FE5F-4607-A6F6-960FD98CF840}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A71AF0D-FE5F-4607-A6F6-960FD98CF840}.Release|Any CPU.Build.0 = Release|Any CPU
+		{741DEEE6-FD0B-4F99-8A6F-43584B3E8D5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{741DEEE6-FD0B-4F99-8A6F-43584B3E8D5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{741DEEE6-FD0B-4F99-8A6F-43584B3E8D5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{741DEEE6-FD0B-4F99-8A6F-43584B3E8D5F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
+++ b/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
@@ -18,6 +18,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="GraphQL" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Project References">

--- a/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
+++ b/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
@@ -18,7 +18,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="GraphQL" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Project References">

--- a/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
+++ b/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -17,7 +17,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="GraphQL" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Project References">

--- a/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
+++ b/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Build">
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>GraphQL.Server.Authorization.AspNetCore</AssemblyName>
+    <RootNamespace>GraphQL.Server.Authorization.AspNetCore</RootNamespace>
+    <Product>graphql-dotnet server</Product>
+    <Company>graphql-dotnet</Company>
+    <Authors>Pekka Heikura</Authors>
+    <Description>HTTP authorization middleware for graphql</Description>
+    <PackageProjectUrl>https://github.com/graphql-dotnet/server</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/graphql-dotnet/server</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageTags>GraphQL authentication authorization middleware</PackageTags>
+    <Copyright>Pekka Heikura</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup Label="Package References">
+    <PackageReference Include="GraphQL" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
+++ b/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using GraphQL.Builders;
 using GraphQL.Types;
 
@@ -9,11 +8,15 @@ namespace GraphQL.Server.Authorization.AspNetCore
     {
         public const string PolicyKey = "Authorization__Policies";
 
-        public static bool RequiresAuthorization(this IProvideMetadata type) => GetPolicies(type).Any();
+        public static bool RequiresAuthorization(this IProvideMetadata type)
+        {
+            var policies = GetPolicies(type);
+            return policies != null && policies.Count > 0;
+        }
 
         public static void AuthorizeWith(this IProvideMetadata type, string policy)
         {
-            var list = GetPolicies(type);
+            var list = GetPolicies(type) ?? new List<string>();
             list.Fill(policy);
             type.Metadata[PolicyKey] = list;
         }

--- a/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
+++ b/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
@@ -26,6 +26,6 @@ namespace GraphQL.Server.Authorization.AspNetCore
         }
 
         public static List<string> GetPolicies(this IProvideMetadata type) =>
-            type.GetMetadata(PolicyKey, new List<string>());
+            type.GetMetadata<List<string>>(PolicyKey, null);
     }
 }

--- a/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
+++ b/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Builders;
+using GraphQL.Types;
+
+namespace GraphQL.Server.Authorization.AspNetCore
+{
+    public static class AuthorizationMetadataExtensions
+    {
+        public const string PolicyKey = "Authorization__Policies";
+
+        public static bool RequiresAuthorization(this IProvideMetadata type) => GetPolicies(type).Any();
+
+        public static void AuthorizeWith(this IProvideMetadata type, string policy)
+        {
+            var list = GetPolicies(type);
+            list.Fill(policy);
+            type.Metadata[PolicyKey] = list;
+        }
+
+        public static FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(
+            this FieldBuilder<TSourceType, TReturnType> builder, string policy)
+        {
+            builder.FieldType.AuthorizeWith(policy);
+            return builder;
+        }
+
+        public static List<string> GetPolicies(this IProvideMetadata type) =>
+            type.GetMetadata(PolicyKey, new List<string>());
+    }
+}

--- a/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
+++ b/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using GraphQL.Validation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+
+namespace GraphQL.Server.Authorization.AspNetCore
+{
+    public class AuthorizationValidationRule : IValidationRule
+    {
+        private readonly IAuthorizationService _authorizationService;
+
+        public AuthorizationValidationRule(IAuthorizationService authorizationService)
+        {
+            _authorizationService = authorizationService;
+        }
+
+        public INodeVisitor Validate(ValidationContext context)
+        {
+            var userContext = context.UserContext as IProvideClaimsPrincipal;
+
+            return new EnterLeaveListener(_ =>
+            {
+                var operationType = OperationType.Query;
+
+                // this could leak info about hidden fields or types in error messages
+                // it would be better to implement a filter on the Schema so it
+                // acts as if they just don't exist vs. an auth denied error
+                // - filtering the Schema is not currently supported
+
+                _.Match<Operation>(astType =>
+                {
+                    operationType = astType.OperationType;
+
+                    var type = context.TypeInfo.GetLastType();
+                    AuthorizeAsync(astType, type, userContext, context, operationType).GetAwaiter().GetResult();
+                });
+
+                _.Match<ObjectField>(objectFieldAst =>
+                {
+                    var argumentType = context.TypeInfo.GetArgument().ResolvedType.GetNamedType() as IComplexGraphType;
+                    if (argumentType == null)
+                    {
+                        return;
+                    }
+
+                    var fieldType = argumentType.GetField(objectFieldAst.Name);
+                    AuthorizeAsync(objectFieldAst, fieldType, userContext, context, operationType).GetAwaiter().GetResult();
+                });
+
+                _.Match<Field>(fieldAst =>
+                {
+                    var fieldDef = context.TypeInfo.GetFieldDef();
+                    if (fieldDef == null)
+                    {
+                        return;
+                    }
+
+                    // check target field
+                    AuthorizeAsync(fieldAst, fieldDef, userContext, context, operationType).GetAwaiter().GetResult();
+                    // check returned graph type
+                    AuthorizeAsync(fieldAst, fieldDef.ResolvedType, userContext, context, operationType).GetAwaiter().GetResult();
+                });
+            });
+        }
+
+        private async Task AuthorizeAsync(
+            INode node,
+            IProvideMetadata type,
+            IProvideClaimsPrincipal userContext,
+            ValidationContext context,
+            OperationType operationType)
+        {
+            if (userContext == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(userContext),
+                    $"You must register a user context that implements {nameof(IProvideClaimsPrincipal)}.");
+            }
+
+            if (type == null || !type.RequiresAuthorization())
+            {
+                return;
+            }
+
+            var policyNames = type.GetPolicies();
+            if (policyNames.Count == 0)
+            {
+                return;
+            }
+
+            var tasks = new List<Task<AuthorizationResult>>(policyNames.Count);
+            foreach (var policyName in policyNames)
+            {
+                var task = _authorizationService.AuthorizeAsync(userContext?.User, policyName);
+                tasks.Add(task);
+            }
+            await Task.WhenAll(tasks);
+
+            foreach (var task in tasks)
+            {
+                var result = task.Result;
+                if (!result.Succeeded)
+                {
+                    var stringBuilder = new StringBuilder("You are not authorized to run this ");
+                    stringBuilder.Append(operationType.ToString().ToLower());
+                    stringBuilder.AppendLine(".");
+
+                    foreach (var failure in result.Failure.FailedRequirements)
+                    {
+                        AppendFailureLine(stringBuilder, failure);
+                    }
+
+                    context.ReportError(
+                        new ValidationError(context.OriginalQuery, "authorization", stringBuilder.ToString(), node));
+                }
+            }
+        }
+
+        private static void AppendFailureLine(
+            StringBuilder stringBuilder,
+            IAuthorizationRequirement authorizationRequirement)
+        {
+            switch (authorizationRequirement)
+            {
+                case ClaimsAuthorizationRequirement claimsAuthorizationRequirement:
+                    stringBuilder.Append("Required claim '");
+                    stringBuilder.Append(claimsAuthorizationRequirement.ClaimType);
+                    if (claimsAuthorizationRequirement.AllowedValues == null || !claimsAuthorizationRequirement.AllowedValues.Any())
+                    {
+                        stringBuilder.AppendLine("' is not present.");
+                    }
+                    else
+                    {
+                        stringBuilder.Append("' with any value of '");
+                        stringBuilder.Append(string.Join(", ", claimsAuthorizationRequirement.AllowedValues));
+                        stringBuilder.AppendLine("' is not present.");
+                    }
+                    break;
+                case DenyAnonymousAuthorizationRequirement denyAnonymousAuthorizationRequirement:
+                    stringBuilder.AppendLine("The current user must be authenticated.");
+                    break;
+                case NameAuthorizationRequirement nameAuthorizationRequirement:
+                    stringBuilder.Append("The current user name must match the name '");
+                    stringBuilder.Append(nameAuthorizationRequirement.RequiredName);
+                    stringBuilder.AppendLine("'.");
+                    break;
+                case OperationAuthorizationRequirement operationAuthorizationRequirement:
+                    stringBuilder.Append("Required operation '");
+                    stringBuilder.Append(operationAuthorizationRequirement.Name);
+                    stringBuilder.AppendLine("' was not present.");
+                    break;
+                case RolesAuthorizationRequirement rolesAuthorizationRequirement:
+                    if (rolesAuthorizationRequirement.AllowedRoles == null || !rolesAuthorizationRequirement.AllowedRoles.Any())
+                    {
+                        // This should never happen.
+                        stringBuilder.AppendLine("Required roles are not present.");
+                    }
+                    else
+                    {
+                        stringBuilder.Append("Required roles '");
+                        stringBuilder.Append(string.Join(", ", rolesAuthorizationRequirement.AllowedRoles));
+                        stringBuilder.AppendLine("' are not present.");
+                    }
+                    break;
+                default:
+                    stringBuilder.Append("Requirement '");
+                    stringBuilder.Append(authorizationRequirement.GetType().Name);
+                    stringBuilder.AppendLine("' was not satisfied.");
+                    break;
+            }
+        }
+    }
+}

--- a/src/Authorization.AspNetCore/GraphQLAuthorizeAttribute.cs
+++ b/src/Authorization.AspNetCore/GraphQLAuthorizeAttribute.cs
@@ -1,0 +1,19 @@
+﻿using GraphQL.Utilities;
+
+namespace GraphQL.Server.Authorization.AspNetCore
+{
+    public class GraphQLAuthorizeAttribute : GraphQLAttribute
+    {
+        public string Policy { get; set; }
+
+        public override void Modify(TypeConfig type)
+        {
+            type.AuthorizeWith(Policy);
+        }
+
+        public override void Modify(FieldConfig field)
+        {
+            field.AuthorizeWith(Policy);
+        }
+    }
+}

--- a/src/Authorization.AspNetCore/GraphQlBuilderExtensions.cs
+++ b/src/Authorization.AspNetCore/GraphQlBuilderExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using GraphQL.Server.Authorization.AspNetCore;
+using GraphQL.Validation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphQL.Server
+{
+    public static class GraphQlBuilderExtensions
+    {
+        /// <summary>
+        /// Adds the GraphQL authorization.
+        /// </summary>
+        /// <param name="builder">The GraphQL builder.</param>
+        /// <returns></returns>
+        public static IGraphQLBuilder AddGraphQLAuthorization(this IGraphQLBuilder builder)
+        {
+            builder
+                .Services
+                .AddTransient<IValidationRule, AuthorizationValidationRule>()
+                .AddAuthorization();
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the GraphQL authorization.
+        /// </summary>
+        /// <param name="builder">The GraphQL builder.</param>
+        /// <param name="options">An action delegate to configure the provided <see cref="AuthorizationOptions"/>.</param>
+        /// <returns>The GraphQL builder.</returns>
+        public static IGraphQLBuilder AddGraphQLAuthorization(this IGraphQLBuilder builder, Action<AuthorizationOptions> options)
+        {
+            builder
+                .Services
+                .AddTransient<IValidationRule, AuthorizationValidationRule>()
+                .AddAuthorization(options);
+            return builder;
+        }
+    }
+}

--- a/src/Authorization.AspNetCore/GraphQlBuilderExtensions.cs
+++ b/src/Authorization.AspNetCore/GraphQlBuilderExtensions.cs
@@ -2,7 +2,9 @@
 using GraphQL.Server.Authorization.AspNetCore;
 using GraphQL.Validation;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace GraphQL.Server
 {
@@ -15,6 +17,7 @@ namespace GraphQL.Server
         /// <returns></returns>
         public static IGraphQLBuilder AddGraphQLAuthorization(this IGraphQLBuilder builder)
         {
+            builder.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             builder
                 .Services
                 .AddTransient<IValidationRule, AuthorizationValidationRule>()
@@ -30,6 +33,7 @@ namespace GraphQL.Server
         /// <returns>The GraphQL builder.</returns>
         public static IGraphQLBuilder AddGraphQLAuthorization(this IGraphQLBuilder builder, Action<AuthorizationOptions> options)
         {
+            builder.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             builder
                 .Services
                 .AddTransient<IValidationRule, AuthorizationValidationRule>()

--- a/src/Authorization.AspNetCore/GraphQlBuilderExtensions.cs
+++ b/src/Authorization.AspNetCore/GraphQlBuilderExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQL.Server
 {
-    public static class GraphQlBuilderExtensions
+    public static class GraphQLBuilderExtensions
     {
         /// <summary>
         /// Adds the GraphQL authorization.

--- a/src/Authorization.AspNetCore/IProvideClaimsPrincipal.cs
+++ b/src/Authorization.AspNetCore/IProvideClaimsPrincipal.cs
@@ -1,9 +1,0 @@
-﻿using System.Security.Claims;
-
-namespace GraphQL.Server.Authorization.AspNetCore
-{
-    public interface IProvideClaimsPrincipal
-    {
-        ClaimsPrincipal User { get; }
-    }
-}

--- a/src/Authorization.AspNetCore/IProvideClaimsPrincipal.cs
+++ b/src/Authorization.AspNetCore/IProvideClaimsPrincipal.cs
@@ -1,0 +1,9 @@
+﻿using System.Security.Claims;
+
+namespace GraphQL.Server.Authorization.AspNetCore
+{
+    public interface IProvideClaimsPrincipal
+    {
+        ClaimsPrincipal User { get; }
+    }
+}

--- a/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
+++ b/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />

--- a/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
+++ b/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Build">
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="Project References">
+    <ProjectReference Include="..\..\src\Authorization.AspNetCore\Authorization.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <AssemblyName>GraphQL.Server.Authorization.AspNetCore.Tests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
+++ b/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
@@ -1,0 +1,245 @@
+using System.Collections.Generic;
+using GraphQL.Types;
+using Xunit;
+
+namespace GraphQL.Server.Authorization.AspNetCore.Tests
+{
+    public class AuthorizationValidationRuleTests : ValidationTestBase
+    {
+        [Fact]
+        public void class_policy_success()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("ClassPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldPassRule(_ =>
+            {
+                _.Query = @"query { post }";
+                _.Schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
+                _.User = CreatePrincipal(claims: new Dictionary<string, string>
+                    {
+                        {"Admin", "true"}
+                    });
+            });
+        }
+
+        [Fact]
+        public void class_policy_fail()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("ClassPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = @"query { post }";
+                _.Schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
+            });
+        }
+
+        [Fact]
+        public void field_policy_success()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldPassRule(_ =>
+            {
+                _.Query = @"query { post }";
+                _.Schema = BasicSchema<BasicQueryWithAttributesAndFieldPolicy>();
+                _.User = CreatePrincipal(claims: new Dictionary<string, string>
+                    {
+                        {"Admin", "true"}
+                    });
+            });
+        }
+
+        [Fact]
+        public void field_policy_fail()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = @"query { post }";
+                _.Schema = BasicSchema<BasicQueryWithAttributesAndFieldPolicy>();
+            });
+        }
+
+        [Fact]
+        public void nested_type_policy_success()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("PostPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldPassRule(_ =>
+            {
+                _.Query = @"query { post }";
+                _.Schema = NestedSchema();
+                _.User = CreatePrincipal(claims: new Dictionary<string, string>
+                    {
+                        {"Admin", "true"}
+                    });
+            });
+        }
+
+        [Fact]
+        public void nested_type_policy_fail()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("PostPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = @"query { post }";
+                _.Schema = NestedSchema();
+            });
+        }
+
+        [Fact]
+        public void passes_with_claim_on_input_type()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldPassRule(_ =>
+            {
+                _.Query = @"query { author(input: { name: ""Quinn"" }) }";
+                _.Schema = TypedSchema();
+                _.User = CreatePrincipal(claims: new Dictionary<string, string>
+                    {
+                        {"Admin", "true"}
+                    });
+            });
+        }
+
+        [Fact]
+        public void fails_on_missing_claim_on_input_type()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = @"query { author(input: { name: ""Quinn"" }) }";
+                _.Schema = TypedSchema();
+            });
+        }
+
+        private ISchema BasicSchema<T>()
+        {
+            string defs = @"
+                type Query {
+                    post(id: ID!): String
+                }
+            ";
+
+            return Schema.For(defs, _ =>
+            {
+                _.Types.Include<T>();
+            });
+        }
+
+        [GraphQLMetadata("Query")]
+        [GraphQLAuthorize(Policy = "ClassPolicy")]
+        public class BasicQueryWithAttributesAndClassPolicy
+        {
+            public string Post(string id)
+            {
+                return "";
+            }
+        }
+
+        [GraphQLMetadata("Query")]
+        public class BasicQueryWithAttributesAndFieldPolicy
+        {
+            [GraphQLAuthorize(Policy = "FieldPolicy")]
+            public string Post(string id)
+            {
+                return "";
+            }
+        }
+
+        private ISchema NestedSchema()
+        {
+            string defs = @"
+                type Query {
+                    post(id: ID!): Post
+                }
+
+                type Post {
+                    id: ID!
+                }
+            ";
+
+            return Schema.For(defs, _ =>
+            {
+                _.Types.Include<NestedQueryWithAttributes>();
+                _.Types.Include<Post>();
+            });
+        }
+
+        [GraphQLMetadata("Query")]
+        public class NestedQueryWithAttributes
+        {
+            public Post Post(string id)
+            {
+                return null;
+            }
+        }
+
+        [GraphQLAuthorize(Policy = "PostPolicy")]
+        public class Post
+        {
+            public string Id { get; set; }
+        }
+
+        public class Author
+        {
+            public string Name { get; set; }
+        }
+
+        private ISchema TypedSchema()
+        {
+            var query = new ObjectGraphType();
+            query.Field<StringGraphType>(
+                "author",
+                arguments: new QueryArguments(new QueryArgument<AuthorInputType> { Name = "input" }),
+                resolve: context => "testing"
+            );
+            return new Schema { Query = query };
+        }
+
+        public class AuthorInputType : InputObjectGraphType<Author>
+        {
+            public AuthorInputType()
+            {
+                Field(x => x.Name).AuthorizeWith("FieldPolicy");
+            }
+        }
+    }
+}

--- a/tests/Authorization.AspNetCore.Tests/ValidationTestBase.cs
+++ b/tests/Authorization.AspNetCore.Tests/ValidationTestBase.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using GraphQL.Execution;
+using GraphQL.Http;
+using GraphQL.Types;
+using GraphQL.Validation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace GraphQL.Server.Authorization.AspNetCore.Tests
+{
+    public class ValidationTestConfig
+    {
+        private readonly List<IValidationRule> _rules = new List<IValidationRule>();
+
+        public string Query { get; set; }
+        public ISchema Schema { get; set; }
+        public IEnumerable<IValidationRule> Rules => _rules;
+        public ClaimsPrincipal User { get; set; }
+        public Inputs Inputs { get; set; }
+
+        public void Rule(params IValidationRule[] rules)
+        {
+            _rules.AddRange(rules);
+        }
+    }
+
+    public class GraphQLUserContext : IProvideClaimsPrincipal
+    {
+        public ClaimsPrincipal User { get; set;}
+    }
+
+    public class ValidationTestBase
+    {
+        private IDocumentExecuter _executor = new DocumentExecuter();
+        private IDocumentWriter _writer = new DocumentWriter(indent: true);
+
+        protected AuthorizationValidationRule Rule { get; private set; }
+
+        protected void ConfigureAuthorizationOptions(Action<AuthorizationOptions> setupOptions)
+        {
+            var authorizationService = BuildAuthorizationService(setupOptions);
+            Rule = new AuthorizationValidationRule(authorizationService);
+        }
+
+        protected void ShouldPassRule(Action<ValidationTestConfig> configure)
+        {
+            var config = new ValidationTestConfig();
+            config.Rule(Rule);
+            configure(config);
+
+            config.Rules.Any().ShouldBeTrue("Must provide at least one rule to validate against.");
+
+            config.Schema.Initialize();
+
+            var result = Validate(config);
+
+            var message = "";
+            if (result.Errors?.Any() == true)
+            {
+                message = string.Join(", ", result.Errors.Select(x => x.Message));
+            }
+            result.IsValid.ShouldBeTrue(message);
+        }
+
+        protected void ShouldFailRule(Action<ValidationTestConfig> configure)
+        {
+            var config = new ValidationTestConfig();
+            config.Rule(Rule);
+            configure(config);
+
+            config.Rules.Any().ShouldBeTrue("Must provide at least one rule to validate against.");
+
+            config.Schema.Initialize();
+
+            var result = Validate(config);
+
+            result.IsValid.ShouldBeFalse("Expected validation errors though there were none.");
+        }
+
+        private IAuthorizationService BuildAuthorizationService(Action<AuthorizationOptions> setupOptions)
+        {
+            var services = new ServiceCollection();
+            services.AddAuthorization(setupOptions);
+            services.AddLogging();
+            services.AddOptions();
+            return services.BuildServiceProvider().GetRequiredService<IAuthorizationService>();
+        }
+
+        private IValidationResult Validate(ValidationTestConfig config)
+        {
+            var userContext = new GraphQLUserContext { User = config.User };
+            var documentBuilder = new GraphQLDocumentBuilder();
+            var document = documentBuilder.Build(config.Query);
+            var validator = new DocumentValidator();
+            return validator.Validate(config.Query, config.Schema, document, config.Rules, userContext, config.Inputs);
+        }
+
+        protected ClaimsPrincipal CreatePrincipal(string authenticationType = null, IDictionary<string, string> claims = null)
+        {
+            var claimsList = new List<Claim>();
+
+            claims?.Apply(c =>
+            {
+                claimsList.Add(new Claim(c.Key, c.Value));
+            });
+
+            return new ClaimsPrincipal(new ClaimsIdentity(claimsList, authenticationType));
+        }
+    }
+}


### PR DESCRIPTION
The current [Authorization](https://github.com/graphql-dotnet/authorization) NuGet package duplicates code from `Microsoft.AspNetCore.Authorization` to work around some issues with .NET 4.6 and binding redirects. This causes all kinds of problems for ASP.NET Core users because the API has been slightly changed.

I initially submitted a PR https://github.com/graphql-dotnet/authorization/pull/13 to make use of `Microsoft.AspNetCore.Authorization` directly instead in the [Authorization](https://github.com/graphql-dotnet/authorization) repo. After a long discussion in https://github.com/graphql-dotnet/authorization/issues/11 with @joemcbride and others it was decided that this should be a separate project.

Some changes were made in the authorization repo by @joemcbride to support argument fields. I have updated the code here to reflect that. This PR is mostly copying the code from the authorization repo but adding in ASP.NET Core idioms. It also copies across calls to `.GetAwaiter().GetResult()` which is bad but fixing this requires changes to the core GraphQL project (not looked at how to fix that in too much detail yet) which I think can be done in a separate PR.