### PR TITLE
Bump GraphQLVersion from 3.2.0 to 3.3.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,7 +58,7 @@
   <PropertyGroup Label="Package dependency versions">
     <CastleCoreVersion>4.4.1</CastleCoreVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
-    <GraphQLVersion>3.2.0</GraphQLVersion>
+    <GraphQLVersion>3.3.2</GraphQLVersion>
     <SerilogVersion>2.10.0</SerilogVersion>
     <SerilogAspNetCoreVersion>2.1.1</SerilogAspNetCoreVersion>
     <SerilogSinksConsoleVersion>3.1.1</SerilogSinksConsoleVersion>


### PR DESCRIPTION
Bumps `GraphQLVersion` from 3.2.0 to 3.3.2.

Updates `GraphQL.NewtonsoftJson` from 3.2.0 to 3.3.2
- [Release notes](https://github.com/graphql-dotnet/graphql-dotnet/releases)
- [Commits](https://github.com/graphql-dotnet/graphql-dotnet/compare/3.2.0...3.3.2)

Updates `GraphQL` from 3.2.0 to 3.3.2
- [Release notes](https://github.com/graphql-dotnet/graphql-dotnet/releases)
- [Commits](https://github.com/graphql-dotnet/graphql-dotnet/compare/3.2.0...3.3.2)

Updates `GraphQL.SystemTextJson` from 3.2.0 to 3.3.2
- [Release notes](https://github.com/graphql-dotnet/graphql-dotnet/releases)
- [Commits](https://github.com/graphql-dotnet/graphql-dotnet/compare/3.2.0...3.3.2)

Signed-off-by: dependabot[bot] <support@github.com>