### PR TITLE
Fixed null exception when getting argument info

### DIFF
--- a/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
+++ b/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
@@ -50,7 +50,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
                 }),
                 new MatchingNodeVisitor<ObjectField>((objectFieldAst, context) =>
                 {
-                    if (context.TypeInfo.GetArgument().ResolvedType.GetNamedType() is IComplexGraphType argumentType)
+                    if (context.TypeInfo.GetArgument()?.ResolvedType.GetNamedType() is IComplexGraphType argumentType)
                     {
                         var fieldType = argumentType.GetField(objectFieldAst.Name);
                         AuthorizeAsync(objectFieldAst, fieldType, context, operationType).GetAwaiter().GetResult(); // TODO: need to think of something to avoid this


### PR DESCRIPTION
Updated AuthorizationValidationRule.cs to check for nulls after calling GetArgument as it can sometimes return null if the request schema is invalid