### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For more information on how to migrate from `Newtonsoft.Json` to `System.Text.Js
 For the WebSocket subscription protocol (depends on above) middleware:
 
 ```
-> dotnet add package GraphQL.Server.Transports.WebSockets
+> dotnet add package GraphQL.Server.Transports.Subscriptions.WebSockets
 ```
 
 #### 3. Authorization


### PR DESCRIPTION
Replaced GraphQL.Server.Transports.WebSockets with GraphQL.Server.Transports.Subscriptions.WebSockets in the install instructions to match the new Nuget package.