### PR TITLE
Enable calling AuthorizeWith() on a Schema directly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Сommon properties">
-    <VersionPrefix>4.3.2-preview</VersionPrefix>
+    <VersionPrefix>4.4.0-preview</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Pekka Heikura</Copyright>
@@ -57,7 +57,7 @@
   <PropertyGroup Label="Package dependency versions">
     <CastleCoreVersion>4.4.1</CastleCoreVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
-    <GraphQLVersion>3.1.3</GraphQLVersion>
+    <GraphQLVersion>3.2.0</GraphQLVersion>
     <SerilogVersion>2.10.0</SerilogVersion>
     <SerilogAspNetCoreVersion>2.1.1</SerilogAspNetCoreVersion>
     <SerilogSinksConsoleVersion>3.1.1</SerilogSinksConsoleVersion>

--- a/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
+++ b/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
@@ -5,28 +5,85 @@ using System.Collections.Generic;
 namespace GraphQL.Server.Authorization.AspNetCore
 {
     /// <summary>
-    /// Extension methods for authorizing GraphQL requests.
+    /// Extension methods to configure authorization requirements for GraphQL elements: types, fields, schema.
     /// </summary>
     public static class AuthorizationMetadataExtensions
     {
+        /// <summary>
+        /// Metadata key name for storing authorization policy names. Value of this key
+        /// is a simple list of strings.
+        /// </summary>
         public const string POLICY_KEY = "Authorization__Policies";
 
-        public static bool RequiresAuthorization(this IProvideMetadata type)
+        /// <summary>
+        /// Gets a list of authorization policy names for the specified metadata provider.
+        /// </summary>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        /// <returns> List of authorization policy names applied to this metadata provider. </returns>
+        public static List<string> GetPolicies(this IProvideMetadata provider) => provider.GetMetadata<List<string>>(POLICY_KEY);
+
+        /// <summary>
+        /// Gets a boolean value that determines whether any authorization policy is applied to this metadata provider.
+        /// </summary>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        /// <returns> <c>true</c> if any authorization policy is applied, otherwise <c>false</c>. </returns>
+        public static bool RequiresAuthorization(this IProvideMetadata provider)
         {
-            var policies = GetPolicies(type);
+            var policies = GetPolicies(provider);
             return policies != null && policies.Count > 0;
         }
 
-        public static void AuthorizeWith(this IProvideMetadata type, string policy)
+        /// <summary>
+        /// Adds authorization policy to the specified metadata provider. If the provider already contains
+        /// a policy with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TMetadataProvider"> The type of metadata provider. Generics are used here to
+        /// let compiler infer the returning type to allow methods chaining.
+        /// </typeparam>
+        /// <param name="provider">
+        /// Metadata provider. This can be an instance of <see cref="GraphType"/>,
+        /// <see cref="FieldType"/>, <see cref="Schema"/> or others.
+        /// </param>
+        /// <param name="policy"> Authorization policy name. </param>
+        /// <returns> The reference to the specified <paramref name="provider"/>. </returns>
+        public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
+            where TMetadataProvider : IProvideMetadata
+        {
+            var list = GetPolicies(provider) ?? new List<string>();
+
+            if (!list.Contains(policy))
+                list.Add(policy);
+
+            provider.Metadata[POLICY_KEY] = list;
+            return provider;
+        }
+
+        [System.Obsolete("This method will be removed in v5. Use TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy) instead.")]
+        public static void AuthorizeWith(this IProvideMetadata type, string policy) // TODO: remove in v5
         {
             var list = GetPolicies(type) ?? new List<string>();
+
             if (!list.Contains(policy))
-            {
                 list.Add(policy);
-            }
+
             type.Metadata[POLICY_KEY] = list;
         }
 
+        /// <summary>
+        /// Adds authorization policy to the specified field builder. If the underlying field already contains
+        /// a policy with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TSourceType"></typeparam>
+        /// <typeparam name="TReturnType"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="policy"> Authorization policy name. </param>
+        /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
         public static FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(
             this FieldBuilder<TSourceType, TReturnType> builder, string policy)
         {
@@ -34,13 +91,19 @@ namespace GraphQL.Server.Authorization.AspNetCore
             return builder;
         }
 
+        /// <summary>
+        /// Adds authorization policy to the specified connection builder. If the underlying field already
+        /// contains a policy with the same name, then it will not be added twice.
+        /// </summary>
+        /// <typeparam name="TSourceType"></typeparam>
+        /// <param name="builder"></param>
+        /// <param name="policy"> Authorization policy name. </param>
+        /// <returns> The reference to the specified <paramref name="builder"/>. </returns>
         public static ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(
             this ConnectionBuilder<TSourceType> builder, string policy)
         {
             builder.FieldType.AuthorizeWith(policy);
             return builder;
         }
-
-        public static List<string> GetPolicies(this IProvideMetadata type) => type.GetMetadata<List<string>>(POLICY_KEY);
     }
 }

