### PR TITLE
subscriptionsClient.subscribe is not a function

### DIFF
--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -42,7 +42,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.min.css" />
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.13.0/graphiql.min.js"></script>
 
-	<script src="https://unpkg.com/subscriptions-transport-ws@0.9.15/browser/client.js"></script>
+	<script src="https://unpkg.com/subscriptions-transport-ws@0.8.3/browser/client.js"></script>
     	<script src="https://unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
 
 </head>


### PR DESCRIPTION
version `0.9.*` of `subscriptions-transport-ws` throws an error whenever a subscription is executed on the GraphiQL UI. Downgrading to `0.8.*` is suggested for the time being.

### Way to reproduce
This occurs on the sample server project on URL `http://localhost:<port>/ui/graphiql`