### PR TITLE
Adding the option to use IServiceProvider while building GraphQlOptions

### DIFF
--- a/src/Core/ServiceCollectionExtensions.cs
+++ b/src/Core/ServiceCollectionExtensions.cs
@@ -18,9 +18,20 @@ namespace GraphQL.Server
         /// <returns></returns>
         public static IGraphQLBuilder AddGraphQL(this IServiceCollection services, GraphQLOptions options)
         {
+            return services.AddGraphQL(p => options);
+        }
+
+        /// <summary>
+        /// Add required services for GraphQL
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static IGraphQLBuilder AddGraphQL(this IServiceCollection services, Func<IServiceProvider, GraphQLOptions> options)
+        {
             services.TryAddSingleton<IDocumentExecuter, DocumentExecuter>();
             services.AddTransient(typeof(IGraphQLExecuter<>), typeof(DefaultGraphQLExecuter<>));
-            services.AddSingleton(Options.Create(options));
+            services.AddSingleton(p => Options.Create(options(p)));
 
             services.TryAddSingleton<IDocumentWriter>(x =>
             {
@@ -32,20 +43,36 @@ namespace GraphQL.Server
         }
 
         /// <summary>
-        /// Add required services for GraphQL
+        /// Add required services for GraphQL.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="configureOptions"></param>
         /// <returns></returns>
         public static IGraphQLBuilder AddGraphQL(this IServiceCollection services, Action<GraphQLOptions> configureOptions)
         {
+            return services.AddGraphQL((provider, options) =>
+            {
+                configureOptions(options);
+            }); 
+        }
+
+        /// <summary>
+        /// Add required services for GraphQL
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="configureOptions"></param>
+        /// <returns></returns>
+        public static IGraphQLBuilder AddGraphQL(this IServiceCollection services, Action<IServiceProvider, GraphQLOptions> configureOptions)
+        {
             if (configureOptions == null)
                 throw new ArgumentNullException(nameof(configureOptions));
 
-            var options = new GraphQLOptions();
-            configureOptions(options);
-
-            return services.AddGraphQL(options);
+            return services.AddGraphQL(p =>
+            {
+                var options = new GraphQLOptions();
+                configureOptions(p, options);
+                return options;
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
Hi, here is a small change for registering graphql options, it gives the opportunity to make use of IServiceProvider to build the GraphQlOptions