### PR TITLE
Fix ArgumentNullException in AddNewtonsoftJson

### DIFF
--- a/src/Transports.AspNetCore.NewtonsoftJson/GraphQLBuilderExtensions.cs
+++ b/src/Transports.AspNetCore.NewtonsoftJson/GraphQLBuilderExtensions.cs
@@ -29,8 +29,8 @@ namespace GraphQL.Server
             Action<JsonSerializerSettings> configureDeserializerSettings = null,
             Action<JsonSerializerSettings> configureSerializerSettings = null)
         {
-            builder.Services.AddSingleton<IGraphQLRequestDeserializer>(p => new GraphQLRequestDeserializer(configureDeserializerSettings));
-            builder.Services.Replace(ServiceDescriptor.Singleton<IDocumentWriter>(p => new DocumentWriter(configureSerializerSettings, p.GetService<IErrorInfoProvider>() ?? new ErrorInfoProvider())));
+            builder.Services.AddSingleton<IGraphQLRequestDeserializer>(p => new GraphQLRequestDeserializer(configureDeserializerSettings ?? (_ => { })));
+            builder.Services.Replace(ServiceDescriptor.Singleton<IDocumentWriter>(p => new DocumentWriter(configureSerializerSettings ?? (_ => { }), p.GetService<IErrorInfoProvider>() ?? new ErrorInfoProvider())));
 
             return builder;
         }

--- a/src/Transports.AspNetCore.SystemTextJson/GraphQLBuilderExtensions.cs
+++ b/src/Transports.AspNetCore.SystemTextJson/GraphQLBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace GraphQL.Server
             Action<JsonSerializerOptions> configureDeserializerSettings = null,
             Action<JsonSerializerOptions> configureSerializerSettings = null)
         {
-            builder.Services.AddSingleton<IGraphQLRequestDeserializer>(p => new GraphQLRequestDeserializer(configureDeserializerSettings));
+            builder.Services.AddSingleton<IGraphQLRequestDeserializer>(p => new GraphQLRequestDeserializer(configureDeserializerSettings ?? (_ => { })));
             builder.Services.Replace(ServiceDescriptor.Singleton<IDocumentWriter>(p => new DocumentWriter(opt =>
             {
                 opt.Converters.Add(new OperationMessageConverter());


### PR DESCRIPTION
System.ArgumentNullException: 'Value cannot be null. '

```sh
GraphQL.NewtonsoftJson.dll!GraphQL.NewtonsoftJson.DocumentWriter.DocumentWriter(System.Action<Newtonsoft.Json.JsonSerializerSettings> configureSerializerSettings, GraphQL.Execution.IErrorInfoProvider errorInfoProvider)
GraphQL.Server.Transports.AspNetCore.NewtonsoftJson.dll!GraphQL.Server.GraphQLBuilderExtensions.AddNewtonsoftJson.AnonymousMethod__1(System.IServiceProvider p) 
```