### PR TITLE
Add GraphQL Playground settings to settable options

### DIFF
--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -57,7 +57,11 @@ namespace GraphQL.Samples.Server
             app.UseGraphQL<ChatSchema>("/graphql");
             app.UseGraphQLPlayground(new GraphQLPlaygroundOptions()
             {
-                Path = "/ui/playground"
+                Path = "/ui/playground",
+                PlaygroundSettings = @"{
+                    'editor.theme': 'light',
+                    'tracing.hideTracingResponse': false
+                }"
             });
             app.UseGraphiQLServer(new GraphiQLOptions
             {

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
 
 namespace GraphQL.Samples.Server
 {
@@ -58,10 +59,10 @@ namespace GraphQL.Samples.Server
             app.UseGraphQLPlayground(new GraphQLPlaygroundOptions()
             {
                 Path = "/ui/playground",
-                PlaygroundSettings = @"{
-                    'editor.theme': 'light',
-                    'tracing.hideTracingResponse': false
-                }"
+                PlaygroundSettings = new Dictionary<string, object> {
+                    ["editor.theme"] = "light",
+                    ["tracing.hideTracingResponse"] = false
+                }
             });
             app.UseGraphiQLServer(new GraphiQLOptions
             {

--- a/src/Ui.Playground/GraphQLPlaygroundOptions.cs
+++ b/src/Ui.Playground/GraphQLPlaygroundOptions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
 
 namespace GraphQL.Server.Ui.Playground {
 
@@ -12,14 +13,14 @@ namespace GraphQL.Server.Ui.Playground {
         public PathString GraphQLEndPoint { get; set; } = "/graphql";
 
         /// <summary>
-        /// The GraphQL Config (as JSON string)
+        /// The GraphQL Config
         /// </summary>
-        public string GraphQLConfig { get; set; } = null;
+        public Dictionary<string, object> GraphQLConfig { get; set; } = null;
 
         /// <summary>
-        /// The GraphQL Playground Settings (as JSON string)
+        /// The GraphQL Playground Settings
         /// </summary>
-        public string PlaygroundSettings { get; set; } = null;
+        public Dictionary<string, object> PlaygroundSettings { get; set; } = null;
 
     }
 

--- a/src/Ui.Playground/GraphQLPlaygroundOptions.cs
+++ b/src/Ui.Playground/GraphQLPlaygroundOptions.cs
@@ -11,6 +11,16 @@ namespace GraphQL.Server.Ui.Playground {
         /// </summary>
         public PathString GraphQLEndPoint { get; set; } = "/graphql";
 
+        /// <summary>
+        /// The GraphQL Config (as JSON string)
+        /// </summary>
+        public string GraphQLConfig { get; set; } = null;
+
+        /// <summary>
+        /// The GraphQL Playground Settings (as JSON string)
+        /// </summary>
+        public string PlaygroundSettings { get; set; } = null;
+
     }
 
 }

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Reflection;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace GraphQL.Server.Ui.Playground.Internal {
 
@@ -26,9 +27,9 @@ namespace GraphQL.Server.Ui.Playground.Internal {
                     builder.Replace("@Model.GraphQLEndPoint",
                         options.GraphQLEndPoint);
                     builder.Replace("@Model.GraphQLConfig",
-                        options.GraphQLConfig ?? "null");
+                        JsonConvert.SerializeObject(options.GraphQLConfig));
                     builder.Replace("@Model.PlaygroundSettings",
-                        options.PlaygroundSettings ?? "null");
+                        JsonConvert.SerializeObject(options.PlaygroundSettings));
                     playgroundCSHtml = builder.ToString();
                     return this.Render();
                 }

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -9,10 +9,10 @@ namespace GraphQL.Server.Ui.Playground.Internal {
 
 		private string playgroundCSHtml;
 
-		private readonly GraphQLPlaygroundOptions settings;
+		private readonly GraphQLPlaygroundOptions options;
 
-		public PlaygroundPageModel(GraphQLPlaygroundOptions settings) {
-			this.settings = settings;
+		public PlaygroundPageModel(GraphQLPlaygroundOptions options) {
+			this.options = options;
 		}
 
 		public string Render() {
@@ -23,7 +23,12 @@ namespace GraphQL.Server.Ui.Playground.Internal {
             using (var manifestResourceStream = assembly.GetManifestResourceStream("GraphQL.Server.Ui.Playground.Internal.playground.cshtml")) {
                 using (var streamReader = new StreamReader(manifestResourceStream)) {
                     var builder = new StringBuilder(streamReader.ReadToEnd());
-                    builder.Replace("@Model.GraphQLEndPoint", this.settings.GraphQLEndPoint);
+                    builder.Replace("@Model.GraphQLEndPoint",
+                        options.GraphQLEndPoint);
+                    builder.Replace("@Model.GraphQLConfig",
+                        options.GraphQLConfig ?? "null");
+                    builder.Replace("@Model.PlaygroundSettings",
+                        options.PlaygroundSettings ?? "null");
                     playgroundCSHtml = builder.ToString();
                     return this.Render();
                 }

--- a/src/Ui.Playground/Internal/playground.cshtml
+++ b/src/Ui.Playground/Internal/playground.cshtml
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
   <meta charset=utf-8 />
@@ -53,9 +53,8 @@
           setTitle: true,
           endpoint: window.location.protocol + "//" + window.location.host + "@Model.GraphQLEndPoint",
           subscriptionEndpoint: (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.GraphQLEndPoint",
-          settings: {
-            'tracing.hideTracingResponse': false
-          }
+          config: @Model.GraphQLConfig,
+          settings: @Model.PlaygroundSettings
         });
     })
   </script>

--- a/src/Ui.Playground/Ui.Playground.csproj
+++ b/src/Ui.Playground/Ui.Playground.csproj
@@ -24,6 +24,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Make GraphQL Playground settings and GraphQL config settable via `GraphQLPlaygroundOptions`.

Reverted the changed default setting (show tracing, see #166), since this is customizable now. Better to stick with the default settings of Playground (principle of least astonishment).

The Samples.Server shows a usage example.