### PR TITLE
Upgrade GraphiQL to 1.5.1

### DIFF
--- a/samples/Samples.Schemas.Chat/IChat.cs
+++ b/samples/Samples.Schemas.Chat/IChat.cs
@@ -44,7 +44,7 @@ namespace GraphQL.Samples.Schemas.Chat
             return AddMessage(new Message
             {
                 Content = message.Content,
-                SentAt = message.SentAt,
+                SentAt = message.SentAt ?? DateTime.UtcNow,
                 From = new MessageFrom
                 {
                     DisplayName = displayName,

--- a/samples/Samples.Schemas.Chat/Message.cs
+++ b/samples/Samples.Schemas.Chat/Message.cs
@@ -10,6 +10,6 @@ namespace GraphQL.Samples.Schemas.Chat
 
         public string Content { get; set; }
 
-        public DateTime SentAt { get; set; }
+        public DateTime? SentAt { get; set; }
     }
 }

--- a/samples/Samples.Schemas.Chat/MessageType.cs
+++ b/samples/Samples.Schemas.Chat/MessageType.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Samples.Schemas.Chat
         public MessageType()
         {
             Field(o => o.Content);
-            Field(o => o.SentAt, type: typeof(DateGraphType));
+            Field(o => o.SentAt, type: typeof(DateTimeGraphType));
             Field(o => o.Sub);
             Field(o => o.From, false, typeof(MessageFromType)).Resolve(ResolveFrom);
         }

--- a/samples/Samples.Schemas.Chat/ReceivedMessage.cs
+++ b/samples/Samples.Schemas.Chat/ReceivedMessage.cs
@@ -8,6 +8,6 @@ namespace GraphQL.Samples.Schemas.Chat
 
         public string Content { get; set; }
 
-        public DateTime SentAt { get; set; }
+        public DateTime? SentAt { get; set; }
     }
 }

--- a/samples/Samples.Server/Samples.Server.csproj
+++ b/samples/Samples.Server/Samples.Server.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GraphQL.SystemReactive" Version="4.6.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="GraphQL.MicrosoftDI" Version="4.6.1" />

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -7,6 +7,7 @@ using GraphQL.Server.Ui.Altair;
 using GraphQL.Server.Ui.GraphiQL;
 using GraphQL.Server.Ui.Playground;
 using GraphQL.Server.Ui.Voyager;
+using GraphQL.SystemReactive;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -34,6 +35,7 @@ namespace GraphQL.Samples.Server
             services.AddSingleton<IChat, Chat>();
 
             MicrosoftDI.GraphQLBuilderExtensions.AddGraphQL(services)
