### PR TITLE
Authorization.AspNetCore split proposal

### DIFF
--- a/GraphQL.Server.sln
+++ b/GraphQL.Server.sln
@@ -77,6 +77,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiApprovalTests", "tests\A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "All", "src\All\All.csproj", "{B39BC064-B96A-442D-89A0-79B750F88ADD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Authorization", "src\Authorization\Authorization.csproj", "{152E46DC-7225-4676-8942-14E2D51819B6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -163,6 +165,10 @@ Global
 		{B39BC064-B96A-442D-89A0-79B750F88ADD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B39BC064-B96A-442D-89A0-79B750F88ADD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B39BC064-B96A-442D-89A0-79B750F88ADD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{152E46DC-7225-4676-8942-14E2D51819B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{152E46DC-7225-4676-8942-14E2D51819B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{152E46DC-7225-4676-8942-14E2D51819B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{152E46DC-7225-4676-8942-14E2D51819B6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Authorization/Authorization.csproj
+++ b/src/Authorization/Authorization.csproj
@@ -2,13 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Description>Integration of GraphQL.NET validation subsystem into ASP.NET Core</Description>
+    <Description>Integration of GraphQL.NET validation subsystem</Description>
     <PackageTags>GraphQL;authentication;authorization;validation</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <ProjectReference Include="..\Authorization\Authorization.csproj" />
+    <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Authorization/AuthorizationMetadataExtensions.cs
+++ b/src/Authorization/AuthorizationMetadataExtensions.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using GraphQL.Builders;
 using GraphQL.Types;
 
-namespace GraphQL.Server.Authorization.AspNetCore
+namespace GraphQL.Server.Authorization
 {
     /// <summary>
     /// Extension methods to configure authorization requirements for GraphQL elements: types, fields, schema.

--- a/src/Authorization/AuthorizationMetadataExtensions.cs
+++ b/src/Authorization/AuthorizationMetadataExtensions.cs
@@ -9,6 +9,7 @@ namespace GraphQL.Server.Authorization
     /// </summary>
     public static class AuthorizationMetadataExtensions
     {
+
         /// <summary>
         /// Metadata key name for storing authorization policy names. Value of this key
         /// is a simple list of strings.
@@ -105,5 +106,6 @@ namespace GraphQL.Server.Authorization
             builder.FieldType.AuthorizeWith(policy);
             return builder;
         }
+
     }
 }

--- a/src/Authorization/GraphQLAuthorizeAttribute.cs
+++ b/src/Authorization/GraphQLAuthorizeAttribute.cs
@@ -1,6 +1,6 @@
 using GraphQL.Utilities;
 
-namespace GraphQL.Server.Authorization.AspNetCore
+namespace GraphQL.Server.Authorization
 {
     public class GraphQLAuthorizeAttribute : GraphQLAttribute
     {

--- a/tests/ApiApprovalTests/GraphQL.Server.Authorization.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Authorization.AspNetCore.approved.txt
@@ -9,19 +9,6 @@ namespace GraphQL.Server.Authorization.AspNetCore
         public static void AppendFailureHeader(System.Text.StringBuilder error, GraphQL.Language.AST.OperationType? operationType) { }
         public static void AppendFailureLine(System.Text.StringBuilder error, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement authorizationRequirement) { }
     }
-    public static class AuthorizationMetadataExtensions
-    {
-        public const string POLICY_KEY = "Authorization__Policies";
-        [System.Obsolete("This method will be removed in v5. Use TMetadataProvider AuthorizeWith<TMetadataP" +
-            "rovider>(this TMetadataProvider provider, string policy) instead.")]
-        public static void AuthorizeWith(this GraphQL.Types.IProvideMetadata type, string policy) { }
-        public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
-        public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
-            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
-        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
-        public static System.Collections.Generic.List<string> GetPolicies(this GraphQL.Types.IProvideMetadata provider) { }
-        public static bool RequiresAuthorization(this GraphQL.Types.IProvideMetadata provider) { }
-    }
     public class AuthorizationValidationRule : GraphQL.Validation.IValidationRule
     {
         public AuthorizationValidationRule(Microsoft.AspNetCore.Authorization.IAuthorizationService authorizationService, GraphQL.Server.Authorization.AspNetCore.IClaimsPrincipalAccessor claimsPrincipalAccessor) { }
@@ -32,13 +19,6 @@ namespace GraphQL.Server.Authorization.AspNetCore
     {
         public DefaultClaimsPrincipalAccessor(Microsoft.AspNetCore.Http.IHttpContextAccessor contextAccessor) { }
         public System.Security.Claims.ClaimsPrincipal GetClaimsPrincipal(GraphQL.Validation.ValidationContext context) { }
-    }
-    public class GraphQLAuthorizeAttribute : GraphQL.GraphQLAttribute
-    {
-        public GraphQLAuthorizeAttribute() { }
-        public string Policy { get; set; }
-        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
-        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
     }
     public interface IClaimsPrincipalAccessor
     {

--- a/tests/ApiApprovalTests/GraphQL.Server.Authorization.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Authorization.approved.txt
@@ -1,0 +1,23 @@
+namespace GraphQL.Server.Authorization
+{    
+    public static class AuthorizationMetadataExtensions
+    {
+        public const string POLICY_KEY = "Authorization__Policies";
+        [System.Obsolete("This method will be removed in v5. Use TMetadataProvider AuthorizeWith<TMetadataP" +
+            "rovider>(this TMetadataProvider provider, string policy) instead.")]
+        public static void AuthorizeWith(this GraphQL.Types.IProvideMetadata type, string policy) { }
+        public static GraphQL.Builders.ConnectionBuilder<TSourceType> AuthorizeWith<TSourceType>(this GraphQL.Builders.ConnectionBuilder<TSourceType> builder, string policy) { }
+        public static TMetadataProvider AuthorizeWith<TMetadataProvider>(this TMetadataProvider provider, string policy)
+            where TMetadataProvider : GraphQL.Types.IProvideMetadata { }
+        public static GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> AuthorizeWith<TSourceType, TReturnType>(this GraphQL.Builders.FieldBuilder<TSourceType, TReturnType> builder, string policy) { }
+        public static System.Collections.Generic.List<string> GetPolicies(this GraphQL.Types.IProvideMetadata provider) { }
+        public static bool RequiresAuthorization(this GraphQL.Types.IProvideMetadata provider) { }
+    }   
+    public class GraphQLAuthorizeAttribute : GraphQL.GraphQLAttribute
+    {
+        public GraphQLAuthorizeAttribute() { }
+        public string Policy { get; set; }
+        public override void Modify(GraphQL.Utilities.FieldConfig field) { }
+        public override void Modify(GraphQL.Utilities.TypeConfig type) { }
+    }
+}


### PR DESCRIPTION
Hi all,

First, thank you all for reviweing and having a look to this PR, let me expose briefly the idea behind this proposal:

**Basically, in those projects, where GraphQL objects/queries are in a different layer of the Web API, as it could happen in a n-Layered structure, unnecessary AspNetCore dependencies are carried in the case of implementing security.

This proposal is intended to avoid carrying those dependencies in layers that don't require it, when in reality, the only dependency that are strictly required comes from the Core in that case.**

I understand that this PR, if it is accepted according to your most expert criteria, still has pending points to implement, probably  tests or documentation...

If you agree with the idea, I will be happy to add what you may consider neccesary

Thank you all, have a nice day!