### PR TITLE
Updated: websocket implementation to support documentwriter.

### DIFF
--- a/src/Transports.Subscriptions.Abstractions/OperationMessage.cs
+++ b/src/Transports.Subscriptions.Abstractions/OperationMessage.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json.Linq;
-
 namespace GraphQL.Server.Transports.Subscriptions.Abstractions
 {
     /// <summary>
@@ -20,7 +18,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         /// <summary>
         ///     Nullable payload
         /// </summary>
-        public JObject Payload { get; set; }
+        public object Payload { get; set; }
 
 
         /// <inheritdoc />

--- a/src/Transports.Subscriptions.Abstractions/ProtocolMessageListener.cs
+++ b/src/Transports.Subscriptions.Abstractions/ProtocolMessageListener.cs
@@ -54,14 +54,13 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             {
                 Type = MessageType.GQL_CONNECTION_ERROR,
                 Id = message.Id,
-                Payload = JObject.FromObject(new
+                Payload = new ExecutionResult
                 {
-                    message.Id,
                     Errors = new ExecutionErrors
                     {
                         new ExecutionError($"Unexpected message type {message.Type}")
                     }
-                })
+                }
             });
         }
 
@@ -76,7 +75,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         {
             var message = context.Message;
             _logger.LogDebug("Handle start: {id}", message.Id);
-            var payload = message.Payload.ToObject<OperationMessagePayload>();
+            var payload = ((JObject)message.Payload).ToObject<OperationMessagePayload>();
             if (payload == null)
                 throw new InvalidOperationException($"Could not get OperationMessagePayload from message.Payload");
 

--- a/src/Transports.Subscriptions.Abstractions/Subscription.cs
+++ b/src/Transports.Subscriptions.Abstractions/Subscription.cs
@@ -63,7 +63,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             {
                 Type = MessageType.GQL_DATA,
                 Id = Id,
-                Payload = JObject.FromObject(value)
+                Payload = value
             });
         }
 

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
@@ -93,7 +93,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
                 {
                     Type = MessageType.GQL_ERROR,
                     Id = id,
-                    Payload = JObject.FromObject(result)
+                    Payload = result
                 });
 
                 return null;
@@ -110,7 +110,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
                         {
                             Type = MessageType.GQL_ERROR,
                             Id = id,
-                            Payload = JObject.FromObject(result)
+                            Payload = result
                         });
 
                         return null;
@@ -131,7 +131,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             {
                 Type = MessageType.GQL_DATA,
                 Id = id,
-                Payload = JObject.FromObject(result) 
+                Payload = result
             });
 
             await writer.SendAsync(new OperationMessage

--- a/src/Transports.Subscriptions.WebSockets/WebSocketConnectionFactory.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketConnectionFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.WebSockets;
+using GraphQL.Http;
 using GraphQL.Server.Internal;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using GraphQL.Types;
@@ -14,23 +15,26 @@ namespace GraphQL.Server.Transports.WebSockets
         private readonly ILoggerFactory _loggerFactory;
         private readonly IGraphQLExecuter<TSchema> _executer;
         private readonly IEnumerable<IOperationMessageListener> _messageListeners;
+        private readonly IDocumentWriter _documentWriter;
 
         public WebSocketConnectionFactory(ILogger<WebSocketConnectionFactory<TSchema>> logger,
             ILoggerFactory loggerFactory,
             IGraphQLExecuter<TSchema> executer,
-            IEnumerable<IOperationMessageListener> messageListeners)
+            IEnumerable<IOperationMessageListener> messageListeners,
+            IDocumentWriter documentWriter)
         {
             _logger = logger;
             _loggerFactory = loggerFactory;
             _executer = executer;
             _messageListeners = messageListeners;
+            _documentWriter = documentWriter;
         }
 
         public WebSocketConnection CreateConnection(WebSocket socket, string connectionId)
         {
             _logger.LogDebug("Creating server for connection {connectionId}", connectionId);
 
-            var transport = new WebSocketTransport(socket);
+            var transport = new WebSocketTransport(socket, _documentWriter);
             var manager = new SubscriptionManager(_executer, _loggerFactory);
             var server = new SubscriptionServer(
                 transport,

--- a/src/Transports.Subscriptions.WebSockets/WebSocketTransport.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketTransport.cs
@@ -1,6 +1,7 @@
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
+using GraphQL.Http;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -11,7 +12,7 @@ namespace GraphQL.Server.Transports.WebSockets
     {
         private readonly WebSocket _socket;
 
-        public WebSocketTransport(WebSocket socket)
+        public WebSocketTransport(WebSocket socket, IDocumentWriter documentWriter)
         {
             _socket = socket;
             var serializerSettings = new JsonSerializerSettings
@@ -22,7 +23,7 @@ namespace GraphQL.Server.Transports.WebSockets
             };
 
             Reader = new WebSocketReaderPipeline(_socket, serializerSettings);
-            Writer = new WebSocketWriterPipeline(_socket, serializerSettings);
+            Writer = new WebSocketWriterPipeline(_socket, documentWriter);
         }
 
 

--- a/src/Transports.Subscriptions.WebSockets/WebSocketWriterPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketWriterPipeline.cs
@@ -63,6 +63,7 @@ namespace GraphQL.Server.Transports.WebSockets
             finally
             {
                 await stream.FlushAsync();
+                stream.Dispose();
             }
         }
     }

