### PR TITLE
Use SubscriptionDocumentExecuter by default

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="4.1.0" />
+    <!--TODO: remove SystemReactive in v6 -->
+    <PackageReference Include="GraphQL.SystemReactive" Version="4.1.0" />
     <PackageReference Include="GraphQL.DataLoader" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.0" />
   </ItemGroup>

--- a/src/Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/ServiceCollectionExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // This is used instead of "normal" services.Configure(configureOptions) to pass IServiceProvider to user code.
             services.AddSingleton<IConfigureOptions<GraphQLOptions>>(x => new ConfigureNamedOptions<GraphQLOptions>(Options.Options.DefaultName, opt => configureOptions(opt, x)));
             services.TryAddSingleton<InstrumentFieldsMiddleware>();
-            services.TryAddSingleton<IDocumentExecuter, DocumentExecuter>();
+            services.TryAddSingleton<IDocumentExecuter, SubscriptionDocumentExecuter>(); // TODO: rewrite in v6
             services.TryAddTransient(typeof(IGraphQLExecuter<>), typeof(DefaultGraphQLExecuter<>));
 
             services.TryAddSingleton<IDocumentWriter>(x =>


### PR DESCRIPTION
fixes #544

Just an oversight when migrating on GraphQL.NET v4. Public API for document executer should be changed in v6. 