### PR TITLE
Fix path and warning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,6 @@ jobs:
                 repo,
                 release_id: ${{ github.event.release.id }},
                 name: file,
-                data: await fs.readFile(`src/out/${file}`)
+                data: await fs.readFile(`out/${file}`)
               });
             }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,9 @@
 <Project>
 
   <PropertyGroup Label="Сommon properties">
-    <VersionPrefix>4.3.0-preview</VersionPrefix>
+    <VersionPrefix>4.3.1-preview</VersionPrefix>
     <LangVersion>latest</LangVersion>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Pekka Heikura</Copyright>
     <Authors>Pekka Heikura</Authors>
     <Product>graphql-dotnet server</Product>


### PR DESCRIPTION
```
warn : All published packages should have license information specified. Learn more: https://aka.ms/deprecateLicenseUrl.
```

+ one more fix for `src/out`