--- a/src/Transports.Subscriptions.WebSockets/WebSocketWriterPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketWriterPipeline.cs
@@ -1,33 +1,23 @@
-using System;
 using System.Net.WebSockets;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
+using GraphQL.Http;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
-using Newtonsoft.Json;
 
 namespace GraphQL.Server.Transports.WebSockets
 {
     public class WebSocketWriterPipeline : IWriterPipeline
     {
-        private readonly ITargetBlock<string> _endBlock;
-        private readonly JsonSerializerSettings _serializerSettings;
         private readonly WebSocket _socket;
-        private readonly IPropagatorBlock<OperationMessage, string> _startBlock;
+        private readonly IDocumentWriter _documentWriter;
+        private readonly ITargetBlock<OperationMessage> _startBlock;
 
-        public WebSocketWriterPipeline(WebSocket socket, JsonSerializerSettings serializerSettings)
+        public WebSocketWriterPipeline(WebSocket socket, IDocumentWriter documentWriter)
         {
             _socket = socket;
-            _serializerSettings = serializerSettings;
+            _documentWriter = documentWriter;
 
-            _endBlock = CreateMessageWriter();
-            _startBlock = CreateWriterJsonTransformer();
-
-            _startBlock.LinkTo(_endBlock, new DataflowLinkOptions
-            {
-                PropagateCompletion = true
-            });
+            _startBlock = CreateMessageWriter();
         }
 
         public bool Post(OperationMessage message)
@@ -40,7 +30,7 @@ namespace GraphQL.Server.Transports.WebSockets
             return _startBlock.SendAsync(message);
         }
 
-        public Task Completion => _endBlock.Completion;
+        public Task Completion => _startBlock.Completion;
 
         public Task Complete()
         {
@@ -48,21 +38,9 @@ namespace GraphQL.Server.Transports.WebSockets
             return Task.CompletedTask;
         }
 
-        protected IPropagatorBlock<OperationMessage, string> CreateWriterJsonTransformer()
+        private ITargetBlock<OperationMessage> CreateMessageWriter()
         {
-            var transformer = new TransformBlock<OperationMessage, string>(
-                input => JsonConvert.SerializeObject(input, _serializerSettings),
-                new ExecutionDataflowBlockOptions
-                {
-                    EnsureOrdered = true
-                });
-
-            return transformer;
-        }
-
-        private ITargetBlock<string> CreateMessageWriter()
-        {
-            var target = new ActionBlock<string>(
+            var target = new ActionBlock<OperationMessage>(
                 WriteMessageAsync, new ExecutionDataflowBlockOptions
                 {
                     BoundedCapacity = 1,
@@ -73,12 +51,19 @@ namespace GraphQL.Server.Transports.WebSockets
             return target;
         }
 
-        private Task WriteMessageAsync(string message)
+        private async Task WriteMessageAsync(OperationMessage message)
         {
-            if (_socket.CloseStatus.HasValue) return Task.CompletedTask;
+            if (_socket.CloseStatus.HasValue) return;
 
-            var messageSegment = new ArraySegment<byte>(Encoding.UTF8.GetBytes(message));
-            return _socket.SendAsync(messageSegment, WebSocketMessageType.Text, true, CancellationToken.None);
+            var stream = new WebsocketWriterStream(_socket);
+            try
+            {
+                await _documentWriter.WriteAsync(stream, message);
+            }
+            finally
+            {
+                await stream.FlushAsync();
+            }
         }
     }
 }

--- a/src/Transports.Subscriptions.WebSockets/WebsocketWriterStream.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebsocketWriterStream.cs
@@ -33,7 +33,7 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            throw new System.NotImplementedException();
+            throw new System.NotSupportedException();
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/Transports.Subscriptions.WebSockets/WebsocketWriterStream.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebsocketWriterStream.cs
@@ -21,6 +21,11 @@ namespace GraphQL.Server.Transports.WebSockets
                 cancellationToken);
         }
 
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
+        }
+
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
             return _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>()), WebSocketMessageType.Text, true, cancellationToken);