+                .AddSubscriptionDocumentExecuter()
                 .AddServer(true)
                 .AddSchema<ChatSchema>()
                 .ConfigureExecution(options =>

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -43,6 +43,9 @@ namespace GraphQL.Samples.Server
                 .AddWebSockets()
                 .AddDataLoader()
                 .AddGraphTypes(typeof(ChatSchema));
+
+            services
+                .AddSingleton<IDocumentExecuter, SubscriptionDocumentExecuter>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -43,9 +43,6 @@ namespace GraphQL.Samples.Server
                 .AddWebSockets()
                 .AddDataLoader()
                 .AddGraphTypes(typeof(ChatSchema));
-
-            services
-                .AddSingleton<IDocumentExecuter, SubscriptionDocumentExecuter>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/samples/Samples.Server/StartupWithRouting.cs
+++ b/samples/Samples.Server/StartupWithRouting.cs
@@ -7,6 +7,7 @@ using GraphQL.Server.Ui.Altair;
 using GraphQL.Server.Ui.GraphiQL;
 using GraphQL.Server.Ui.Playground;
 using GraphQL.Server.Ui.Voyager;
+using GraphQL.SystemReactive;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -35,6 +36,7 @@ namespace GraphQL.Samples.Server
             services.AddSingleton<IChat, Chat>();
 
             MicrosoftDI.GraphQLBuilderExtensions.AddGraphQL(services)
+                .AddSubscriptionDocumentExecuter()
                 .AddServer(true)
                 .AddSchema<ChatSchema>()
                 .ConfigureExecution(options =>

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -40,6 +40,9 @@ namespace GraphQL.Server.Ui.GraphiQL
         /// Enables the header editor when <c>true</c>.
         /// Not supported when <see cref="ExplorerExtensionEnabled"/> is <see langword="true"/>.
         /// </summary>
+        /// <remarks>
+        /// Original setting from <see href="https://github.com/graphql/graphiql/blob/08250feb6ee8335c3b1ca83a912911ae92a75722/packages/graphiql/src/components/GraphiQL.tsx#L186">GraphiQL</see>.
+        /// </remarks>
         public bool HeaderEditorEnabled { get; set; } = true;
 
         /// <summary>

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -43,7 +43,7 @@ namespace GraphQL.Server.Ui.GraphiQL
         public bool HeaderEditorEnabled { get; set; } = true;
 
         /// <summary>
-        /// Enables the explorer extension when <c>true</c>.
+        /// Enables the explorer extension when <see langword="true"/>.
         /// </summary>
         public bool ExplorerExtensionEnabled { get; set; } = true;
     }

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -38,7 +38,7 @@ namespace GraphQL.Server.Ui.GraphiQL
 
         /// <summary>
         /// Enables the header editor when <c>true</c>.
-        /// Not supported when ExplorerExtensionEnabled is <c>true</c>.
+        /// Not supported when <see cref="ExplorerExtensionEnabled"/> is <see langword="true"/>.
         /// </summary>
         public bool HeaderEditorEnabled { get; set; } = true;
 

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -22,5 +22,16 @@ namespace GraphQL.Server.Ui.GraphiQL
         /// HTTP headers with which the GraphiQL will be initialized.
         /// </summary>
         public Dictionary<string, string> Headers { get; set; }
+
+        /// <summary>
+        /// Enables the header editor when <c>true</c>.
+        /// Not supported when ExplorerExtensionEnabled is <c>true</c>.
+        /// </summary>
+        public bool HeaderEditorEnabled { get; set; } = true;
+
+        /// <summary>
+        /// Enables the explorer extension when <c>true</c>.
+        /// </summary>
+        public bool ExplorerExtensionEnabled { get; set; } = true;
     }
 }

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -37,7 +37,7 @@ namespace GraphQL.Server.Ui.GraphiQL
         public Func<GraphiQLOptions, string, string> PostConfigure { get; set; } = (options, result) => result;
 
         /// <summary>
-        /// Enables the header editor when <c>true</c>.
+        /// Enables the header editor when <see langword="true"/>.
         /// Not supported when <see cref="ExplorerExtensionEnabled"/> is <see langword="true"/>.
         /// </summary>
         /// <remarks>

--- a/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
+++ b/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
@@ -39,7 +39,9 @@ namespace GraphQL.Server.Ui.GraphiQL.Internal
                 var builder = new StringBuilder(streamReader.ReadToEnd())
                     .Replace("@Model.GraphQLEndPoint", _options.GraphQLEndPoint)
                     .Replace("@Model.SubscriptionsEndPoint", _options.SubscriptionsEndPoint)
-                    .Replace("@Model.Headers", JsonSerializer.Serialize<object>(headers));
+                    .Replace("@Model.Headers", JsonSerializer.Serialize<object>(headers))
+                    .Replace("@Model.HeaderEditorEnabled", _options.HeaderEditorEnabled ? "true" : "false")
+                    .Replace("@Model.GraphiQLElement", _options.ExplorerExtensionEnabled ? "GraphiQLWithExtensions.GraphiQLWithExtensions" : "GraphiQL");
 
                 _graphiQLCSHtml = builder.ToString();
             }

--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -68,7 +68,6 @@
   <div id="graphiql">Loading...</div>
   <script
     src="https://unpkg.com/graphiql@1.5.1/graphiql.min.js"
-    type="application/javascript"
   ></script>
   <script>
 

--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -1,5 +1,5 @@
 <!--
- *  Copyright (c) Facebook, Inc.
+ *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.
  *
  *  This source code is licensed under the license found in the
@@ -8,148 +8,175 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta charset="UTF-8">
-	<style>
-		body {
-			height: 100%;
-			margin: 0;
-			width: 100%;
-			overflow: hidden;
-		}
+  <meta charset="UTF-8">
+  <style>
+    body {
+      height: 100%;
+      margin: 0;
+      width: 100%;
+      overflow: hidden;
+    }
 
-		#graphiql {
-			height: 100vh;
-		}
-	</style>
+    #graphiql {
+      height: 100vh;
+    }
+  </style>
 
