### PR TITLE
Made list of nugets readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ For the WebSocket subscription protocol (depends on above) middleware:
 >`dotnet add package GraphQL.Server.Transports.WebSockets`
 
 For the UI middleware/s:
->`dotnet add package GraphQL.Server.Ui.GraphiQL`
->`dotnet add package GraphQL.Server.Ui.Playground`
->`dotnet add package GraphQL.Server.Ui.Voyager`
+>`dotnet add package GraphQL.Server.Ui.GraphiQL`  
+>`dotnet add package GraphQL.Server.Ui.Playground`  
+>`dotnet add package GraphQL.Server.Ui.Voyager`  
 
 
 ### Configure


### PR DESCRIPTION
The list of UI Middlewares to add was 1 long list so wasn't easy to read, made it fall to new line so it's readable.

Before:
![image](https://user-images.githubusercontent.com/895629/50644482-f07c1a00-0fab-11e9-97ce-a8b7434fe65c.png)


After:
![image](https://user-images.githubusercontent.com/895629/50644457-e0fcd100-0fab-11e9-93f5-e12ffb685258.png)

(yellow is the github diff tool preview)