### PR TITLE
Fix: WebSocket in the "Aborted" state cannot be closed.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>5.0.2</VersionPrefix>
+    <VersionPrefix>5.0.2-preview</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>5.0.1-preview</VersionPrefix>
+    <VersionPrefix>5.0.2</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
@@ -42,7 +42,9 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public async Task Complete(WebSocketCloseStatus closeStatus, string statusDescription)
         {
-            if (_socket.State != WebSocketState.Closed && _socket.State != WebSocketState.CloseSent)
+            if (_socket.State != WebSocketState.Closed &&
+                _socket.State != WebSocketState.CloseSent &&
+                _socket.State != WebSocketState.Aborted)
                 try
                 {
                     if (closeStatus == WebSocketCloseStatus.NormalClosure)


### PR DESCRIPTION
WebSocket connection which are aborted for some reason - client drop, ou load balancer drop - the call to GraphQL.Server.Transports.WebSockets.WebSocketReaderPipeline.Complete will throw an Exception:
"System.Net.WebSockets.WebSocketException (%d): The WebSocket is in an invalid state ('Aborted') for this operation. Valid states are: 'Open, CloseReceived, CloseSent'"

Aborted connection therefore should not be "closed", as it is already closed.