### PR TITLE
Fix content-type bug

### DIFF
--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -27,7 +27,16 @@ namespace GraphQL.Server.Ui.Playground.Internal
                 var headers = new Dictionary<string, object>
                 {
                     ["Accept"] = "application/json",
-                    ["Content-Type"] = "application/json",
+                    // TODO: investigate, fails in Chrome
+                    // {
+                    //   "error": "Response not successful: Received status code 400"
+                    // }
+                    //
+                    // MediaTypeHeaderValue.TryParse(httpRequest.ContentType, out var mediaTypeHeader) from GraphQLHttpMiddleware
+                    // returns false because of
+                    // content-type: application/json, application/json
+
+                    //["Content-Type"] = "application/json",
                 };
 
                 if (_options.Headers?.Count > 0)


### PR DESCRIPTION
I checked all middlewares in Firefox first. Then I noticed that Playground doesn't work in Chrome. See comments.