@@ -28,7 +33,7 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public override void Flush()
         {
-            throw new System.NotImplementedException("Synchronous methods are not supported by WebsocketWriterStream.");
+            FlushAsync().GetAwaiter().GetResult();
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -38,29 +43,24 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            throw new System.NotImplementedException();
+            throw new System.NotSupportedException();
         }
 
         public override void SetLength(long value)
         {
-            throw new System.NotImplementedException();
-        }
-
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            throw new System.NotImplementedException("Synchronous methods are not supported by WebsocketWriterStream.");
+            throw new System.NotSupportedException();
         }
 
         public override bool CanRead => false;
         public override bool CanSeek => false;
         public override bool CanWrite => true;
 
-        public override long Length => throw new NotImplementedException();
+        public override long Length => throw new NotSupportedException();
 
         public override long Position
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
         }
     }
 }

--- a/src/Transports.Subscriptions.WebSockets/WebsocketWriterStream.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebsocketWriterStream.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GraphQL.Server.Transports.WebSockets
+{
+    public class WebsocketWriterStream : Stream
+    {
+        private readonly WebSocket _webSocket;
+
+        public WebsocketWriterStream(WebSocket webSocket)
+        {
+            _webSocket = webSocket;
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _webSocket.SendAsync(new ArraySegment<byte>(buffer, offset, count), WebSocketMessageType.Text, false,
+                cancellationToken);
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>()), WebSocketMessageType.Text, true, cancellationToken);
+        }
+
+        public override void Flush()
+        {
+            throw new System.NotImplementedException("Synchronous methods are not supported by WebsocketWriterStream.");
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new System.NotImplementedException("Synchronous methods are not supported by WebsocketWriterStream.");
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.Abstractions.Tests/Specs/ChatSpec.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/Specs/ChatSpec.cs
@@ -49,7 +49,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests.Specs
         private void AssertReceivedData(List<OperationMessage> writtenMessages, Predicate<JObject> predicate)
         {
             var dataMessages = writtenMessages.Where(m => m.Type == MessageType.GQL_DATA);
-            var results = dataMessages.Select(m => m.Payload["data"] as JObject)
+            var results = dataMessages.Select(m => JObject.FromObject(((ExecutionResult)m.Payload).Data))
                 .ToList();
 
             Assert.Contains(results, predicate);

--- a/tests/Transports.Subscriptions.WebSockets.Tests/TestMessage.cs
+++ b/tests/Transports.Subscriptions.WebSockets.Tests/TestMessage.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GraphQL.Server.Transports.WebSockets.Tests
+{
+    public class TestMessage
+    {
+        public string Content { get; set; }
+
+        public DateTimeOffset SentAt { get; set; }
+    }
+}

--- a/tests/Transports.Subscriptions.WebSockets.Tests/TestWebSocket.cs
+++ b/tests/Transports.Subscriptions.WebSockets.Tests/TestWebSocket.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GraphQL.Server.Transports.WebSockets.Tests
+{
+    public class TestWebSocket : WebSocket
+    {
+        public TestWebSocket()
+        {
+            CurrentMessage = new ChunkedMemoryStream();
+        }
+
+        public override void Abort()
+        {
+        }
+
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription,
+            CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription,
+            CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override void Dispose()
+        {
+        }
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage,
+            CancellationToken cancellationToken)
+        {
+            if (buffer.Array != null)
+            {
+                CurrentMessage.Write(buffer.Array, buffer.Offset, buffer.Count);
+            }
+
+            if (endOfMessage)
+            {
+                Messages.Add(CurrentMessage);
+                CurrentMessage = new ChunkedMemoryStream();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        internal List<ChunkedMemoryStream> Messages { get; } = new List<ChunkedMemoryStream>();
+        private ChunkedMemoryStream CurrentMessage { get; set; }
+
+        public override WebSocketCloseStatus? CloseStatus { get; } = null;
+        public override string CloseStatusDescription { get; } = "";
+        public override string SubProtocol { get; } = "";
+        public override WebSocketState State { get; } = WebSocketState.Open;
+    }
+
+    internal class ChunkedMemoryStream : Stream
+    {
+        private readonly List<byte[]> _chunks = new List<byte[]>();
+        private int _positionChunk;
+        private int _positionOffset;
+        private long _position;
+
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return true; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Length
+        {
+            get { return _chunks.Sum(c => c.Length); }
+        }
+
+        public override long Position
+        {
+            get { return _position; }
+            set
+            {
+                _position = value;
+
+                _positionChunk = 0;
+
+                while (_positionOffset != 0)
+                {
+                    if (_positionChunk >= _chunks.Count)
+                        throw new OverflowException();
+
+                    if (_positionOffset < _chunks[_positionChunk].Length)
+                        return;
+
+                    _positionOffset -= _chunks[_positionChunk].Length;
+                    _positionChunk++;
+                }
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int result = 0;
+            while ((count != 0) && (_positionChunk != _chunks.Count))
+            {
+                int fromChunk = Math.Min(count, _chunks[_positionChunk].Length - _positionOffset);
+                if (fromChunk != 0)
+                {
+                    Array.Copy(_chunks[_positionChunk], _positionOffset, buffer, offset, fromChunk);
+                    offset += fromChunk;
+                    count -= fromChunk;
+                    result += fromChunk;
+                    _position += fromChunk;
+                }
+
+                _positionOffset = 0;
+                _positionChunk++;
+            }
+
+            return result;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long newPos = 0;
+
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    newPos = offset;
+                    break;
+                case SeekOrigin.Current:
+                    newPos = Position + offset;
+                    break;
+                case SeekOrigin.End:
+                    newPos = Length - offset;
+                    break;
+            }
+
+            Position = Math.Max(0, Math.Min(newPos, Length));
+            return newPos;
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            while ((count != 0) && (_positionChunk != _chunks.Count))
+            {
+                int toChunk = Math.Min(count, _chunks[_positionChunk].Length - _positionOffset);
+                if (toChunk != 0)
+                {
+                    Array.Copy(buffer, offset, _chunks[_positionChunk], _positionOffset, toChunk);
+                    offset += toChunk;
+                    count -= toChunk;
+                    _position += toChunk;
+                }
+
+                _positionOffset = 0;
+                _positionChunk++;
+            }
+
+            if (count != 0)
+            {
+                byte[] chunk = new byte[count];
+                Array.Copy(buffer, offset, chunk, 0, count);
+                _chunks.Add(chunk);
+                _positionChunk = _chunks.Count;
+                _position += count;
+            }
+        }
+
+        public byte[] ToArray()
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                foreach (var bytes in _chunks)
+                {
+                    ms.Write(bytes, 0, bytes.Length);
+                }
+                return ms.ToArray();
+            }
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.WebSockets.Tests/WebSocketWriterPipelineTests.cs
+++ b/tests/Transports.Subscriptions.WebSockets.Tests/WebSocketWriterPipelineTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GraphQL.Http;
+using GraphQL.Server.Transports.Subscriptions.Abstractions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace GraphQL.Server.Transports.WebSockets.Tests
+{
+    public class WebSocketWriterPipelineFacts
+    {
+        private readonly WebSocketWriterPipeline _webSocketWriterPipeline;
+        private readonly TestWebSocket _testWebSocket;
+
+        public WebSocketWriterPipelineFacts()
+        {
+            _testWebSocket = new TestWebSocket();
+            _webSocketWriterPipeline = new WebSocketWriterPipeline(_testWebSocket, new DocumentWriter(Formatting.None,
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    NullValueHandling = NullValueHandling.Ignore
+                }));
+        }
+
+        public static IEnumerable<object[]> TestData =>
+            new List<object[]>
+            {
+                new object[]
+                {
+                    new OperationMessage
+                    {
+                        Payload = new ExecutionResult
+                        {
+                            Data = new TestMessage
+                            {
+                                Content = "Hello world",
+                                SentAt = new DateTimeOffset(2018, 12, 12, 10, 0,0, TimeSpan.Zero)
+                            }
+                        }
+                    },
+                    83
+                },
+                new object[]
+                {
+                    new OperationMessage
+                    {
+                        Payload = new ExecutionResult
+                        {
+                            Data = Enumerable.Repeat(new TestMessage
+                            {
+                                Content = "Hello world",
+                                SentAt = new DateTimeOffset(2018, 12, 12, 10, 0,0, TimeSpan.Zero)
+                            }, 10)
+                        }
+                    },
+                    652
+                },
+                new object[]
+                {
+                    new OperationMessage
+                    {
+                        Payload = new ExecutionResult
+                        {
+                            Data = Enumerable.Repeat(new TestMessage
+                            {
+                                Content = "Hello world",
+                                SentAt = new DateTimeOffset(2018, 12, 12, 10, 0,0, TimeSpan.Zero)
+                            }, 16_000)
+                        }
+                    },
+                    // About 1 megabyte
+                    1_008_022
+                },
+                new object[]
+                {
+                    new OperationMessage
+                    {
+                        Payload = new ExecutionResult
+                        {
+                            Data = Enumerable.Repeat(new TestMessage
+                            {
+                                Content = "Hello world",
+                                SentAt = new DateTimeOffset(2018, 12, 12, 10, 0,0, TimeSpan.Zero)
+                            }, 160_000)
+                        }
+                    },
+                    // About 10 megabytes
+                    10_080_022
+                },
+                new object[]
+                {
+                    new OperationMessage
+                    {
+                        Payload = new ExecutionResult
+                        {
+                            Data = Enumerable.Repeat(new TestMessage
+                            {
+                                Content = "Hello world",
+                                SentAt = new DateTimeOffset(2018, 12, 12, 10, 0,0, TimeSpan.Zero)
+                            }, 1_600_000)
+                        }
+                    },
+                    // About 100 megabytes
+                    100_800_022
+                },
+            };
+
+        [Fact]
+        public async Task should_post_single_message()
+        {
+            var message = new OperationMessage
+            {
+                Payload = new ExecutionResult
+                {
+                    Data = new TestMessage
+                    {
+                        Content = "Hello world",
+                        SentAt = new DateTimeOffset(2018, 12, 12, 10, 0, 0, TimeSpan.Zero)
+                    }
+                }
+            };
+            Assert.True(_webSocketWriterPipeline.Post(message));
+            await _webSocketWriterPipeline.Complete();
+            await _webSocketWriterPipeline.Completion;
+            Assert.Single(_testWebSocket.Messages);
+
+            var resultingJson = Encoding.UTF8.GetString(_testWebSocket.Messages.First().ToArray());
+            Assert.Equal(
+                "{\"payload\":{\"data\":{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}}}",
+                resultingJson);
+        }
+
+        [Fact]
+        public async Task should_post_array_of_10_messages()
+        {
+            var message = new OperationMessage
+            {
+                Payload = new ExecutionResult
+                {
+                    Data = Enumerable.Repeat(new TestMessage
+                    {
+                        Content = "Hello world",
+                        SentAt = new DateTimeOffset(2018, 12, 12, 10, 0, 0, TimeSpan.Zero)
+                    }, 10)
+                }
+            };
+            Assert.True(_webSocketWriterPipeline.Post(message));
+            await _webSocketWriterPipeline.Complete();
+            await _webSocketWriterPipeline.Completion;
+            Assert.Single(_testWebSocket.Messages);
+
+            var resultingJson = Encoding.UTF8.GetString(_testWebSocket.Messages.First().ToArray());
+            Assert.Equal("{\"payload\":{\"data\":[{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}," +
+                         "{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}," +
+                         "{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}," +
+                         "{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}," +
+                         "{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}," +
+                         "{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}," +
+                         "{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}," +
+                         "{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}," +
+                         "{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}," +
+                         "{\"content\":\"Hello world\",\"sentAt\":\"2018-12-12T10:00:00+00:00\"}]}}",
+                resultingJson);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public async Task should_post_for_any_message_length(OperationMessage message, long expectedLength)
+        {
+            Assert.True(_webSocketWriterPipeline.Post(message));
+            await _webSocketWriterPipeline.Complete();
+            await _webSocketWriterPipeline.Completion;
+            Assert.Single(_testWebSocket.Messages);
+            Assert.Equal(expectedLength, _testWebSocket.Messages.First().Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public async Task should_send_for_any_message_length(OperationMessage message, long expectedLength)
+        {
+            await _webSocketWriterPipeline.SendAsync(message);
+            await _webSocketWriterPipeline.Complete();
+            await _webSocketWriterPipeline.Completion;
+            Assert.Single(_testWebSocket.Messages);
+            Assert.Equal(expectedLength, _testWebSocket.Messages.First().Length);
+        }
+    }
+}


### PR DESCRIPTION
Implemented support for new DocumentWriter for websocket transport.
Things to note:

1. Writing to socket is achieved by using a proxy stream object - WebsocketWriterStream. It solves several issues:
    
    -  The initial idea of DocumentWriter method has a memory limit of 1 mb per message

    - There is some overly complex code around buffers in DocumentWriter implementation. Reducing it to a single method that writes to stream is great.
There is a con, however. There is always a need to call the websocket API at lease twice. Not sure how this will affect the performance and not sure how to test this (perhaps, some load test?).

2. The ProtocolMessageListener was sending a message.Id twice, once as part of ExecutionResult, and once in OperationMessage. I believe this is not requred, but I may be wrong.

Let me know  what you think! Should this approach be accepted, it should be possible to remove the "extra" method within the DocumentWriter, and always stick to Stream API for serialization.
