### PR TITLE
Correct launch urls in sample project

### DIFF
--- a/samples/Samples.Server/Properties/launchSettings.json
+++ b/samples/Samples.Server/Properties/launchSettings.json
@@ -7,7 +7,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:60341/"
+      "applicationUrl": "http://localhost:60341"
     },
     "GraphiQL": {
       "commandName": "Project",
@@ -16,7 +16,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:60341/"
+      "applicationUrl": "http://localhost:60341"
     },
     "Altair": {
       "commandName": "Project",
@@ -25,7 +25,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:60341/"
+      "applicationUrl": "http://localhost:60341"
     },
     "Voyager": {
       "commandName": "Project",
@@ -34,7 +34,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:60341/"
+      "applicationUrl": "http://localhost:60341"
     }
   }
 }


### PR DESCRIPTION
When I first tried launching the project (using Rider and .net 5 SDK), it started up `http://localhost:60341//ui/playground` in the browser which didn't work due to the double `/`.

This is fixed by removing the trailing slash from the `applicationUrl`.