-	<!--
-	  This GraphiQL example depends on Promise and fetch, which are available in
-	  modern browsers, but can be "polyfilled" for older browsers.
-	  GraphiQL itself depends on React DOM.
-	  If you do not want to rely on a CDN, you can host these files locally or
-	  include them directly in your favored resource bunder.
-	-->
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.production.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.production.min.js"></script>
+  <!--
+    This GraphiQL example depends on Promise and fetch, which are available in
+    modern browsers, but can be "polyfilled" for older browsers.
+    GraphiQL itself depends on React DOM.
+    If you do not want to rely on a CDN, you can host these files locally or
+    include them directly in your favored resource bunder.
+  -->
+  <script
+    src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.3/fetch.min.js"
+    integrity="sha384-dcF7KoWRaRpjcNbVPUFgatYgAijf8DqW6NWuqLdfB5Sb4Cdbb8iHX7bHsl9YhpKa"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    src="https://unpkg.com/react@16.14.0/umd/react.production.min.js"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    src="https://unpkg.com/react-dom@16.14.0/umd/react-dom.production.min.js"
+    crossorigin="anonymous"
+  ></script>
 
-	<!--
-	  These two files can be found in the npm module, however you may wish to
-	  copy them directly into your environment, or perhaps include them in your
-	  favored resource bundler.
-	 -->
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/1.0.6/graphiql.min.css" />
-	<script src="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"></script>
-
-	<script src="https://unpkg.com/subscriptions-transport-ws@0.9.18/browser/client.js"></script>
-	<script src="https://unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
+  <!--
+    These two files can be found in the npm module, however you may wish to
+    copy them directly into your environment, or perhaps include them in your
+    favored resource bundler.
+   -->
+  <link rel="stylesheet" href="https://unpkg.com/graphiql@1.5.1/graphiql.min.css" />
+  <script
+    src="https://unpkg.com/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"
+    integrity="sha384-TqI6gT2PjmSrnEOTvGHLad1U4Vm5VoyzMmcKK0C/PLCWTnwPyXhCJY6NYhC/tp19"
+    crossorigin="anonymous"
+  ></script>
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.css"
+    integrity="sha384-GBqwox+q8UtVEyBLBKloN5QDlBDsQnuoSUfMeJH1ZtDiCrrk103D7Bg/WjIvl4ya"
+    crossorigin="anonymous"
+  />
+  <script src="https://unpkg.com/subscriptions-transport-ws@0.8.2/browser/client.js"></script>
+  <script src="https://unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
 
 </head>
 <body>
-	<div id="graphiql">Loading...</div>
-	<script>
+  <div id="graphiql">Loading...</div>
+  <script
+    src="https://unpkg.com/graphiql@1.5.1/graphiql.min.js"
+    type="application/javascript"
+  ></script>
+  <script>
 
-		/**
-		 * This GraphiQL example illustrates how to use some of GraphiQL's props
-		 * in order to enable reading and updating the URL parameters, making
-		 * link sharing of queries a little bit easier.
-		 *
-		 * This is only one example of this kind of feature, GraphiQL exposes
-		 * various React params to enable interesting integrations.
-		 */
+    /**
+     * This GraphiQL example illustrates how to use some of GraphiQL's props
+     * in order to enable reading and updating the URL parameters, making
+     * link sharing of queries a little bit easier.
+     *
+     * This is only one example of this kind of feature, GraphiQL exposes
+     * various React params to enable interesting integrations.
+     */
 
-		// Parse the search string to get url parameters.
-		var search = window.location.search;
-		var parameters = {};
-		search.substr(1).split('&').forEach(function (entry) {
-			var eq = entry.indexOf('=');
-			if (eq >= 0) {
-				parameters[decodeURIComponent(entry.slice(0, eq))] =
-					decodeURIComponent(entry.slice(eq + 1));
-			}
-		});
+    // Parse the search string to get url parameters.
+    var search = window.location.search;
+    var parameters = {};
+    search.substr(1).split('&').forEach(function (entry) {
+      var eq = entry.indexOf('=');
+      if (eq >= 0) {
+        parameters[decodeURIComponent(entry.slice(0, eq))] =
+          decodeURIComponent(entry.slice(eq + 1));
+      }
+    });
 
