### PR TITLE
Allow injection of ClaimsPrincipal into AuthorizationValidationRule

### DIFF
--- a/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
+++ b/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
@@ -82,16 +82,16 @@ namespace GraphQL.Server.Authorization.AspNetCore
         private async Task AuthorizeAsync(INode node, IProvideMetadata type, ValidationContext context, OperationType? operationType)
         {
             var policyNames = type?.GetPolicies();
-            var claimsPrincipal = _claimsPrincipalAccessor.GetClaimsPrincipal(context);
 
             if (policyNames?.Count == 1)
             {
                 // small optimization for the single policy - no 'new List<>()', no 'await Task.WhenAll()'
-                var authorizationResult = await _authorizationService.AuthorizeAsync(claimsPrincipal, policyNames[0]);
+                var authorizationResult = await _authorizationService.AuthorizeAsync(_claimsPrincipalAccessor.GetClaimsPrincipal(context), policyNames[0]);
                 AddValidationError(node, context, operationType, authorizationResult);
             }
             else if (policyNames?.Count > 1)
             {
+                var claimsPrincipal = _claimsPrincipalAccessor.GetClaimsPrincipal(context);
                 var tasks = new List<Task<AuthorizationResult>>(policyNames.Count);
                 foreach (string policyName in policyNames)
                 {

--- a/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
+++ b/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
@@ -19,17 +19,17 @@ namespace GraphQL.Server.Authorization.AspNetCore
     public class AuthorizationValidationRule : IValidationRule
     {
         private readonly IAuthorizationService _authorizationService;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IClaimsPrincipalAccessor _claimsPrincipalAccessor;
 
         /// <summary>
         /// Creates an instance of <see cref="AuthorizationValidationRule"/>.
         /// </summary>
         /// <param name="authorizationService"> ASP.NET Core <see cref="IAuthorizationService"/> to authorize against. </param>
-        /// <param name="httpContextAccessor"> ASP.NET Core <see cref="IHttpContextAccessor"/> to take user (HttpContext.User) from. </param>
-        public AuthorizationValidationRule(IAuthorizationService authorizationService, IHttpContextAccessor httpContextAccessor)
+        /// <param name="claimsPrincipalAccessor"> ASP.NET Core <see cref="IHttpContextAccessor"/> to take user (HttpContext.User) from. </param>
+        public AuthorizationValidationRule(IAuthorizationService authorizationService, IClaimsPrincipalAccessor claimsPrincipalAccessor)
         {
             _authorizationService = authorizationService;
-            _httpContextAccessor = httpContextAccessor;
+            _claimsPrincipalAccessor = claimsPrincipalAccessor;
         }
 
         /// <inheritdoc />
@@ -86,7 +86,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
             if (policyNames?.Count == 1)
             {
                 // small optimization for the single policy - no 'new List<>()', no 'await Task.WhenAll()'
-                var authorizationResult = await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, policyNames[0]);
+                var authorizationResult = await _authorizationService.AuthorizeAsync(_claimsPrincipalAccessor.GetClaimsPrincipal(context), policyNames[0]);
                 AddValidationError(node, context, operationType, authorizationResult);
             }
             else if (policyNames?.Count > 1)
@@ -94,7 +94,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
                 var tasks = new List<Task<AuthorizationResult>>(policyNames.Count);
                 foreach (string policyName in policyNames)
                 {
-                    var task = _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, policyName);
+                    var task = _authorizationService.AuthorizeAsync(_claimsPrincipalAccessor.GetClaimsPrincipal(context), policyName);
                     tasks.Add(task);
                 }
 

--- a/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
+++ b/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
@@ -17,7 +17,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
         /// <param name="contextAccessor">ASP.NET Core <see cref="IHttpContextAccessor"/> to take claims principal (<see cref="HttpContext.User"/>) from.</param>
         public DefaultClaimsPrincipalAccessor(IHttpContextAccessor contextAccessor)
         {
-            _contextAccessor = contextAccessor;
+            _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor));
         }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
         /// <returns></returns>
         public ClaimsPrincipal GetClaimsPrincipal(ValidationContext context)
         {
-            return _contextAccessor.HttpContext.User;
+            return _contextAccessor.HttpContext?.User;
         }
     }
 }

