### PR TITLE
Fix the issue when the client prematurely closes and the server canno…

### DIFF
--- a/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
@@ -44,25 +44,30 @@ namespace GraphQL.Server.Transports.WebSockets
         {
             if (_socket.State != WebSocketState.Closed && _socket.State != WebSocketState.CloseSent)
             {
-                if (closeStatus == WebSocketCloseStatus.NormalClosure)
-                {
-                    // If nothing went wrong, close connection with handshakes.
-                    await _socket.CloseAsync(
-                           closeStatus,
-                           statusDescription,
-                           CancellationToken.None);
-                }
-                else
-                {
-                    // Something went wrong, so don't wait for answer from the other side, just close the connection.
-                    await _socket.CloseOutputAsync(
-                           closeStatus,
-                           statusDescription,
-                           CancellationToken.None);
-                }
-
-                _startBlock.Complete();
-            }
+							try
+							{
+								if (closeStatus == WebSocketCloseStatus.NormalClosure)
+								{
+									// If nothing went wrong, close connection with handshakes.
+									await _socket.CloseAsync(
+										closeStatus,
+										statusDescription,
+										CancellationToken.None);
+								}
+								else
+								{
+									// Something went wrong, so don't wait for answer from the other side, just close the connection.
+									await _socket.CloseOutputAsync(
+										closeStatus,
+										statusDescription,
+										CancellationToken.None);
+								}
+							}
+							finally
+							{
+								_startBlock.Complete();
+							}
+						}
         }
 
         public Task Completion => _endBlock.Completion;

--- a/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
@@ -40,29 +40,29 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public Task Complete() => Complete(WebSocketCloseStatus.NormalClosure, "Completed");
 
-      public async Task Complete(WebSocketCloseStatus closeStatus, string statusDescription)
-      {
-        if (_socket.State != WebSocketState.Closed && _socket.State != WebSocketState.CloseSent)
-          try
-          {
-            if (closeStatus == WebSocketCloseStatus.NormalClosure)
-              await _socket.CloseAsync(
-                closeStatus,
-                statusDescription,
-                CancellationToken.None);
-            else
-              await _socket.CloseOutputAsync(
-                closeStatus,
-                statusDescription,
-                CancellationToken.None);
-          }
-          finally
-          {
-            _startBlock.Complete();
-          }
-      }
+        public async Task Complete(WebSocketCloseStatus closeStatus, string statusDescription)
+        {
+          if (_socket.State != WebSocketState.Closed && _socket.State != WebSocketState.CloseSent)
+            try
+            {
+              if (closeStatus == WebSocketCloseStatus.NormalClosure)
+                await _socket.CloseAsync(
+                  closeStatus,
+                  statusDescription,
+                  CancellationToken.None);
+              else
+                await _socket.CloseOutputAsync(
+                  closeStatus,
+                  statusDescription,
+                  CancellationToken.None);
+            }
+            finally
+            {
+              _startBlock.Complete();
+            }
+        }
 
-      public Task Completion => _endBlock.Completion;
+        public Task Completion => _endBlock.Completion;
 
         protected IPropagatorBlock<string, OperationMessage> CreateReaderJsonTransformer()
         {

--- a/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
@@ -47,7 +47,7 @@ namespace GraphQL.Server.Transports.WebSockets
                 if (closeStatus == WebSocketCloseStatus.NormalClosure)
                 {
                     // If nothing went wrong, close connection with handshakes.
-                    await _socket.CloseOutputAsync(
+                    await _socket.CloseAsync(
                            closeStatus,
                            statusDescription,
                            CancellationToken.None);
@@ -55,7 +55,7 @@ namespace GraphQL.Server.Transports.WebSockets
                 else
                 {
                     // Something went wrong, so don't wait for answer from the other side, just close the connection.
-                    await _socket.CloseAsync(
+                    await _socket.CloseOutputAsync(
                            closeStatus,
                            statusDescription,
                            CancellationToken.None);

--- a/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
@@ -40,37 +40,29 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public Task Complete() => Complete(WebSocketCloseStatus.NormalClosure, "Completed");
 
-        public async Task Complete(WebSocketCloseStatus closeStatus, string statusDescription)
-        {
-            if (_socket.State != WebSocketState.Closed && _socket.State != WebSocketState.CloseSent)
-            {
-							try
-							{
-								if (closeStatus == WebSocketCloseStatus.NormalClosure)
-								{
-									// If nothing went wrong, close connection with handshakes.
-									await _socket.CloseAsync(
-										closeStatus,
-										statusDescription,
-										CancellationToken.None);
-								}
-								else
-								{
-									// Something went wrong, so don't wait for answer from the other side, just close the connection.
-									await _socket.CloseOutputAsync(
-										closeStatus,
-										statusDescription,
-										CancellationToken.None);
-								}
-							}
-							finally
-							{
-								_startBlock.Complete();
-							}
-						}
-        }
+      public async Task Complete(WebSocketCloseStatus closeStatus, string statusDescription)
+      {
+        if (_socket.State != WebSocketState.Closed && _socket.State != WebSocketState.CloseSent)
+          try
+          {
+            if (closeStatus == WebSocketCloseStatus.NormalClosure)
+              await _socket.CloseAsync(
+                closeStatus,
+                statusDescription,
+                CancellationToken.None);
+            else
+              await _socket.CloseOutputAsync(
+                closeStatus,
+                statusDescription,
+                CancellationToken.None);
+          }
+          finally
+          {
+            _startBlock.Complete();
+          }
+      }
 
-        public Task Completion => _endBlock.Completion;
+      public Task Completion => _endBlock.Completion;
 
         protected IPropagatorBlock<string, OperationMessage> CreateReaderJsonTransformer()
         {


### PR DESCRIPTION
…t complete the websocket reader pipeline

When a GraphQL client is subscribed and prematurely closes (e.g. the app crashes, or is simply closed), the   WebSocketReaderPipeline tries to close the socket by calling _socket.CloseAsync which never returns.

Even though Microsoft's documentation on CloseAsync and CloseOutputAsync is quite similar, according to the below links:
- https://stackoverflow.com/a/26744644
- http://www.salmanq.com/blog/5-things-you-probably-didnt-know-about-net-websockets/2013/04/

CloseAsync waits for the client to acknowledge closing of the socket, whereas  CloseOutputAsync works in fire-and-forget mode.

It looks like the use of those methods should be swapped to achieve the correct semantics, so that CloseAsync does not get stuck waiting for the client's acknowledgement (the client may already be closed by now) and hence never complete the reader pipeline.