-		// if variables was provided, try to format it.
-		if (parameters.variables) {
-			try {
-				parameters.variables =
-					JSON.stringify(JSON.parse(parameters.variables), null, 2);
-			} catch (e) {
-				// Do nothing, we want to display the invalid JSON as a string, rather
-				// than present an error.
-			}
-		}
+    // if variables was provided, try to format it.
+    if (parameters.variables) {
+      try {
+        parameters.variables =
+          JSON.stringify(JSON.parse(parameters.variables), null, 2);
+      } catch (e) {
+        // Do nothing, we want to display the invalid JSON as a string, rather
+        // than present an error.
+      }
+    }
 
-		// When the query and variables string is edited, update the URL bar so
-		// that it can be easily shared
-		function onEditQuery(newQuery) {
-			parameters.query = newQuery;
-			updateURL();
-		}
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
 
-		function onEditVariables(newVariables) {
-			parameters.variables = newVariables;
-			updateURL();
-		}
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
 
-		function onEditOperationName(newOperationName) {
-			parameters.operationName = newOperationName;
-			updateURL();
-		}
+    function onEditOperationName(newOperationName) {
+      parameters.operationName = newOperationName;
+      updateURL();
+    }
 
-		function updateURL() {
-			var newSearch = '?' + Object.keys(parameters).filter(function (key) {
-				return Boolean(parameters[key]);
-			}).map(function (key) {
-				return encodeURIComponent(key) + '=' +
-					encodeURIComponent(parameters[key]);
-			}).join('&');
-			history.replaceState(null, null, newSearch);
-		}
+    function updateURL() {
+      var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+        return Boolean(parameters[key]);
+      }).map(function (key) {
+        return encodeURIComponent(key) + '=' +
+          encodeURIComponent(parameters[key]);
+      }).join('&');
+      history.replaceState(null, null, newSearch);
+    }
 
-		// Defines a GraphQL fetcher using the fetch API. You're not required to
-		// use fetch, and could instead implement graphQLFetcher however you like,
-		// as long as it returns a Promise or Observable.
-		function graphQLFetcher(graphQLParams) {
-			// This example expects a GraphQL server at the path /graphql.
-			// Change this to point wherever you host your GraphQL server.
-			return fetch(window.location.protocol + "//" + window.location.host + '@Model.GraphQLEndPoint', {
-				method: 'post',
-				headers: @Model.Headers,
-				body: JSON.stringify(graphQLParams),
-				credentials: 'include',
-			}).then(function (response) {
-				return response.text();
-			}).then(function (responseBody) {
-				try {
-					return JSON.parse(responseBody);
-				} catch (error) {
-					return responseBody;
-				}
-			});
-		}
+    // Defines a GraphQL fetcher using the fetch API. You're not required to
+    // use fetch, and could instead implement graphQLFetcher however you like,
+    // as long as it returns a Promise or Observable.
+    function graphQLFetcher(graphQLParams, fetcherOpts = { headers: {} }) {
+      // This example expects a GraphQL server at the path /graphql.
+      // Change this to point wherever you host your GraphQL server.
+      return fetch(window.location.protocol + "//" + window.location.host + '@Model.GraphQLEndPoint', {
+        method: 'post',
+        headers: Object.assign(@Model.Headers, fetcherOpts.headers),
+        body: JSON.stringify(graphQLParams),
+        credentials: 'include',
+      }).then(function (response) {
+        return response.text();
+      }).then(function (responseBody) {
+        try {
+          return JSON.parse(responseBody);
+        } catch (error) {
+          return responseBody;
+        }
+      });
+    }
 