--- a/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
+++ b/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
@@ -4,15 +4,27 @@ using Microsoft.AspNetCore.Http;
 
 namespace GraphQL.Server.Authorization.AspNetCore
 {
+    /// <summary>
+    /// The default claims principal accessor.
+    /// </summary>
     public class DefaultClaimsPrincipalAccessor: IClaimsPrincipalAccessor
     {
         private readonly IHttpContextAccessor _contextAccessor;
 
+        /// <summary>
+        /// Creates an instance of <see cref="DefaultClaimsPrincipalAccessor"/>.
+        /// </summary>
+        /// <param name="contextAccessor">ASP.NET Core <see cref="IHttpContextAccessor"/> to take claims principal (<see cref="HttpContext.User"/>) from.</param>
         public DefaultClaimsPrincipalAccessor(IHttpContextAccessor contextAccessor)
         {
             _contextAccessor = contextAccessor;
         }
 
+        /// <summary>
+        /// Returns the <see cref="HttpContext.User"/> of the current http query
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
         public ClaimsPrincipal GetClaimsPrincipal(ValidationContext context)
         {
             return _contextAccessor.HttpContext.User;

--- a/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
+++ b/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
@@ -1,0 +1,21 @@
+using System.Security.Claims;
+using GraphQL.Validation;
+using Microsoft.AspNetCore.Http;
+
+namespace GraphQL.Server.Authorization.AspNetCore
+{
+    public class DefaultClaimsPrincipalAccessor: IClaimsPrincipalAccessor
+    {
+        private readonly IHttpContextAccessor _contextAccessor;
+
+        public DefaultClaimsPrincipalAccessor(IHttpContextAccessor contextAccessor)
+        {
+            _contextAccessor = contextAccessor;
+        }
+
+        public ClaimsPrincipal GetClaimsPrincipal(ValidationContext context)
+        {
+            return _contextAccessor.HttpContext.User;
+        }
+    }
+}

--- a/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
+++ b/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
         }
 
         /// <summary>
-        /// Returns the <see cref="HttpContext.User"/> of the current http query
+        /// Returns the <see cref="HttpContext.User"/>.
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>

--- a/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
+++ b/src/Authorization.AspNetCore/DefaultClaimsPrincipalAccessor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Claims;
 using GraphQL.Validation;
 using Microsoft.AspNetCore.Http;

--- a/src/Authorization.AspNetCore/GraphQLBuilderAuthorizationExtensions.cs
+++ b/src/Authorization.AspNetCore/GraphQLBuilderAuthorizationExtensions.cs
@@ -3,6 +3,7 @@ using GraphQL.Server.Authorization.AspNetCore;
 using GraphQL.Validation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace GraphQL.Server
 {
@@ -24,6 +25,7 @@ namespace GraphQL.Server
         /// <returns>Reference to the passed <paramref name="builder"/>.</returns>
         public static IGraphQLBuilder AddGraphQLAuthorization(this IGraphQLBuilder builder, Action<AuthorizationOptions> options)
         {
+            builder.Services.TryAddTransient<IClaimsPrincipalAccessor, DefaultClaimsPrincipalAccessor>();
             builder.Services
                 .AddHttpContextAccessor()
                 .AddTransient<IValidationRule, AuthorizationValidationRule>()

--- a/src/Authorization.AspNetCore/IClaimsPrincipalAccessor.cs
+++ b/src/Authorization.AspNetCore/IClaimsPrincipalAccessor.cs
@@ -1,0 +1,10 @@
+﻿using System.Security.Claims;
+using GraphQL.Validation;
+
+namespace GraphQL.Server.Authorization.AspNetCore
+{
+    public interface IClaimsPrincipalAccessor
+    {
+        ClaimsPrincipal GetClaimsPrincipal(ValidationContext context);
+    }
+}

--- a/src/Authorization.AspNetCore/IClaimsPrincipalAccessor.cs
+++ b/src/Authorization.AspNetCore/IClaimsPrincipalAccessor.cs
@@ -1,10 +1,18 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 using GraphQL.Validation;
 
 namespace GraphQL.Server.Authorization.AspNetCore
 {
+    /// <summary>
+    /// Provides access to the <see cref="ClaimsPrincipal"/> used for GraphQL operation authorization
+    /// </summary>
     public interface IClaimsPrincipalAccessor
     {
+        /// <summary>
+        /// Provides the <see cref="ClaimsPrincipal"/> for the current <see cref="ValidationContext"/>
+        /// </summary>
+        /// <param name="context">the <see cref="ValidationContext"/> of the current operation</param>
+        /// <returns></returns>
         ClaimsPrincipal GetClaimsPrincipal(ValidationContext context);
     }
 }

--- a/src/Authorization.AspNetCore/IClaimsPrincipalAccessor.cs
+++ b/src/Authorization.AspNetCore/IClaimsPrincipalAccessor.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
         /// <summary>
         /// Provides the <see cref="ClaimsPrincipal"/> for the current <see cref="ValidationContext"/>
         /// </summary>
-        /// <param name="context">the <see cref="ValidationContext"/> of the current operation</param>
+        /// <param name="context">The <see cref="ValidationContext"/> of the current operation</param>
         /// <returns></returns>
         ClaimsPrincipal GetClaimsPrincipal(ValidationContext context);
     }

--- a/tests/ApiApprovalTests/GraphQL.Server.Authorization.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Authorization.AspNetCore.approved.txt
@@ -15,8 +15,13 @@ namespace GraphQL.Server.Authorization.AspNetCore
     }
     public class AuthorizationValidationRule : GraphQL.Validation.IValidationRule
     {
-        public AuthorizationValidationRule(Microsoft.AspNetCore.Authorization.IAuthorizationService authorizationService, Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor) { }
+        public AuthorizationValidationRule(Microsoft.AspNetCore.Authorization.IAuthorizationService authorizationService, GraphQL.Server.Authorization.AspNetCore.IClaimsPrincipalAccessor claimsPrincipalAccessor) { }
         public System.Threading.Tasks.Task<GraphQL.Validation.INodeVisitor> ValidateAsync(GraphQL.Validation.ValidationContext context) { }
+    }
+    public class DefaultClaimsPrincipalAccessor : GraphQL.Server.Authorization.AspNetCore.IClaimsPrincipalAccessor
+    {
+        public DefaultClaimsPrincipalAccessor(Microsoft.AspNetCore.Http.IHttpContextAccessor contextAccessor) { }
+        public System.Security.Claims.ClaimsPrincipal GetClaimsPrincipal(GraphQL.Validation.ValidationContext context) { }
     }
     public class GraphQLAuthorizeAttribute : GraphQL.GraphQLAttribute
     {
@@ -24,6 +29,10 @@ namespace GraphQL.Server.Authorization.AspNetCore
         public string Policy { get; set; }
         public override void Modify(GraphQL.Utilities.FieldConfig field) { }
         public override void Modify(GraphQL.Utilities.TypeConfig type) { }
+    }
+    public interface IClaimsPrincipalAccessor
+    {
+        System.Security.Claims.ClaimsPrincipal GetClaimsPrincipal(GraphQL.Validation.ValidationContext context);
     }
 }
 namespace GraphQL.Server

--- a/tests/Authorization.AspNetCore.Tests/ValidationTestBase.cs
+++ b/tests/Authorization.AspNetCore.Tests/ValidationTestBase.cs
@@ -23,7 +23,7 @@ namespace GraphQL.Server.Authorization.AspNetCore.Tests
         {
             var (authorizationService, httpContextAccessor) = BuildServices(setupOptions);
             HttpContext = httpContextAccessor.HttpContext;
-            Rule = new AuthorizationValidationRule(authorizationService, httpContextAccessor);
+            Rule = new AuthorizationValidationRule(authorizationService, new DefaultClaimsPrincipalAccessor(httpContextAccessor));
         }
 
         protected void ShouldPassRule(Action<ValidationTestConfig> configure)


### PR DESCRIPTION
This implements the idea of @klowdo in https://github.com/graphql-dotnet/server/issues/156#issuecomment-422180470 to allow the injection of a `ClaimsPrincipal` via `IClaimsPrincipalAccessor` into `AuthorizationValidationRule`.

IMO this creates a lot of flexibility in doing authorization of queries (not just subscriptions) via web sockets without settling on a fixed implementation.

I also injected a `IAuthorizationFailureDescriptionGenerator` to be able to output custom messages for other claim types.