### PR TITLE
Ensure underlying type is used for auth instead of generic graph type

### DIFF
--- a/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
+++ b/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
@@ -66,7 +66,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
                     // check target field
                     AuthorizeAsync(fieldAst, fieldDef, context, operationType).GetAwaiter().GetResult();
                     // check returned graph type
-                    AuthorizeAsync(fieldAst, fieldDef.ResolvedType, context, operationType).GetAwaiter().GetResult();
+                    AuthorizeAsync(fieldAst, fieldDef.ResolvedType.GetNamedType(), context, operationType).GetAwaiter().GetResult();
                 });
             });
         }

--- a/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
+++ b/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
@@ -135,6 +135,38 @@ namespace GraphQL.Server.Authorization.AspNetCore.Tests
         }
 
         [Fact]
+        public void nested_type_list_policy_fail()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("PostPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = @"query { posts }";
+                _.Schema = NestedSchema();
+            });
+        }
+
+        [Fact]
+        public void nested_type_list_non_null_policy_fail()
+        {
+            ConfigureAuthorizationOptions(
+                options =>
+                {
+                    options.AddPolicy("PostPolicy", x => x.RequireClaim("admin"));
+                });
+
+            ShouldFailRule(_ =>
+            {
+                _.Query = @"query { postsNonNull }";
+                _.Schema = NestedSchema();
+            });
+        }
+
+        [Fact]
         public void fails_on_missing_claim_on_input_type()
         {
             ConfigureAuthorizationOptions(
@@ -189,6 +221,8 @@ namespace GraphQL.Server.Authorization.AspNetCore.Tests
             string defs = @"
                 type Query {
                     post(id: ID!): Post
+                    posts: [Post]
+                    postsNonNull: [Post!]!
                 }
 
                 type Post {
@@ -207,6 +241,16 @@ namespace GraphQL.Server.Authorization.AspNetCore.Tests
         public class NestedQueryWithAttributes
         {
             public Post Post(string id)
+            {
+                return null;
+            }
+
+            public IEnumerable<Post> Posts()
+            {
+                return null;
+            }
+
+            public IEnumerable<Post> PostsNonNull()
             {
                 return null;
             }


### PR DESCRIPTION
Fixes #214 

Solution from: https://github.com/graphql-dotnet/authorization/pull/37 by @joemcbride 