### PR TITLE
Use IDocumentWriter.WriteAsync() to write directly to response stream

### DIFF
--- a/samples/Samples.Schemas.Chat/Samples.Schemas.Chat.csproj
+++ b/samples/Samples.Schemas.Chat/Samples.Schemas.Chat.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>GraphQL.Samples.Schemas.Chat</RootNamespace>
   </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="GraphQL" Version="[2.0.0, 2.1)" />
+        <PackageReference Include="GraphQL" Version="2.3.0" />
         <PackageReference Include="System.Reactive" Version="3.1.1" />
     </ItemGroup>
     <ItemGroup>

--- a/samples/Samples.Server/Samples.Server.csproj
+++ b/samples/Samples.Server/Samples.Server.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="[2.0.0, 2.1)" />
+    <PackageReference Include="GraphQL" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.0.2" />
     <PackageReference Include="Serilog" Version="2.6.0" />

--- a/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
+++ b/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="GraphQL" Version="2.0.0" />
+    <PackageReference Include="GraphQL" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
   </ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -16,7 +16,7 @@
         <Copyright>Pekka Heikura</Copyright>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="GraphQL" Version="2.0.0" />
+        <PackageReference Include="GraphQL" Version="2.3.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.1" />
     </ItemGroup>

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -107,22 +107,18 @@ namespace GraphQL.Server.Transports.AspNetCore
                 }
             };
 
-            var json = writer.Write(result);
-
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = 400; // Bad Request
 
-            return context.Response.WriteAsync(json);
+            return writer.WriteAsync(context.Response.Body, result);
         }
 
         private Task WriteResponseAsync(HttpContext context, IDocumentWriter writer, ExecutionResult result)
         {
-            var json = writer.Write(result);
-
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = 200; // OK
 
-            return context.Response.WriteAsync(json);
+            return writer.WriteAsync(context.Response.Body, result);
         }
 
         private static T Deserialize<T>(Stream s)

--- a/src/Transports.AspNetCore/Transports.AspNetCore.csproj
+++ b/src/Transports.AspNetCore/Transports.AspNetCore.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="2.0.0" />
+    <PackageReference Include="GraphQL" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />

--- a/src/Transports.Subscriptions.Abstractions/Transports.Subscriptions.Abstractions.csproj
+++ b/src/Transports.Subscriptions.Abstractions/Transports.Subscriptions.Abstractions.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="2.0.0" />
+    <PackageReference Include="GraphQL" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.8.0" />

--- a/src/Transports.Subscriptions.WebSockets/Transports.Subscriptions.WebSockets.csproj
+++ b/src/Transports.Subscriptions.WebSockets/Transports.Subscriptions.WebSockets.csproj
@@ -16,7 +16,7 @@
     <Copyright>Pekka Heikura</Copyright>
   </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="GraphQL" Version="2.0.0" />
+        <PackageReference Include="GraphQL" Version="2.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
         <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />

--- a/tests/Transports.Subscriptions.Abstractions.Tests/Transports.Subscriptions.Abstractions.Tests.csproj
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/Transports.Subscriptions.Abstractions.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="[2.0.0, 2.1)" />
+    <PackageReference Include="GraphQL" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />

--- a/tests/Transports.Subscriptions.WebSockets.Tests/Transports.Subscriptions.WebSockets.Tests.csproj
+++ b/tests/Transports.Subscriptions.WebSockets.Tests/Transports.Subscriptions.WebSockets.Tests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.2.1" />
-    <PackageReference Include="GraphQL" Version="[2.0.0, 2.1)" />
+    <PackageReference Include="GraphQL" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.0.2" />


### PR DESCRIPTION
I updated the projects to reference GraphQL.NET 2.3.0. 

Then I updated `GraphQLHttpMiddleware` to use the new method on `IDocumentWriter` to serialize the result directly to the response stream.

I did *not* change the web socket stuff for this pull request.