-		// Enable Subscriptions via WebSocket
-		var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient((window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.SubscriptionsEndPoint", { reconnect: true });
-		var subscriptionsFetcher = window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
+    // Enable Subscriptions via WebSocket
+    var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient((window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.SubscriptionsEndPoint", { reconnect: true });
+    function subscriptionsFetcher(graphQLParams, fetcherOpts = { headers: {} }) {
+      return window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, function (_graphQLParams) {
+        return graphQLFetcher(_graphQLParams, fetcherOpts);
+      })(graphQLParams);
+    }
 
-		// Render <GraphiQL /> into the body.
-		// See the README in the top level of this module to learn more about
-		// how you can customize GraphiQL by providing different values or
-		// additional child elements.
-		ReactDOM.render(
-			React.createElement(GraphiQLWithExtensions.GraphiQLWithExtensions, {
-				fetcher: subscriptionsFetcher,
-				query: parameters.query,
-				variables: parameters.variables,
-				operationName: parameters.operationName,
-				onEditQuery: onEditQuery,
-				onEditVariables: onEditVariables,
-				onEditOperationName: onEditOperationName
-			}),
-			document.getElementById('graphiql')
-		);
-	</script>
+    // Render <GraphiQL /> into the body.
+    // See the README in the top level of this module to learn more about
+    // how you can customize GraphiQL by providing different values or
+    // additional child elements.
+    ReactDOM.render(
+      React.createElement(@Model.GraphiQLElement, {
+        fetcher: subscriptionsFetcher,
+        query: parameters.query,
+        variables: parameters.variables,
+        operationName: parameters.operationName,
+        onEditQuery: onEditQuery,
+        onEditVariables: onEditVariables,
+        onEditOperationName: onEditOperationName,
+        headerEditorEnabled: @Model.HeaderEditorEnabled,
+      }),
+      document.getElementById('graphiql'),
+    );
+  </script>
 </body>
 </html>

--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -36,10 +36,12 @@
   ></script>
   <script
     src="https://unpkg.com/react@16.14.0/umd/react.production.min.js"
+    integrity="sha384-N7y5SSAooNlIfb9H750GR82ufkn1JXJFaCjg8pmt+OZuKcZoTvTGfog4d4taG/cF"
     crossorigin="anonymous"
   ></script>
   <script
     src="https://unpkg.com/react-dom@16.14.0/umd/react-dom.production.min.js"
+    integrity="sha384-j7WmMv3OO6n8pZRATOsaMVEdZcHpoaTBIika/l92YM2AkEex72QunlTQlgmu+pI8"
     crossorigin="anonymous"
   ></script>
 
@@ -48,7 +50,12 @@
     copy them directly into your environment, or perhaps include them in your
     favored resource bundler.
    -->
-  <link rel="stylesheet" href="https://unpkg.com/graphiql@1.5.1/graphiql.min.css" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/graphiql@1.5.1/graphiql.min.css"
+    integrity="sha384-1YHEU+Xy8hlKYAZ26WTz+JQEPMM6i/Mx5m8umMkSZChlzSYmq7RqyCyRbGqrILVZ"
+    crossorigin="anonymous"
+  />
   <script
     src="https://unpkg.com/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"
     integrity="sha384-TqI6gT2PjmSrnEOTvGHLad1U4Vm5VoyzMmcKK0C/PLCWTnwPyXhCJY6NYhC/tp19"
@@ -60,14 +67,24 @@
     integrity="sha384-GBqwox+q8UtVEyBLBKloN5QDlBDsQnuoSUfMeJH1ZtDiCrrk103D7Bg/WjIvl4ya"
     crossorigin="anonymous"
   />
-  <script src="https://unpkg.com/subscriptions-transport-ws@0.8.2/browser/client.js"></script>
-  <script src="https://unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
+  <script
+    src="https://unpkg.com/subscriptions-transport-ws@0.8.2/browser/client.js"
+    integrity="sha384-Eqe2SG8kA+Au+rwrgfWJ+epqYAtKGW/As+WdcywebVKX7377xelWa+/il4CHiHXI"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    src="https://unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"
+    integrity="sha384-ArTEHLNWIe9TuoDpFEtD/NeztNdWn3SdmWwMiAuZaSJeOaYypEGzeQoBxuPO+ORM"
+    crossorigin="anonymous"
+  ></script>
 
 </head>
 <body>
   <div id="graphiql">Loading...</div>
   <script
     src="https://unpkg.com/graphiql@1.5.1/graphiql.min.js"
+    integrity="sha384-ktvW/i3KUd0D3ub91RkvHlJmf5wWqq7/VSBpCtpRrItml9btmAZH0x8c7fEXcr3e"
+    crossorigin="anonymous"
   ></script>
   <script>
 

--- a/tests/ApiApprovalTests/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -8,7 +8,9 @@ namespace GraphQL.Server.Ui.GraphiQL
     public class GraphiQLOptions
     {
         public GraphiQLOptions() { }
+        public bool ExplorerExtensionEnabled { get; set; }
         public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
+        public bool HeaderEditorEnabled { get; set; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; set; }
         public Microsoft.AspNetCore.Http.PathString SubscriptionsEndPoint { get; set; }
     }

--- a/tests/Samples.Server.Tests/ResponseTests.cs
+++ b/tests/Samples.Server.Tests/ResponseTests.cs
@@ -50,7 +50,7 @@ namespace Samples.Server.Tests
 
             string response = await SendRequestAsync(request, requestType, queryStringOverride: requestB);
             response.ShouldBeEquivalentJson(
-                @"{""data"":{""addMessage"":{""sentAt"":""2020-01-01"",""content"":""two content"",""from"":{""id"":""1""}}}}",
+                @"{""data"":{""addMessage"":{""sentAt"":""2020-01-01T00:00:00Z"",""content"":""two content"",""from"":{""id"":""1""}}}}",
                 ignoreExtensions: true);
         }
 
@@ -140,7 +140,7 @@ namespace Samples.Server.Tests
             };
             string response = await SendRequestAsync(request, requestType);
             response.ShouldBeEquivalentJson(
-                @"{""data"":{""addMessage"":{""sentAt"":""2020-01-01"",""content"":""some content"",""from"":{""id"":""1""}}}}",
+                @"{""data"":{""addMessage"":{""sentAt"":""2020-01-01T00:00:00Z"",""content"":""some content"",""from"":{""id"":""1""}}}}",
                 ignoreExtensions: true);
         }
 
