### PR TITLE
Use replace instead of add

### DIFF
--- a/src/Transports.AspNetCore.NewtonsoftJson/GraphQLBuilderExtensions.cs
+++ b/src/Transports.AspNetCore.NewtonsoftJson/GraphQLBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace GraphQL.Server
             Action<JsonSerializerSettings> configureSerializerSettings = null)
         {
             builder.Services.AddSingleton<IGraphQLRequestDeserializer>(p => new GraphQLRequestDeserializer(configureDeserializerSettings));
-            builder.Services.Replace(new ServiceDescriptor(typeof(IDocumentWriter), p => new DocumentWriter(configureSerializerSettings), ServiceLifetime.Singleton));
+            builder.Services.Replace(ServiceDescriptor.Singleton<IDocumentWriter>(p => new DocumentWriter(configureSerializerSettings)));
 
             return builder;
         }

--- a/src/Transports.AspNetCore.NewtonsoftJson/GraphQLBuilderExtensions.cs
+++ b/src/Transports.AspNetCore.NewtonsoftJson/GraphQLBuilderExtensions.cs
@@ -2,6 +2,7 @@ using GraphQL.NewtonsoftJson;
 using GraphQL.Server.Transports.AspNetCore.Common;
 using GraphQL.Server.Transports.AspNetCore.NewtonsoftJson;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Newtonsoft.Json;
 using System;
 
@@ -28,7 +29,7 @@ namespace GraphQL.Server
             Action<JsonSerializerSettings> configureSerializerSettings = null)
         {
             builder.Services.AddSingleton<IGraphQLRequestDeserializer>(p => new GraphQLRequestDeserializer(configureDeserializerSettings));
-            builder.Services.AddSingleton<IDocumentWriter>(p => new DocumentWriter(configureSerializerSettings));
+            builder.Services.Replace(new ServiceDescriptor(typeof(IDocumentWriter), p => new DocumentWriter(configureSerializerSettings), ServiceLifetime.Singleton));
 
             return builder;
         }

--- a/src/Transports.AspNetCore.SystemTextJson/GraphQLBuilderExtensions.cs
+++ b/src/Transports.AspNetCore.SystemTextJson/GraphQLBuilderExtensions.cs
@@ -2,6 +2,7 @@ using GraphQL.Server.Transports.AspNetCore.Common;
 using GraphQL.Server.Transports.AspNetCore.SystemTextJson;
 using GraphQL.SystemTextJson;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Text.Json;
 
@@ -28,11 +29,11 @@ namespace GraphQL.Server
             Action<JsonSerializerOptions> configureSerializerSettings = null)
         {
             builder.Services.AddSingleton<IGraphQLRequestDeserializer>(p => new GraphQLRequestDeserializer(configureDeserializerSettings));
-            builder.Services.AddSingleton<IDocumentWriter>(p => new DocumentWriter(opt =>
+            builder.Services.Replace(new ServiceDescriptor(typeof(IDocumentWriter), p => new DocumentWriter(opt =>
             {
                 opt.Converters.Add(new OperationMessageConverter());
                 configureSerializerSettings?.Invoke(opt);
-            }));
+            }), ServiceLifetime.Singleton));
 
             return builder;
         }

--- a/src/Transports.AspNetCore.SystemTextJson/GraphQLBuilderExtensions.cs
+++ b/src/Transports.AspNetCore.SystemTextJson/GraphQLBuilderExtensions.cs
@@ -29,11 +29,11 @@ namespace GraphQL.Server
             Action<JsonSerializerOptions> configureSerializerSettings = null)
         {
             builder.Services.AddSingleton<IGraphQLRequestDeserializer>(p => new GraphQLRequestDeserializer(configureDeserializerSettings));
-            builder.Services.Replace(new ServiceDescriptor(typeof(IDocumentWriter), p => new DocumentWriter(opt =>
+            builder.Services.Replace(ServiceDescriptor.Singleton<IDocumentWriter>(p => new DocumentWriter(opt =>
             {
                 opt.Converters.Add(new OperationMessageConverter());
                 configureSerializerSettings?.Invoke(opt);
-            }), ServiceLifetime.Singleton));
+            })));
 
             return builder;
         }

--- a/tests/Samples.Server.Tests/DITest.cs
+++ b/tests/Samples.Server.Tests/DITest.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using GraphQL;
+using GraphQL.Samples.Server;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Samples.Server.Tests
+{
+    public class DITest
+    {
+        [Fact]
+        public void Services_Should_Contain_Only_One_DocumentWriter()
+        {
+            var cfg = new ConfigurationBuilder().Build();
+#if NETCOREAPP2_2
+            var env = new Microsoft.AspNetCore.Hosting.Internal.HostingEnvironment();
+#else
+            
+            var env = (IWebHostEnvironment)Activator.CreateInstance(Type.GetType("Microsoft.AspNetCore.Hosting.HostingEnvironment, Microsoft.AspNetCore.Hosting"));
+#endif
+            var startup = new Startup(cfg, env);
+            var services = new ServiceCollection();
+            startup.ConfigureServices(services);
+            var provider = services.BuildServiceProvider();
+            var writers = provider.GetServices<IDocumentWriter>();
+            writers.Count().ShouldBe(1);
+        }
+    }
+}


### PR DESCRIPTION
Before this change I got error from
```c#
 throw new InvalidOperationException(
                    "IDocumentWriter not set in DI container. " +
                    "Add a IDocumentWriter implementation, for example " +
                    "GraphQL.SystemTextJson.DocumentWriter or GraphQL.NewtonsoftJson.DocumentWriter." +
                    "For more information, see: https://github.com/graphql-dotnet/graphql-dotnet/blob/master/README.md and https://github.com/graphql-dotnet/server/blob/develop/README.md.");
```
if I call GetService**S**.