### PR TITLE
Compatibility with GraphQL.NET 3.0.0-preview-1446.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,8 +42,8 @@
     <MicrosoftNETTestSdkVersion>16.3.0</MicrosoftNETTestSdkVersion>
     <CastleCoreVersion>4.4.0</CastleCoreVersion>
     <NSubstituteVersion>3.1.0</NSubstituteVersion>
-    <NewtonsoftJsonVersion>12.0.2</NewtonsoftJsonVersion>
-    <GraphQLVersion>3.0.0-preview-1430</GraphQLVersion>
+    <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
+    <GraphQLVersion>3.0.0-preview-1446</GraphQLVersion>
     <MoqVersion>4.13.1</MoqVersion>
     <ShouldlyVersion>3.0.2</ShouldlyVersion>
 

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -12,6 +12,8 @@
   
   <ItemGroup>
     <PackageReference Include="GraphQL" Version="$(GraphQLVersion)" />
+    <PackageReference Include="GraphQL.NewtonsoftJson" Version="$(GraphQLVersion)" />
+
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsVersion)" />
   </ItemGroup>

--- a/src/Core/ServiceCollectionExtensions.cs
+++ b/src/Core/ServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using GraphQL.Http;
+using System;
+using GraphQL.NewtonsoftJson;
 using GraphQL.Server.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -36,7 +36,7 @@ namespace GraphQL.Server
             services.TryAddSingleton<IDocumentWriter>(x =>
             {
                 var jsonSerializerSettings = x.GetRequiredService<IOptions<JsonSerializerSettings>>();
-                return new DocumentWriter(Formatting.None, jsonSerializerSettings.Value);
+                return new DocumentWriter(jsonSerializerSettings.Value);
             });
 
             return new GraphQLBuilder(services);

--- a/src/Transports.AspNetCore/Common/GraphQLRequest.cs
+++ b/src/Transports.AspNetCore/Common/GraphQLRequest.cs
@@ -1,3 +1,4 @@
+using GraphQL.NewtonsoftJson;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -1,4 +1,3 @@
-using GraphQL.Http;
 using GraphQL.Instrumentation;
 using GraphQL.Server.Internal;
 using GraphQL.Server.Transports.AspNetCore.Common;

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
@@ -1,3 +1,4 @@
+using GraphQL.NewtonsoftJson;
 using GraphQL.Server.Internal;
 using GraphQL.Server.Transports.Subscriptions.Abstractions.Internal;
 using GraphQL.Subscription;

--- a/src/Transports.Subscriptions.WebSockets/WebSocketConnectionFactory.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketConnectionFactory.cs
@@ -1,4 +1,3 @@
-﻿using GraphQL.Http;
 using GraphQL.Server.Internal;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using GraphQL.Types;

--- a/src/Transports.Subscriptions.WebSockets/WebSocketTransport.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketTransport.cs
@@ -1,4 +1,3 @@
-using GraphQL.Http;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;

--- a/src/Transports.Subscriptions.WebSockets/WebSocketWriterPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketWriterPipeline.cs
@@ -1,4 +1,3 @@
-using GraphQL.Http;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using System.Net.WebSockets;
 using System.Threading.Tasks;

--- a/tests/Transports.Subscriptions.WebSockets.Tests/WebSocketWriterPipelineTests.cs
+++ b/tests/Transports.Subscriptions.WebSockets.Tests/WebSocketWriterPipelineTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using GraphQL.Http;
+using GraphQL.NewtonsoftJson;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -217,8 +217,8 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
 
         private WebSocketWriterPipeline CreateWebSocketWriterPipeline(IContractResolver contractResolver)
         {
-            return new WebSocketWriterPipeline(_testWebSocket, new DocumentWriter(Formatting.None,
-                new JsonSerializerSettings
+            return new WebSocketWriterPipeline(_testWebSocket, new DocumentWriter(
+            	new JsonSerializerSettings
                 {
                     ContractResolver = contractResolver,
                     NullValueHandling = NullValueHandling.Ignore


### PR DESCRIPTION
* Bumps NewtonsoftJsonVersion to 12.0.3
* Bumps GraphQLVersion to 3.0.0-preview-1446
* Adds GraphQL.Newtonsoft.Json PackageReference to Core
* Imports GraphQl.NewtonsoftJson as needed
* Removes unused references to now invalid namespace GraphQl.Http
* Removes the `Formatting.None` argument in `DocumentWriter` as per https://github.com/graphql-dotnet/graphql-dotnet/commit/43a80a883997a88f9dd9e22d3ca2f80b6183825f#diff-66c55d68e4a8af8db5205e0f30b1907e

It seems however that either the Newtonsoft.Json upgrade, or the new default settings in `DocumentWriter` as in the above commit change the behaviour of some serialization values.

Particularly, in `WebSocketWriterPipelineFacts`, all tests fail due to slight mismatches in the expected output like so

```
  Assert.Equal() Failure
                                     ↓ (pos 71)
    Expected: ···:"Type","payload":{"data":{"Content":"Hello world","SentAt":"···
    Actual:   ···:"Type","payload":{"Data":{"Content":"Hello world","SentAt":"···
                                     ↑ (pos 71)
```

Please advise on how to fix these tests, or if they require fixing.