@@ -158,7 +158,7 @@ namespace Samples.Server.Tests
             };
             string response = await SendRequestAsync(request, requestType);
             response.ShouldBeEquivalentJson(
-                @"{""data"":{""addMessage"":{""sentAt"":""2020-01-01"",""content"":""some content"",""from"":{""id"":""1""}}}}",
+                @"{""data"":{""addMessage"":{""sentAt"":""2020-01-01T00:00:00Z"",""content"":""some content"",""from"":{""id"":""1""}}}}",
                 ignoreExtensions: true);
         }
 
@@ -176,7 +176,7 @@ namespace Samples.Server.Tests
             };
             string response = await SendRequestAsync(request, requestType);
             response.ShouldBeEquivalentJson(
-                @"{""data"":{""addMessage"":{""sentAt"":""2020-01-01"",""content"":""some content"",""from"":{""id"":""1""}}}}",
+                @"{""data"":{""addMessage"":{""sentAt"":""2020-01-01T00:00:00Z"",""content"":""some content"",""from"":{""id"":""1""}}}}",
                 ignoreExtensions: true);
         }
 


### PR DESCRIPTION
# Context

The goal is to add support request headers in GraphiQL (discussed in https://github.com/graphql-dotnet/server/issues/504).

# Description

Request headers support has been added in recent versions of GraphiQL. Unfortunately, [GraphiQL with extensions](https://github.com/OneGraph/graphiql-with-extensions) does not support it. As it wraps the GraphiQL component and masks the props, upgrading has no effect. There is not much activity on graphiql-with-extensions repo since some time now.

The current integration of GraphiQL has a broken support of subscription (see #544), due to the deprecation of `subscribe` function in https://github.com/apollographql/subscriptions-transport-ws/pull/272. Also this dependency is still required though not [maintained anymore](https://the-guild.dev/blog/graphql-over-websockets) until #492 is resolved. For the same reason, the current integration relies on [graphiql-subscriptions-fetcher](https://github.com/apollographql/GraphiQL-Subscriptions-Fetcher) which is archived and not maintained anymore, also wrapping the `GraphQLFetcher` and masking the additional options necessary to support request headers.

# Proposal

1. Upgrading GraphiQL to version 1.5.1: cshtml file is inspired from [CDN example](https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html).

2. Adding an option to enable/disable GraphiQL with extensions: `ExplorerExtensionEnabled`, enabled by default for backward compatibility.

3. Adding an option to enable/disable header editor: `HeaderEditorEnabled`, enable by default (same as in GraphiQL).

4. Wrapping `subscriptionsFetcher` to pass additional option to support request headers editor.

5. Downgrade subscriptions-transport-ws to version 0.8.2 to fix #544.

# Tests

Screenshot of side by side example of a mutation on the left leading to a working subscription on the right:

![Screenshot 2021-11-20 210857](https://user-images.githubusercontent.com/13953151/142747748-313d0c58-3c9d-4b77-a395-7b865546c6f4.png)

On the previous screenshot, the request headers editor is visible on the right and the authorization header is available in HTTP context when debugging:

![Screenshot 2021-11-20 210339](https://user-images.githubusercontent.com/13953151/142747815-e2910994-d8ac-4295-9840-cc0ae9bba9dc.png)
