### PR TITLE
Fixing path string issue for playground schema fetch

### DIFF
--- a/src/Transports.AspNetCore/Transports.AspNetCore.csproj
+++ b/src/Transports.AspNetCore/Transports.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/Transports.AspNetCore/Transports.AspNetCore.csproj
+++ b/src/Transports.AspNetCore/Transports.AspNetCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -24,6 +24,7 @@ namespace GraphQL.Server.Ui.Playground.Internal {
                 using (var streamReader = new StreamReader(manifestResourceStream)) {
                     var builder = new StringBuilder(streamReader.ReadToEnd());
                     builder.Replace("@Model.GraphQLEndPoint", this.settings.GraphQLEndPoint);
+                    builder.Replace("@Model.Path", this.settings.Path);
                     playgroundCSHtml = builder.ToString();
                     return this.Render();
                 }

--- a/src/Ui.Playground/Internal/playground.cshtml
+++ b/src/Ui.Playground/Internal/playground.cshtml
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
   <meta charset=utf-8 />
@@ -47,12 +47,15 @@
     </div>
   </div>
   <script>
-    window.addEventListener('load', function (event) {
+      window.addEventListener('load', function (event) {
+          var path = window.location.pathname;
+          var regex = new RegExp("@Model.Path" + "\/*");
+          path = path.replace(regex , '');
       GraphQLPlayground.init(document.getElementById('root'),
         {
-          setTitle: true,
-          endpoint: window.location.protocol + "//" + window.location.host + "@Model.GraphQLEndPoint",
-          subscriptionEndpoint: (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.GraphQLEndPoint",
+            setTitle: true,
+            endpoint: window.location.protocol + "//" + window.location.host + path + "@Model.GraphQLEndPoint",
+            subscriptionEndpoint: (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + path + "@Model.GraphQLEndPoint",
           settings: {
             'tracing.hideTracingResponse': false
           }


### PR DESCRIPTION
Fix for #184 
Fix to consider path string for creation of graphql schema endpoint in playground 