--- a/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
+++ b/src/Authorization.AspNetCore/AuthorizationMetadataExtensions.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 
 namespace GraphQL.Server.Authorization.AspNetCore
 {
+    /// <summary>
+    /// Extension methods for authorizing GraphQL requests.
+    /// </summary>
     public static class AuthorizationMetadataExtensions
     {
         public const string POLICY_KEY = "Authorization__Policies";

--- a/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
+++ b/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
@@ -159,7 +159,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
                     }
                     break;
 
-                case DenyAnonymousAuthorizationRequirement:
+                case DenyAnonymousAuthorizationRequirement _:
                     error.Append("The current user must be authenticated.");
                     break;
 
@@ -189,7 +189,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
                     }
                     break;
 
-                case AssertionRequirement:
+                case AssertionRequirement _:
                 default:
                     error.Append("Requirement '");
                     error.Append(authorizationRequirement.GetType().Name);

--- a/tests/ApiApprovalTests/GraphQL.Server.Authorization.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Authorization.AspNetCore.approved.txt
@@ -3,11 +3,15 @@ namespace GraphQL.Server.Authorization.AspNetCore
     public static class AuthorizationMetadataExtensions
     {
         public const string POLICY_KEY = "Authorization__Policies";
+        [System.Obsolete("This method will be removed in v5. Use TMetadataProvider AuthorizeWith<TMetadataP" +
+            "rovider>(this TMetadataProvider provider, string policy) instead.")]
         public static void AuthorizeWith(this GraphQL.Types.IProvideMetadata type, string policy) { }
         public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
+        public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
         public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
-        public static System.Collections.Generic.List<string> GetPolicies(this GraphQL.Types.IProvideMetadata type) { }
-        public static bool RequiresAuthorization(this GraphQL.Types.IProvideMetadata type) { }
+        public static System.Collections.Generic.List<string> GetPolicies(this GraphQL.Types.IProvideMetadata provider) { }
+        public static bool RequiresAuthorization(this GraphQL.Types.IProvideMetadata provider) { }
     }
     public class AuthorizationValidationRule : GraphQL.Validation.IValidationRule
     {

--- a/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
+++ b/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
@@ -1,155 +1,237 @@
+using System.Collections.Generic;
 using GraphQL.Types;
 using GraphQL.Types.Relay.DataObjects;
-using System.Collections.Generic;
+using Shouldly;
 using Xunit;
 
 namespace GraphQL.Server.Authorization.AspNetCore.Tests
 {
     public class AuthorizationValidationRuleTests : ValidationTestBase
     {
+        // https://github.com/graphql-dotnet/server/issues/463
+        [Fact]
+        public void policy_on_schema_success()
+        {
+            ConfigureAuthorizationOptions(options =>
+            {
+                options.AddPolicy("ClassPolicy", x => x.RequireClaim("admin"));
+                options.AddPolicy("SchemaPolicy", x => x.RequireClaim("some"));
+            });
+
+            ShouldPassRule(config =>
+            {
+                var schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
+                (schema as IProvideMetadata).AuthorizeWith("SchemaPolicy");
+
+                config.Query = @"query { post }";
+                config.Schema = schema;
+                config.User = CreatePrincipal(claims: new Dictionary<string, string>
+                {
+                    { "Admin", "true" },
+                    { "some", "abcdef" }
+                });
+            });
+        }
+
+        // https://github.com/graphql-dotnet/server/issues/463
+        [Fact]
+        public void policy_on_schema_fail()
+        {
+            ConfigureAuthorizationOptions(options =>
+            {
+                options.AddPolicy("ClassPolicy", x => x.RequireClaim("admin"));
+                options.AddPolicy("SchemaPolicy", x => x.RequireClaim("some"));
+            });
+
+            ShouldFailRule(config =>
+            {
+                var schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
+                (schema as IProvideMetadata).AuthorizeWith("SchemaPolicy");
+
+                config.Query = @"query { post }";
+                config.Schema = schema;
+                config.User = CreatePrincipal(claims: new Dictionary<string, string>
+                {
+                    { "Admin", "true" },
+                });
+                config.ValidateResult = result =>
+                {
+                    result.Errors.Count.ShouldBe(1);
+                    result.Errors[0].Message.ShouldBe(@"You are not authorized to run this operation.
+Required claim 'some' is not present.");
+                };
+            });
+        }
+
         [Fact]
         public void class_policy_success()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("ClassPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("ClassPolicy", x => x.RequireClaim("admin")));
 
-            ShouldPassRule(_ =>
+            ShouldPassRule(config =>
             {
-                _.Query = @"query { post }";
-                _.Schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
-                _.User = CreatePrincipal(claims: new Dictionary<string, string>
-                    {
-                        { "Admin", "true" }
-                    });
+                config.Query = @"query { post }";
+                config.Schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
+                config.User = CreatePrincipal(claims: new Dictionary<string, string>
+                {
+                    { "Admin", "true" }
+                });
             });
         }
 
         [Fact]
         public void class_policy_fail()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("ClassPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("ClassPolicy", x => x.RequireClaim("admin")));
 
-            ShouldFailRule(_ =>
+            ShouldFailRule(config =>
             {
-                _.Query = @"query { post }";
-                _.Schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
+                config.Query = @"query { post }";
+                config.Schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
+                config.ValidateResult = result =>
+                {
+                    result.Errors.Count.ShouldBe(1);
+                    result.Errors[0].Message.ShouldBe(@"You are not authorized to run this query.
+Required claim 'admin' is not present.");
+                };
             });
         }
 
         [Fact]
         public void field_policy_success()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin")));
 
-            ShouldPassRule(_ =>
+            ShouldPassRule(config =>
             {
-                _.Query = @"query { post }";
-                _.Schema = BasicSchema<BasicQueryWithAttributesAndFieldPolicy>();
-                _.User = CreatePrincipal(claims: new Dictionary<string, string>
-                    {
-                        { "Admin", "true" }
-                    });
+                config.Query = @"query { post }";
+                config.Schema = BasicSchema<BasicQueryWithAttributesAndFieldPolicy>();
+                config.User = CreatePrincipal(claims: new Dictionary<string, string>
+                {
+                    { "Admin", "true" }
+                });
             });
         }
 
         [Fact]
         public void field_policy_fail()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin")));
 
-            ShouldFailRule(_ =>
+            ShouldFailRule(config =>
             {
-                _.Query = @"query { post }";
-                _.Schema = BasicSchema<BasicQueryWithAttributesAndFieldPolicy>();
+                config.Query = @"query { post }";
+                config.Schema = BasicSchema<BasicQueryWithAttributesAndFieldPolicy>();
+                config.ValidateResult = result =>
+                {
+                    result.Errors.Count.ShouldBe(1);
+                    result.Errors[0].Message.ShouldBe(@"You are not authorized to run this query.
+Required claim 'admin' is not present.");
+                };
             });
         }
 
         [Fact]
         public void nested_type_policy_success()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("PostPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("PostPolicy", x => x.RequireClaim("admin")));
 
-            ShouldPassRule(_ =>
+            ShouldPassRule(config =>
             {
-                _.Query = @"query { post }";
-                _.Schema = NestedSchema();
-                _.User = CreatePrincipal(claims: new Dictionary<string, string>
-                    {
-                        { "Admin", "true" }
-                    });
+                config.Query = @"query { post }";
+                config.Schema = NestedSchema();
+                config.User = CreatePrincipal(claims: new Dictionary<string, string>
+                {
+                    { "Admin", "true" }
+                });
             });
         }
 
         [Fact]
         public void nested_type_policy_fail()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("PostPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("PostPolicy", x => x.RequireClaim("admin")));
 
-            ShouldFailRule(_ =>
+            ShouldFailRule(config =>
             {
-                _.Query = @"query { post }";
-                _.Schema = NestedSchema();
+                config.Query = @"query { post }";
+                config.Schema = NestedSchema();
+                config.ValidateResult = result =>
+                {
+                    result.Errors.Count.ShouldBe(1);
+                    result.Errors[0].Message.ShouldBe(@"You are not authorized to run this query.
+Required claim 'admin' is not present.");
+                };
             });
         }
 
         [Fact]
         public void passes_with_claim_on_input_type()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin")));
 
-            ShouldPassRule(_ =>
+            ShouldPassRule(config =>
             {
-                _.Query = @"query { author(input: { name: ""Quinn"" }) }";
-                _.Schema = TypedSchema();
-                _.User = CreatePrincipal(claims: new Dictionary<string, string>
-                    {
-                        { "Admin", "true" }
-                    });
+                config.Query = @"query { author(input: { name: ""Quinn"" }) }";
+                config.Schema = TypedSchema();
+                config.User = CreatePrincipal(claims: new Dictionary<string, string>
+                {
+                    { "Admin", "true" }
+                });
             });
         }
 
         [Fact]
         public void nested_type_list_policy_fail()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("PostPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("PostPolicy", x => x.RequireClaim("admin")));
 
-            ShouldFailRule(_ =>
+            ShouldFailRule(config =>
             {
-                _.Query = @"query { posts }";
-                _.Schema = NestedSchema();
+                config.Query = @"query { posts }";
+                config.Schema = NestedSchema();
+                config.ValidateResult = result =>
+                {
+                    result.Errors.Count.ShouldBe(1);
+                    result.Errors[0].Message.ShouldBe(@"You are not authorized to run this query.
+Required claim 'admin' is not present.");
+                };
             });
         }
 
         [Fact]
         public void nested_type_list_non_null_policy_fail()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("PostPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("PostPolicy", x => x.RequireClaim("admin")));
 
-            ShouldFailRule(_ =>
+            ShouldFailRule(config =>
             {
-                _.Query = @"query { postsNonNull }";
-                _.Schema = NestedSchema();
+                config.Query = @"query { postsNonNull }";
+                config.Schema = NestedSchema();
+                config.ValidateResult = result =>
+                {
+                    result.Errors.Count.ShouldBe(1);
+                    result.Errors[0].Message.ShouldBe(@"You are not authorized to run this query.
+Required claim 'admin' is not present.");
+                };
             });
         }
 
         [Fact]
         public void fails_on_missing_claim_on_input_type()
         {
-            ConfigureAuthorizationOptions(
-                options => options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin")));
+            ConfigureAuthorizationOptions(options => options.AddPolicy("FieldPolicy", x => x.RequireClaim("admin")));
 
-            ShouldFailRule(_ =>
+            ShouldFailRule(config =>
             {
-                _.Query = @"query { author(input: { name: ""Quinn"" }) }";
-                _.Schema = TypedSchema();
+                config.Query = @"query { author(input: { name: ""Quinn"" }) }";
+                config.Schema = TypedSchema();
+                config.ValidateResult = result =>
+                {
+                    result.Errors.Count.ShouldBe(1);
+                    result.Errors[0].Message.ShouldBe(@"You are not authorized to run this query.
+Required claim 'admin' is not present.");
+                };
             });
         }
 
@@ -158,11 +240,11 @@ namespace GraphQL.Server.Authorization.AspNetCore.Tests
         {
             ConfigureAuthorizationOptions(options => options.AddPolicy("ConnectionPolicy", x => x.RequireClaim("admin")));
 
-            ShouldPassRule(_ =>
+            ShouldPassRule(config =>
             {
-                _.Query = @"query { posts { items { id } } }";
-                _.Schema = TypedSchema();
-                _.User = CreatePrincipal(claims: new Dictionary<string, string>
+                config.Query = @"query { posts { items { id } } }";
+                config.Schema = TypedSchema();
+                config.User = CreatePrincipal(claims: new Dictionary<string, string>
                 {
                     { "Admin", "true" }
                 });
@@ -174,11 +256,17 @@ namespace GraphQL.Server.Authorization.AspNetCore.Tests
         {
             ConfigureAuthorizationOptions(options => options.AddPolicy("ConnectionPolicy", x => x.RequireClaim("admin")));
 
-            ShouldFailRule(_ =>
+            ShouldFailRule(config =>
             {
-                _.Query = @"query { posts { items { id } } }";
-                _.Schema = TypedSchema();
-                _.User = CreatePrincipal();
+                config.Query = @"query { posts { items { id } } }";
+                config.Schema = TypedSchema();
+                config.User = CreatePrincipal();
+                config.ValidateResult = result =>
+                {
+                    result.Errors.Count.ShouldBe(1);
+                    result.Errors[0].Message.ShouldBe(@"You are not authorized to run this query.
+Required claim 'admin' is not present.");
+                };
             });
         }
 

--- a/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
+++ b/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
@@ -20,11 +20,8 @@ namespace GraphQL.Server.Authorization.AspNetCore.Tests
 
             ShouldPassRule(config =>
             {
-                var schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
-                (schema as IProvideMetadata).AuthorizeWith("SchemaPolicy");
-
                 config.Query = @"query { post }";
-                config.Schema = schema;
+                config.Schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>().AuthorizeWith("SchemaPolicy");
                 config.User = CreatePrincipal(claims: new Dictionary<string, string>
                 {
                     { "Admin", "true" },
@@ -45,11 +42,8 @@ namespace GraphQL.Server.Authorization.AspNetCore.Tests
 
             ShouldFailRule(config =>
             {
-                var schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>();
-                (schema as IProvideMetadata).AuthorizeWith("SchemaPolicy");
-
                 config.Query = @"query { post }";
-                config.Schema = schema;
+                config.Schema = BasicSchema<BasicQueryWithAttributesAndClassPolicy>().AuthorizeWith("SchemaPolicy");
                 config.User = CreatePrincipal(claims: new Dictionary<string, string>
                 {
                     { "Admin", "true" },

--- a/tests/Authorization.AspNetCore.Tests/ValidationTestConfig.cs
+++ b/tests/Authorization.AspNetCore.Tests/ValidationTestConfig.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using GraphQL.Types;
+using GraphQL.Validation;
+
+namespace GraphQL.Server.Authorization.AspNetCore.Tests
+{
+    public class ValidationTestConfig
+    {
+        public string Query { get; set; }
+
+        public ISchema Schema { get; set; }
+
+        public List<IValidationRule> Rules { get; set; } = new List<IValidationRule>();
+
+        public ClaimsPrincipal User { get; set; }
+
+        public Inputs Inputs { get; set; }
+
+        public Action<IValidationResult> ValidateResult = _ => { };
+    }
+}


### PR DESCRIPTION
fixes #463 

Also
- fixes `Append`/`AppendLine` error message formatting
- less allocations for strings and arrays
- adds more correct and detailed tests