### PR TITLE
Remove ConfigureAwait(false)

### DIFF
--- a/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
+++ b/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
@@ -91,7 +91,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
                 var task = _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, policyName);
                 tasks.Add(task);
             }
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            await Task.WhenAll(tasks);
 
             foreach (var task in tasks)
             {

--- a/src/Transports.Subscriptions.WebSockets/GraphQLWebSocketsMiddleware.cs
+++ b/src/Transports.Subscriptions.WebSockets/GraphQLWebSocketsMiddleware.cs
@@ -33,15 +33,14 @@ namespace GraphQL.Server.Transports.WebSockets
                 if (!context.WebSockets.IsWebSocketRequest || !context.Request.Path.StartsWithSegments(_path))
                 {
                     _logger.LogDebug("Request is not a valid websocket request");
-                    await _next(context).ConfigureAwait(false);
+                    await _next(context);
 
                     return;
                 }
 
                 _logger.LogDebug("Connection is a valid websocket request");
 
-                var socket = await context.WebSockets.AcceptWebSocketAsync("graphql-ws")
-                    .ConfigureAwait(false);
+                var socket = await context.WebSockets.AcceptWebSocketAsync("graphql-ws");
 
                 if (!context.WebSockets.WebSocketRequestedProtocols.Contains(socket.SubProtocol))
                 {
@@ -52,7 +51,7 @@ namespace GraphQL.Server.Transports.WebSockets
                     await socket.CloseAsync(
                         WebSocketCloseStatus.ProtocolError,
                         "Server only supports graphql-ws protocol",
-                        context.RequestAborted).ConfigureAwait(false);
+                        context.RequestAborted);
 
                     return;
                 }
@@ -62,7 +61,7 @@ namespace GraphQL.Server.Transports.WebSockets
                     var connectionFactory = context.RequestServices.GetRequiredService<IWebSocketConnectionFactory<TSchema>>();
                     var connection = connectionFactory.CreateConnection(socket, context.Connection.Id);
 
-                    await connection.Connect().ConfigureAwait(false);
+                    await connection.Connect();
                 }
             }
         }

--- a/src/Transports.Subscriptions.WebSockets/WebSocketConnection.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketConnection.cs
@@ -18,9 +18,9 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public async Task Connect()
         {
-            await _server.OnConnect().ConfigureAwait(false);
-            await _server.OnDisconnect().ConfigureAwait(false);
-            await _transport.CloseAsync().ConfigureAwait(false);
+            await _server.OnConnect();
+            await _server.OnDisconnect();
+            await _transport.CloseAsync();
         }
     }
 }

--- a/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
@@ -49,12 +49,12 @@ namespace GraphQL.Server.Transports.WebSockets
                         await _socket.CloseAsync(
                           closeStatus,
                           statusDescription,
-                          CancellationToken.None).ConfigureAwait(false); 
+                          CancellationToken.None); 
                     else
                         await _socket.CloseOutputAsync(
                           closeStatus,
                           statusDescription,
-                          CancellationToken.None).ConfigureAwait(false); 
+                          CancellationToken.None); 
                 }
                 finally
                 {
@@ -86,7 +86,7 @@ namespace GraphQL.Server.Transports.WebSockets
                     MaxDegreeOfParallelism = 1
                 });
 
-            Task.Run(async () => await ReadMessageAsync(source).ConfigureAwait(false));
+            Task.Run(async () => await ReadMessageAsync(source));
 
             return source;
         }
@@ -107,7 +107,7 @@ namespace GraphQL.Server.Transports.WebSockets
 
                         do
                         {
-                            receiveResult = await _socket.ReceiveAsync(segment, CancellationToken.None).ConfigureAwait(false);
+                            receiveResult = await _socket.ReceiveAsync(segment, CancellationToken.None);
 
                             if (receiveResult.CloseStatus.HasValue)
                                 target.Complete();
@@ -115,7 +115,7 @@ namespace GraphQL.Server.Transports.WebSockets
                             if (receiveResult.Count == 0)
                                 continue;
 
-                            await memoryStream.WriteAsync(segment.Array, segment.Offset, receiveResult.Count).ConfigureAwait(false);
+                            await memoryStream.WriteAsync(segment.Array, segment.Offset, receiveResult.Count);
                         } while (!receiveResult.EndOfMessage || memoryStream.Length == 0);
 
                         message = Encoding.UTF8.GetString(memoryStream.ToArray());
@@ -141,7 +141,7 @@ namespace GraphQL.Server.Transports.WebSockets
                                 break;
                         }
 
-                        await Complete(closeStatus, $"Closing socket connection due to {wx.WebSocketErrorCode}.").ConfigureAwait(false);
+                        await Complete(closeStatus, $"Closing socket connection due to {wx.WebSocketErrorCode}.");
                         break;
                     }
                     catch (Exception x)
@@ -151,7 +151,7 @@ namespace GraphQL.Server.Transports.WebSockets
                     }
                 }
 
-                await target.SendAsync(message).ConfigureAwait(false);
+                await target.SendAsync(message);
             }
         }
     }

--- a/src/Transports.Subscriptions.WebSockets/WebSocketWriterPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketWriterPipeline.cs
@@ -50,12 +50,11 @@ namespace GraphQL.Server.Transports.WebSockets
             var stream = new WebsocketWriterStream(_socket);
             try
             {
-                await _documentWriter.WriteAsync(stream, message)
-                    .ConfigureAwait(false);
+                await _documentWriter.WriteAsync(stream, message);
             }
             finally
             {
-                await stream.FlushAsync().ConfigureAwait(false);
+                await stream.FlushAsync();
                 stream.Dispose();
             }
         }

--- a/tests/Transports.Subscriptions.WebSockets.Tests/WebSocketsConnectionFacts.cs
+++ b/tests/Transports.Subscriptions.WebSockets.Tests/WebSocketsConnectionFacts.cs
@@ -57,7 +57,7 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
         {
             /* Given */
             /* When */
-            var socket = await ConnectAsync("graphql-ws").ConfigureAwait(false);
+            var socket = await ConnectAsync("graphql-ws");
 
             /* Then */
             Assert.Equal(WebSocketState.Open, socket.State);
@@ -68,9 +68,9 @@ namespace GraphQL.Server.Transports.WebSockets.Tests
         {
             /* Given */
             /* When */
-            var socket = await ConnectAsync("do-not-accept").ConfigureAwait(false);
+            var socket = await ConnectAsync("do-not-accept");
             var segment = new ArraySegment<byte>(new byte[1024]);
-            var received = await socket.ReceiveAsync(segment, CancellationToken.None).ConfigureAwait(false);
+            var received = await socket.ReceiveAsync(segment, CancellationToken.None);
 
             /* Then */
             Assert.Equal(WebSocketCloseStatus.ProtocolError, received.CloseStatus);


### PR DESCRIPTION
I propose to remove `ConfigureAwait(false)` calls because it is nothing more than noise for ASP.NET Core projects that have no synchronization context. I did not remove `ConfigureAwait(false)` only from Transports.Subscriptions.Abstractions project. With high probability they are not needed there, but it will be part of another PR.

@benmccallum @pekkah @joemcbride Please review.