### PR TITLE
add GraphQL Playground UI Tabs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 version: 2
 updates:
-- package-ecosystem: nuget
+- package-ecosystem: "nuget"
   directory: "/"
   schedule:
-    interval: daily
-    time: '02:00'
-  open-pull-requests-limit: 10
+    interval: "daily"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,7 @@ test:
 
 CI:
   - .github/workflows/**/*
+  - .github/dependabot.yml
 
 code style:
   - .editorconfig

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,3 +1,5 @@
+# https://github.com/github/codeql
+# https://github.com/github/codeql-action
 name: CodeQL analysis
 
 on:
@@ -9,12 +11,27 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout source
+      uses: actions/checkout@v2
+
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1
       with:
-        fetch-depth: 2
-    - uses: github/codeql-action/init@v1
+         dotnet-version: '5.0.x'
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
       with:
+        queries: security-and-quality
         languages: csharp
-    - uses: github/codeql-action/autobuild@v1
-    - uses: github/codeql-action/analyze@v1
+
+    - name: Install dependencies
+      run: dotnet restore
+
+    - name: Build solution
+      run: dotnet build --no-restore
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Publish Nuget packages to Nuget registry
         run: dotnet nuget push "out/*" -k ${{secrets.NUGET_AUTH_TOKEN}}
       - name: Upload Nuget packages as release artifacts
-        uses: actions/github-script@v2
+        uses: actions/github-script@v5
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
             const { repo: { owner, repo }, sha } = context;
             for (let file of await fs.readdir('out')) {
               console.log('uploading', file);
-              await github.repos.uploadReleaseAsset({
+              await github.rest.repos.uploadReleaseAsset({
                 owner,
                 repo,
                 release_id: ${{ github.event.release.id }},

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Check formatting
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
-          dotnet tool install -g dotnet-format --version 6.0.* --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+          dotnet tool install -g dotnet-format --version 5.1.* --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
           dotnet format --check --fix-whitespace || (echo "Run 'dotnet format' to fix formatting issues" && exit 1)
           dotnet format --check -v diag --fix-style warn --fix-analyzers warn || (echo "Run 'dotnet format' to fix formatting issues" && exit 1)
       - name: Build solution [Release]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
       - develop
     paths:
       - src/**
+      - tests/**
+      - samples/**
       - .github/workflows/**
       - "*.props"
       - "*.targets"
@@ -17,6 +19,8 @@ on:
       - develop
     paths:
       - src/**
+      - tests/**
+      - samples/**
       - .github/workflows/**
       - "*.props"
       - "*.targets"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Check formatting
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
-          dotnet tool install -g dotnet-format --version 5.1.* --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+          dotnet tool install -g dotnet-format --version 6.0.243104 --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
           dotnet format --check --fix-whitespace || (echo "Run 'dotnet format' to fix formatting issues" && exit 1)
           dotnet format --check -v diag --fix-style warn --fix-analyzers warn || (echo "Run 'dotnet format' to fix formatting issues" && exit 1)
       - name: Build solution [Release]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - src/**
       - .github/workflows/**
+      - "*.props"
+      - "*.targets"
   # Upload code coverage results when PRs are merged
   push:
     branches:
@@ -16,6 +18,8 @@ on:
     paths:
       - src/**
       - .github/workflows/**
+      - "*.props"
+      - "*.targets"
 
 env:
   DOTNET_NOLOGO: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         run: dotnet test --no-restore --no-build -p:CollectCoverage=true
       - name: Upload coverage to codecov
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v2.1.0
         with:
           files: .coverage/GraphQL.Server.Authorization.AspNetCore.Tests/coverage.net5.opencover.xml,.coverage/GraphQL.Server.Samples.Server.Tests/coverage.netcoreapp3.1.opencover.xml,.coverage/GraphQL.Server.Transports.Subscriptions.Abstractions.Tests/coverage.net5.opencover.xml,.coverage/GraphQL.Server.Transports.Subscriptions.WebSockets.Tests/coverage.net5.opencover.xml
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Condition="'$(IsPackable)' == 'true'"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" Condition="'$(IsPackable)' == 'true'"/>
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>5.0.1-preview</VersionPrefix>
+    <VersionPrefix>5.0.2-preview</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>5.0.2-preview</VersionPrefix>
+    <VersionPrefix>5.1.0-preview</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>logo.64x64.png</PackageIcon>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2021 Pekka Heikura, et al. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2021 Pekka Heikura, et al. All rights reserved.
+Copyright (c) 2015-2021 Pekka Heikura, Ivan Maximov, et al. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For more information on how to migrate from `Newtonsoft.Json` to `System.Text.Js
 For the WebSocket subscription protocol (depends on above) middleware:
 
 ```
-> dotnet add package GraphQL.Server.Transports.WebSockets
+> dotnet add package GraphQL.Server.Transports.Subscriptions.WebSockets
 ```
 
 #### 3. Authorization

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For integration of GraphQL.NET validation subsystem into ASP.NET Core:
 
 #### 4. UI integration
 
-For the UI middleware/s:
+For the UI middlewares:
 
 ```
 > dotnet add package GraphQL.Server.Ui.Altair
@@ -101,6 +101,18 @@ For the UI middleware/s:
 > dotnet add package GraphQL.Server.Ui.Playground
 > dotnet add package GraphQL.Server.Ui.Voyager
 ```
+
+```c#
+public void Configure(IApplicationBuilder app)
+{
+    app.[Use|Map]GraphQLAltair();
+    app.[Use|Map]GraphQLGraphiQL();
+    app.[Use|Map]GraphQLPlayground();
+    app.[Use|Map]GraphQLVoyager();
+}
+```
+
+Also each middleware accepts options to configure its behavior and UI.
 
 ## Configure
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For the WebSocket subscription protocol (depends on above) middleware:
 For integration of GraphQL.NET validation subsystem into ASP.NET Core:
 
 ```
-> dotnet add package Authorization.AspNetCore
+> dotnet add package GraphQL.Server.Authorization.AspNetCore
 ```
 
 #### 4. UI integration

--- a/Tests.props
+++ b/Tests.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests.props
+++ b/Tests.props
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/Tests.props
+++ b/Tests.props
@@ -17,8 +17,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.13" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.4" Condition="'$(TargetFramework)' == 'net5'" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.19" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.10" Condition="'$(TargetFramework)' == 'net5'" />
   </ItemGroup>
 
 </Project>

--- a/Tests.props
+++ b/Tests.props
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/samples/Samples.Server/Samples.Server.csproj
+++ b/samples/Samples.Server/Samples.Server.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="4.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Samples.Server/Samples.Server.csproj
+++ b/samples/Samples.Server/Samples.Server.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="4.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -82,6 +82,19 @@ namespace GraphQL.Samples.Server
                     ["MyHeader1"] = "MyValue",
                     ["MyHeader2"] = 42,
                 },
+
+                Tabs = new PlaygroundTab[1]
+                {
+                    new PlaygroundTab(query: "mutation AddMessage($message: MessageInputType!) {\n  addMessage(message: $message) {\n    from {\n      id\n      displayName\n    }\n    content\n  }\n}")
+                    {
+                        Name = "AddMessage",
+                        Variables = "{\n  \"message\": {\n    \"content\": \"Message\",\n    \"fromId\": \"1\"\n  }\n}",
+                        Responses = new string[]
+                        {
+                            "{\n  \"data\": {\n    \"addMessage\": {\n      \"from\": {\n        \"id\": \"1\",\n        \"displayName\": \"developer\"\n      },\n      \"content\": \"Message\"\n    }\n  }\n}"
+                        }
+                    }
+                }
             });
 
             app.UseGraphQLGraphiQL(new GraphiQLOptions

--- a/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
+++ b/src/Authorization.AspNetCore/AuthorizationValidationRule.cs
@@ -50,7 +50,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
                 }),
                 new MatchingNodeVisitor<ObjectField>((objectFieldAst, context) =>
                 {
-                    if (context.TypeInfo.GetArgument().ResolvedType.GetNamedType() is IComplexGraphType argumentType)
+                    if (context.TypeInfo.GetArgument()?.ResolvedType.GetNamedType() is IComplexGraphType argumentType)
                     {
                         var fieldType = argumentType.GetField(objectFieldAst.Name);
                         AuthorizeAsync(objectFieldAst, fieldType, context, operationType).GetAwaiter().GetResult(); // TODO: need to think of something to avoid this

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.13" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" Condition="'$(TargetFramework)' == 'net5'" />
   </ItemGroup>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.13" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" Condition="'$(TargetFramework)' == 'net5'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.19" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" Condition="'$(TargetFramework)' == 'net5'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.19" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" Condition="'$(TargetFramework)' == 'net5'" />
   </ItemGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="4.1.0" />
+    <!--TODO: remove SystemReactive in v6 -->
+    <PackageReference Include="GraphQL.SystemReactive" Version="4.1.0" />
     <PackageReference Include="GraphQL.DataLoader" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.0" />
   </ItemGroup>

--- a/src/Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/ServiceCollectionExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // This is used instead of "normal" services.Configure(configureOptions) to pass IServiceProvider to user code.
             services.AddSingleton<IConfigureOptions<GraphQLOptions>>(x => new ConfigureNamedOptions<GraphQLOptions>(Options.Options.DefaultName, opt => configureOptions(opt, x)));
             services.TryAddSingleton<InstrumentFieldsMiddleware>();
-            services.TryAddSingleton<IDocumentExecuter, DocumentExecuter>();
+            services.TryAddSingleton<IDocumentExecuter, SubscriptionDocumentExecuter>(); // TODO: rewrite in v6
             services.TryAddTransient(typeof(IGraphQLExecuter<>), typeof(DefaultGraphQLExecuter<>));
 
             services.TryAddSingleton<IDocumentWriter>(x =>

--- a/src/Transports.AspNetCore.NewtonsoftJson/GraphQLRequestDeserializer.cs
+++ b/src/Transports.AspNetCore.NewtonsoftJson/GraphQLRequestDeserializer.cs
@@ -41,19 +41,28 @@ namespace GraphQL.Server.Transports.AspNetCore.NewtonsoftJson
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                switch (firstChar)
+                try
                 {
-                    case '{':
-                        result.Single = ToGraphQLRequest(_serializer.Deserialize<InternalGraphQLRequest>(jsonReader));
-                        break;
-                    case '[':
-                        result.Batch = _serializer.Deserialize<InternalGraphQLRequest[]>(jsonReader)
-                            .Select(ToGraphQLRequest)
-                            .ToArray();
-                        break;
-                    default:
-                        result.IsSuccessful = false;
-                        break;
+                    switch (firstChar)
+                    {
+                        case '{':
+                            result.Single = ToGraphQLRequest(_serializer.Deserialize<InternalGraphQLRequest>(jsonReader));
+                            break;
+                        case '[':
+                            result.Batch = _serializer.Deserialize<InternalGraphQLRequest[]>(jsonReader)
+                                .Select(ToGraphQLRequest)
+                                .ToArray();
+                            break;
+                        default:
+                            result.IsSuccessful = false;
+                            result.Exception = GraphQLRequestDeserializationException.InvalidFirstChar();
+                            break;
+                    }
+                }
+                catch (JsonException e)
+                {
+                    result.IsSuccessful = false;
+                    result.Exception = new GraphQLRequestDeserializationException(e);
                 }
             }
 

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -120,6 +120,15 @@ namespace GraphQL.Server.Transports.AspNetCore
                     Extensions = urlGQLRequest.Extensions ?? bodyGQLRequest?.Extensions,
                     OperationName = urlGQLRequest.OperationName ?? bodyGQLRequest?.OperationName
                 };
+
+                if (string.IsNullOrWhiteSpace(gqlRequest.Query))
+                {
+                    await WriteErrorResponseAsync(httpResponse, writer, cancellationToken,
+                        "GraphQL query is missing.",
+                        httpStatusCode: 400 // Bad Input
+                    );
+                    return;
+                }
             }
 
             // Prepare context and execute

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -61,9 +61,12 @@ namespace GraphQL.Server.Transports.AspNetCore
             if (!isGet && !isPost)
             {
                 httpResponse.Headers["Allow"] = "GET, POST";
-                await WriteErrorResponseAsync(httpResponse, writer, cancellationToken,
+                await WriteErrorResponseAsync(
+                    httpResponse,
+                    writer,
+                    cancellationToken,
                     $"Invalid HTTP method. Only GET and POST are supported. {DOCS_URL}",
-                    httpStatusCode: HttpStatusCode.MethodNotAllowed
+                    HttpStatusCode.MethodNotAllowed
                 );
                 return;
             }
@@ -75,7 +78,12 @@ namespace GraphQL.Server.Transports.AspNetCore
             {
                 if (!MediaTypeHeaderValue.TryParse(httpRequest.ContentType, out var mediaTypeHeader))
                 {
-                    await WriteErrorResponseAsync(httpResponse, writer, cancellationToken, $"Invalid 'Content-Type' header: value '{httpRequest.ContentType}' could not be parsed.");
+                    await WriteErrorResponseAsync(
+                        httpResponse,
+                        writer,
+                        cancellationToken,
+                        $"Invalid 'Content-Type' header: value '{httpRequest.ContentType}' could not be parsed.",
+                        HttpStatusCode.BadRequest);
                     return;
                 }
 
@@ -88,7 +96,7 @@ namespace GraphQL.Server.Transports.AspNetCore
                             var message = deserializationResult.Exception is null
                                 ? "JSON body text could not be parsed."
                                 : $"JSON body text could not be parsed. {deserializationResult.Exception.Message}";
-                            await WriteErrorResponseAsync(httpResponse, writer, cancellationToken, message);
+                            await WriteErrorResponseAsync(httpResponse, writer, cancellationToken, message, HttpStatusCode.BadRequest);
                             return;
                         }
                         bodyGQLRequest = deserializationResult.Single;
@@ -132,9 +140,12 @@ namespace GraphQL.Server.Transports.AspNetCore
 
                 if (string.IsNullOrWhiteSpace(gqlRequest.Query))
                 {
-                    await WriteErrorResponseAsync(httpResponse, writer, cancellationToken,
+                    await WriteErrorResponseAsync(
+                        httpResponse,
+                        writer,
+                        cancellationToken,
                         "GraphQL query is missing.",
-                        httpStatusCode: HttpStatusCode.BadRequest
+                        HttpStatusCode.BadRequest
                     );
                     return;
                 }
@@ -204,7 +215,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         }
 
         private Task WriteErrorResponseAsync(HttpResponse httpResponse, IDocumentWriter writer, CancellationToken cancellationToken,
-            string errorMessage, HttpStatusCode httpStatusCode = HttpStatusCode.BadRequest)
+            string errorMessage, HttpStatusCode httpStatusCode)
         {
             var result = new ExecutionResult
             {

--- a/src/Transports.AspNetCore/GraphQLRequestDeserializationException.cs
+++ b/src/Transports.AspNetCore/GraphQLRequestDeserializationException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace GraphQL.Server.Transports.AspNetCore
+{
+    public class GraphQLRequestDeserializationException : Exception
+    {
+        public GraphQLRequestDeserializationException(string message) : base(message)
+        {
+        }
+
+        public GraphQLRequestDeserializationException(Exception inner) : base(inner.Message, inner)
+        {
+        }
+
+        public static GraphQLRequestDeserializationException InvalidFirstChar()
+        {
+            return new GraphQLRequestDeserializationException("Body text should start with '{' for normal graphql query or with '[' for batched query.");
+        }
+    }
+}

--- a/src/Transports.AspNetCore/GraphQLRequestDeserializationException.cs
+++ b/src/Transports.AspNetCore/GraphQLRequestDeserializationException.cs
@@ -2,6 +2,10 @@ using System;
 
 namespace GraphQL.Server.Transports.AspNetCore
 {
+    /// <summary>
+    /// Exception used by <see cref="IGraphQLRequestDeserializer"/> implementations
+    /// when deserialization failed.
+    /// </summary>
     public class GraphQLRequestDeserializationException : Exception
     {
         public GraphQLRequestDeserializationException(string message) : base(message)
@@ -12,6 +16,14 @@ namespace GraphQL.Server.Transports.AspNetCore
         {
         }
 
+        public GraphQLRequestDeserializationException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="GraphQLRequestDeserializationException"/> for a situations
+        /// when the first symbol of JSON body neither '{' nor '['.
+        /// </summary>
         public static GraphQLRequestDeserializationException InvalidFirstChar()
         {
             return new GraphQLRequestDeserializationException("Body text should start with '{' for normal graphql query or with '[' for batched query.");

--- a/src/Transports.AspNetCore/GraphQLRequestDeserializationResult.cs
+++ b/src/Transports.AspNetCore/GraphQLRequestDeserializationResult.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         /// Flag indicating success. When false, the <see cref="GraphQLHttpMiddleware{TSchema}"/>
         /// will return a 400 BadRequest HTTP status to the client.
         /// </summary>
-        public bool IsSuccessful { get; set; }
+        public bool IsSuccessful { get; set; } // TODO: delete in v6
 
         /// <summary>
         /// A deserialized GraphQL request,
@@ -25,7 +25,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         public GraphQLRequest[] Batch { get; set; }
 
         /// <summary>
-        /// If deserialization throws an exception, it is stored here
+        /// If deserialization throws an exception, it is stored here.
         /// </summary>
         public GraphQLRequestDeserializationException Exception { get; set; }
     }

--- a/src/Transports.AspNetCore/GraphQLRequestDeserializationResult.cs
+++ b/src/Transports.AspNetCore/GraphQLRequestDeserializationResult.cs
@@ -23,5 +23,10 @@ namespace GraphQL.Server.Transports.AspNetCore
         /// populated if the HTTP request body contained an array of JSON objects.
         /// </summary>
         public GraphQLRequest[] Batch { get; set; }
+
+        /// <summary>
+        /// If deserialization throws an exception, it is stored here
+        /// </summary>
+        public GraphQLRequestDeserializationException Exception { get; set; }
     }
 }

--- a/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketReaderPipeline.cs
@@ -42,7 +42,9 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public async Task Complete(WebSocketCloseStatus closeStatus, string statusDescription)
         {
-            if (_socket.State != WebSocketState.Closed && _socket.State != WebSocketState.CloseSent)
+            if (_socket.State != WebSocketState.Closed &&
+                _socket.State != WebSocketState.CloseSent &&
+                _socket.State != WebSocketState.Aborted)
                 try
                 {
                     if (closeStatus == WebSocketCloseStatus.NormalClosure)

--- a/src/Ui.Altair/AltairMiddleware.cs
+++ b/src/Ui.Altair/AltairMiddleware.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Ui.Altair
         /// <summary>
         /// The page model used to render Altair.
         /// </summary>
-        private AltairPageModel _pageModel;
+        private AltairPageModel? _pageModel;
 
         /// <summary>
         /// Create a new <see cref="AltairMiddleware"/>
@@ -41,9 +41,7 @@ namespace GraphQL.Server.Ui.Altair
             httpContext.Response.ContentType = "text/html";
             httpContext.Response.StatusCode = 200;
 
-            // Initialize page model if null
-            if (_pageModel == null)
-                _pageModel = new AltairPageModel(_options);
+            _pageModel ??= new AltairPageModel(_options);
 
             byte[] data = Encoding.UTF8.GetBytes(_pageModel.Render());
             return httpContext.Response.Body.WriteAsync(data, 0, data.Length);

--- a/src/Ui.Altair/AltairOptions.cs
+++ b/src/Ui.Altair/AltairOptions.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.AspNetCore.Http;
 
 namespace GraphQL.Server.Ui.Altair
@@ -21,6 +23,17 @@ namespace GraphQL.Server.Ui.Altair
         /// <summary>
         /// Altair headers configuration.
         /// </summary>
-        public Dictionary<string, string> Headers { get; set; }
+        public Dictionary<string, string>? Headers { get; set; }
+
+        /// <summary>
+        /// Gets or sets a Stream function for retrieving the Altair GraphQL UI page.
+        /// </summary>
+        public Func<AltairOptions, Stream> IndexStream { get; set; } = _ => typeof(AltairOptions).Assembly
+            .GetManifestResourceStream("GraphQL.Server.Ui.Altair.Internal.altair.cshtml")!;
+
+        /// <summary>
+        /// Gets or sets a delegate that is called after all transformations of the Altair GraphQL UI page.
+        /// </summary>
+        public Func<AltairOptions, string, string> PostConfigure { get; set; } = (options, result) => result;
     }
 }

--- a/src/Ui.Altair/Internal/AltairPageModel.cs
+++ b/src/Ui.Altair/Internal/AltairPageModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
@@ -7,7 +8,7 @@ namespace GraphQL.Server.Ui.Altair.Internal
     // https://docs.microsoft.com/en-us/aspnet/core/mvc/razor-pages/?tabs=netcore-cli
     internal sealed class AltairPageModel
     {
-        private string _altairCSHtml;
+        private string? _altairCSHtml;
 
         private readonly AltairOptions _options;
 
@@ -20,15 +21,27 @@ namespace GraphQL.Server.Ui.Altair.Internal
         {
             if (_altairCSHtml == null)
             {
-                using var manifestResourceStream = typeof(AltairPageModel).Assembly.GetManifestResourceStream("GraphQL.Server.Ui.Altair.Internal.altair.cshtml");
+                using var manifestResourceStream = _options.IndexStream(_options);
                 using var streamReader = new StreamReader(manifestResourceStream);
+
+                var headers = new Dictionary<string, object>
+                {
+                    ["Accept"] = "application/json",
+                    ["Content-Type"] = "application/json",
+                };
+
+                if (_options.Headers?.Count > 0)
+                {
+                    foreach (var item in _options.Headers)
+                        headers[item.Key] = item.Value;
+                }
 
                 var builder = new StringBuilder(streamReader.ReadToEnd())
                     .Replace("@Model.GraphQLEndPoint", _options.GraphQLEndPoint)
                     .Replace("@Model.SubscriptionsEndPoint", _options.SubscriptionsEndPoint)
-                    .Replace("@Model.Headers", JsonSerializer.Serialize<object>(_options.Headers));
+                    .Replace("@Model.Headers", JsonSerializer.Serialize<object>(headers));
 
-                _altairCSHtml = builder.ToString();
+                _altairCSHtml = _options.PostConfigure(_options, builder.ToString());
             }
 
             return _altairCSHtml;

--- a/src/Ui.Altair/Ui.Altair.csproj
+++ b/src/Ui.Altair/Ui.Altair.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5;netcoreapp3.1</TargetFrameworks>
     <Description>GraphQL Altair integration for ASP.NET Core</Description>
     <PackageTags>Altair;GraphQL</PackageTags>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ui.GraphiQL/GraphiQLMiddleware.cs
+++ b/src/Ui.GraphiQL/GraphiQLMiddleware.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Ui.GraphiQL
         /// <summary>
         /// The page model used to render GraphiQL.
         /// </summary>
-        private GraphiQLPageModel _pageModel;
+        private GraphiQLPageModel? _pageModel;
 
         /// <summary>
         /// Create a new <see cref="GraphiQLMiddleware"/>
@@ -42,9 +42,7 @@ namespace GraphQL.Server.Ui.GraphiQL
             httpContext.Response.ContentType = "text/html";
             httpContext.Response.StatusCode = 200;
 
-            // Initialize page model if null
-            if (_pageModel == null)
-                _pageModel = new GraphiQLPageModel(_options);
+            _pageModel ??= new GraphiQLPageModel(_options);
 
             byte[] data = Encoding.UTF8.GetBytes(_pageModel.Render());
             return httpContext.Response.Body.WriteAsync(data, 0, data.Length);

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.AspNetCore.Http;
 
 namespace GraphQL.Server.Ui.GraphiQL
@@ -21,6 +23,17 @@ namespace GraphQL.Server.Ui.GraphiQL
         /// <summary>
         /// HTTP headers with which the GraphiQL will be initialized.
         /// </summary>
-        public Dictionary<string, string> Headers { get; set; }
+        public Dictionary<string, string>? Headers { get; set; }
+
+        /// <summary>
+        /// Gets or sets a Stream function for retrieving the GraphiQL UI page.
+        /// </summary>
+        public Func<GraphiQLOptions, Stream> IndexStream { get; set; } = _ => typeof(GraphiQLOptions).Assembly
+            .GetManifestResourceStream("GraphQL.Server.Ui.GraphiQL.Internal.graphiql.cshtml")!;
+
+        /// <summary>
+        /// Gets or sets a delegate that is called after all transformations of the GraphiQL UI page.
+        /// </summary>
+        public Func<GraphiQLOptions, string, string> PostConfigure { get; set; } = (options, result) => result;
     }
 }

--- a/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
+++ b/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Server.Ui.GraphiQL.Internal
     // https://docs.microsoft.com/en-us/aspnet/core/mvc/razor-pages/?tabs=netcore-cli
     internal sealed class GraphiQLPageModel
     {
-        private string _graphiQLCSHtml;
+        private string? _graphiQLCSHtml;
 
         private readonly GraphiQLOptions _options;
 
@@ -21,7 +21,7 @@ namespace GraphQL.Server.Ui.GraphiQL.Internal
         {
             if (_graphiQLCSHtml == null)
             {
-                using var manifestResourceStream = typeof(GraphiQLPageModel).Assembly.GetManifestResourceStream("GraphQL.Server.Ui.GraphiQL.Internal.graphiql.cshtml");
+                using var manifestResourceStream = _options.IndexStream(_options);
                 using var streamReader = new StreamReader(manifestResourceStream);
 
                 var headers = new Dictionary<string, object>
@@ -41,7 +41,7 @@ namespace GraphQL.Server.Ui.GraphiQL.Internal
                     .Replace("@Model.SubscriptionsEndPoint", _options.SubscriptionsEndPoint)
                     .Replace("@Model.Headers", JsonSerializer.Serialize<object>(headers));
 
-                _graphiQLCSHtml = builder.ToString();
+                _graphiQLCSHtml = _options.PostConfigure(_options, builder.ToString());
             }
 
             return _graphiQLCSHtml;

--- a/src/Ui.GraphiQL/Ui.GraphiQL.csproj
+++ b/src/Ui.GraphiQL/Ui.GraphiQL.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5;netcoreapp3.1</TargetFrameworks>
     <Description>GraphiQL integration for ASP.NET Core</Description>
     <PackageTags>GraphiQL;GraphQL</PackageTags>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -27,7 +27,16 @@ namespace GraphQL.Server.Ui.Playground.Internal
                 var headers = new Dictionary<string, object>
                 {
                     ["Accept"] = "application/json",
-                    ["Content-Type"] = "application/json",
+                    // TODO: investigate, fails in Chrome
+                    // {
+                    //   "error": "Response not successful: Received status code 400"
+                    // }
+                    //
+                    // MediaTypeHeaderValue.TryParse(httpRequest.ContentType, out var mediaTypeHeader) from GraphQLHttpMiddleware
+                    // returns false because of
+                    // content-type: application/json, application/json
+
+                    //["Content-Type"] = "application/json",
                 };
 
                 if (_options.Headers?.Count > 0)

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 
@@ -45,11 +46,28 @@ namespace GraphQL.Server.Ui.Playground.Internal
                         headers[item.Key] = item.Value;
                 }
 
+                string modelTabs = "null";
+
+                if(_options.Tabs != null)
+                {
+                    var tabs = _options.Tabs.Select(tab =>
+                    {
+                        tab.Headers ??= headers;
+                        return tab;
+                    });
+
+                    modelTabs = JsonSerializer.Serialize<object>(tabs, new JsonSerializerOptions
+                    {
+                        IgnoreNullValues = true
+                    });
+                }
+
                 var builder = new StringBuilder(streamReader.ReadToEnd())
                     .Replace("@Model.GraphQLEndPoint", _options.GraphQLEndPoint)
                     .Replace("@Model.SubscriptionsEndPoint", _options.SubscriptionsEndPoint)
                     .Replace("@Model.GraphQLConfig", JsonSerializer.Serialize<object>(_options.GraphQLConfig!))
                     .Replace("@Model.Headers", JsonSerializer.Serialize<object>(headers))
+                    .Replace("@Model.Tabs", modelTabs)
                     .Replace("@Model.PlaygroundSettings", JsonSerializer.Serialize<object>(_options.PlaygroundSettings));
 
                 _playgroundCSHtml = _options.PostConfigure(_options, builder.ToString());

--- a/src/Ui.Playground/Internal/playground.cshtml
+++ b/src/Ui.Playground/Internal/playground.cshtml
@@ -48,15 +48,25 @@
   </div>
   <script>
     window.addEventListener('load', function (event) {
-      GraphQLPlayground.init(document.getElementById('root'),
-        {
-          setTitle: true,
-          endpoint: window.location.protocol + "//" + window.location.host + "@Model.GraphQLEndPoint",
-          subscriptionEndpoint: (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.SubscriptionsEndPoint",
-          config: @Model.GraphQLConfig,
-          settings: @Model.PlaygroundSettings,
-          headers: @Model.Headers,
+      let options = {
+        setTitle: true,
+        endpoint: window.location.protocol + "//" + window.location.host + "@Model.GraphQLEndPoint",
+        subscriptionEndpoint: (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.SubscriptionsEndPoint",
+        config: @Model.GraphQLConfig,
+        settings: @Model.PlaygroundSettings,
+        headers: @Model.Headers
+      };
+
+      const tabs = @Model.Tabs;
+
+      if(tabs) {
+        options.tabs = tabs.map(tab => {
+          tab.endpoint = window.location.protocol + "//" + window.location.host + tab.endpoint;
+          return tab;
         });
+      }
+
+      GraphQLPlayground.init(document.getElementById('root'), options);
     })
   </script>
 </body>

--- a/src/Ui.Playground/PlaygroundMiddleware.cs
+++ b/src/Ui.Playground/PlaygroundMiddleware.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Ui.Playground
         /// <summary>
         /// The page model used to render Playground.
         /// </summary>
-        private PlaygroundPageModel _pageModel;
+        private PlaygroundPageModel? _pageModel;
 
         /// <summary>
         /// Create a new <see cref="PlaygroundMiddleware"/>
@@ -41,9 +41,7 @@ namespace GraphQL.Server.Ui.Playground
             httpContext.Response.ContentType = "text/html";
             httpContext.Response.StatusCode = 200;
 
-            // Initialize page model if null
-            if (_pageModel == null)
-                _pageModel = new PlaygroundPageModel(_options);
+            _pageModel ??= new PlaygroundPageModel(_options);
 
             byte[] data = Encoding.UTF8.GetBytes(_pageModel.Render());
             return httpContext.Response.Body.WriteAsync(data, 0, data.Length);

--- a/src/Ui.Playground/PlaygroundOptions.cs
+++ b/src/Ui.Playground/PlaygroundOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.AspNetCore.Http;
 
 namespace GraphQL.Server.Ui.Playground
@@ -22,12 +23,23 @@ namespace GraphQL.Server.Ui.Playground
         /// <summary>
         /// The GraphQL configuration.
         /// </summary>
-        public Dictionary<string, object> GraphQLConfig { get; set; }
+        public Dictionary<string, object>? GraphQLConfig { get; set; }
 
         /// <summary>
         /// HTTP headers with which the GraphQL Playground will be initialized.
         /// </summary>
-        public Dictionary<string, object> Headers { get; set; }
+        public Dictionary<string, object>? Headers { get; set; }
+
+        /// <summary>
+        /// Gets or sets a Stream function for retrieving the GraphQL Playground UI page.
+        /// </summary>
+        public Func<PlaygroundOptions, Stream> IndexStream { get; set; } = _ => typeof(PlaygroundOptions).Assembly
+            .GetManifestResourceStream("GraphQL.Server.Ui.Playground.Internal.playground.cshtml")!;
+
+        /// <summary>
+        /// Gets or sets a delegate that is called after all transformations of the GraphQL Playground UI page.
+        /// </summary>
+        public Func<PlaygroundOptions, string, string> PostConfigure { get; set; } = (options, result) => result;
 
         /// <summary>
         /// The GraphQL Playground Settings, see <see href="https://github.com/prisma-labs/graphql-playground/blob/master/README.md#settings"/>.

--- a/src/Ui.Playground/PlaygroundOptions.cs
+++ b/src/Ui.Playground/PlaygroundOptions.cs
@@ -31,6 +31,11 @@ namespace GraphQL.Server.Ui.Playground
         public Dictionary<string, object>? Headers { get; set; }
 
         /// <summary>
+        /// Tabs with which the GraphQL Playground will be initialized.
+        /// </summary>
+        public IEnumerable<PlaygroundTab>? Tabs { get; set; }
+
+        /// <summary>
         /// Gets or sets a Stream function for retrieving the GraphQL Playground UI page.
         /// </summary>
         public Func<PlaygroundOptions, Stream> IndexStream { get; set; } = _ => typeof(PlaygroundOptions).Assembly

--- a/src/Ui.Playground/PlaygroundTab.cs
+++ b/src/Ui.Playground/PlaygroundTab.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GraphQL.Server.Ui.Playground
+{
+    /// <summary>
+    /// A tab for GraphQL Playground UI.
+    /// </summary>
+    public class PlaygroundTab
+    {
+        public PlaygroundTab(string query)
+        {
+            Query = query;
+        }
+
+        /// <summary>
+        /// Endpoint with which the tab will be initialized.
+        /// </summary>
+        [JsonPropertyName("endpoint")]
+        public string Endpoint { get; set; } = "/graphql";
+
+        /// <summary>
+        /// Query with which the tab will be initialized.
+        /// </summary>
+        [JsonPropertyName("query")]
+        public string Query { get; set; }
+
+        /// <summary>
+        /// The tab name.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Variables with which the tab will be initialized.
+        /// </summary>
+        [JsonPropertyName("variables")]
+        public string? Variables { get; set; }
+
+        /// <summary>
+        /// Responses with which the tab will be initialized.
+        /// </summary>
+        [JsonPropertyName("responses")]
+        public IEnumerable<string>? Responses { get; set; }
+
+        /// <summary>
+        /// HTTP headers with which the tab will be initialized.
+        /// </summary>
+        [JsonPropertyName("headers")]
+        public Dictionary<string, object>? Headers { get; set; }
+    }
+}

--- a/src/Ui.Playground/Ui.Playground.csproj
+++ b/src/Ui.Playground/Ui.Playground.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5;netcoreapp3.1</TargetFrameworks>
     <Description>GraphQL Playground integration for ASP.NET Core</Description>
     <PackageTags>GraphQL;Playground</PackageTags>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ui.Voyager/Internal/VoyagerPageModel.cs
+++ b/src/Ui.Voyager/Internal/VoyagerPageModel.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Server.Ui.Voyager.Internal
     // https://docs.microsoft.com/en-us/aspnet/core/mvc/razor-pages/?tabs=netcore-cli
     internal sealed class VoyagerPageModel
     {
-        private string _voyagerCSHtml;
+        private string? _voyagerCSHtml;
 
         private readonly VoyagerOptions _options;
 
@@ -21,7 +21,7 @@ namespace GraphQL.Server.Ui.Voyager.Internal
         {
             if (_voyagerCSHtml == null)
             {
-                using var manifestResourceStream = typeof(VoyagerPageModel).Assembly.GetManifestResourceStream("GraphQL.Server.Ui.Voyager.Internal.voyager.cshtml");
+                using var manifestResourceStream = _options.IndexStream(_options);
                 using var streamReader = new StreamReader(manifestResourceStream);
 
                 var headers = new Dictionary<string, object>
@@ -40,7 +40,7 @@ namespace GraphQL.Server.Ui.Voyager.Internal
                     .Replace("@Model.GraphQLEndPoint", _options.GraphQLEndPoint)
                     .Replace("@Model.Headers", JsonSerializer.Serialize<object>(headers));
 
-                _voyagerCSHtml = builder.ToString();
+                _voyagerCSHtml = _options.PostConfigure(_options, builder.ToString());
             }
 
             return _voyagerCSHtml;

--- a/src/Ui.Voyager/Ui.Voyager.csproj
+++ b/src/Ui.Voyager/Ui.Voyager.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5;netcoreapp3.1</TargetFrameworks>
     <Description>GraphQL Voyager integration for ASP.NET Core</Description>
     <PackageTags>GraphQL;Voyager</PackageTags>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ui.Voyager/VoyagerMiddleware.cs
+++ b/src/Ui.Voyager/VoyagerMiddleware.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Ui.Voyager
         /// <summary>
         /// The page model used to render Voyager.
         /// </summary>
-        private VoyagerPageModel _pageModel;
+        private VoyagerPageModel? _pageModel;
 
         /// <summary>
         /// Create a new <see cref="VoyagerMiddleware"/>
@@ -42,9 +42,7 @@ namespace GraphQL.Server.Ui.Voyager
             httpContext.Response.ContentType = "text/html";
             httpContext.Response.StatusCode = 200;
 
-            // Initialize page model if null
-            if (_pageModel == null)
-                _pageModel = new VoyagerPageModel(_options);
+            _pageModel ??= new VoyagerPageModel(_options);
 
             byte[] data = Encoding.UTF8.GetBytes(_pageModel.Render());
             return httpContext.Response.Body.WriteAsync(data, 0, data.Length);

--- a/src/Ui.Voyager/VoyagerOptions.cs
+++ b/src/Ui.Voyager/VoyagerOptions.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.AspNetCore.Http;
 
 namespace GraphQL.Server.Ui.Voyager
@@ -16,6 +18,17 @@ namespace GraphQL.Server.Ui.Voyager
         /// <summary>
         /// HTTP headers with which the Voyager will send introspection query.
         /// </summary>
-        public Dictionary<string, object> Headers { get; set; }
+        public Dictionary<string, object>? Headers { get; set; }
+
+        /// <summary>
+        /// Gets or sets a Stream function for retrieving the Voyager UI page.
+        /// </summary>
+        public Func<VoyagerOptions, Stream> IndexStream { get; set; } = _ => typeof(VoyagerOptions).Assembly
+            .GetManifestResourceStream("GraphQL.Server.Ui.Voyager.Internal.voyager.cshtml")!;
+
+        /// <summary>
+        /// Gets or sets a delegate that is called after all transformations of the Voyager UI page.
+        /// </summary>
+        public Func<VoyagerOptions, string, string> PostConfigure { get; set; } = (options, result) => result;
     }
 }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -26,6 +26,7 @@ namespace GraphQL.Server.Transports.AspNetCore
     {
         public GraphQLRequestDeserializationException(System.Exception inner) { }
         public GraphQLRequestDeserializationException(string message) { }
+        public GraphQLRequestDeserializationException(string message, System.Exception inner) { }
         public static GraphQL.Server.Transports.AspNetCore.GraphQLRequestDeserializationException InvalidFirstChar() { }
     }
     public class GraphQLRequestDeserializationResult

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -22,10 +22,17 @@ namespace GraphQL.Server.Transports.AspNetCore
         protected virtual System.Threading.Tasks.Task RequestExecutedAsync(in GraphQL.Server.Transports.AspNetCore.GraphQLRequestExecutionResult requestExecutionResult) { }
         protected virtual System.Threading.Tasks.Task RequestExecutingAsync(GraphQL.Server.GraphQLRequest request, int? indexInBatch = default) { }
     }
+    public class GraphQLRequestDeserializationException : System.Exception
+    {
+        public GraphQLRequestDeserializationException(System.Exception inner) { }
+        public GraphQLRequestDeserializationException(string message) { }
+        public static GraphQL.Server.Transports.AspNetCore.GraphQLRequestDeserializationException InvalidFirstChar() { }
+    }
     public class GraphQLRequestDeserializationResult
     {
         public GraphQLRequestDeserializationResult() { }
         public GraphQL.Server.GraphQLRequest[] Batch { get; set; }
+        public GraphQL.Server.Transports.AspNetCore.GraphQLRequestDeserializationException Exception { get; set; }
         public bool IsSuccessful { get; set; }
         public GraphQL.Server.GraphQLRequest Single { get; set; }
     }

--- a/tests/ApiApprovalTests/GraphQL.Server.Ui.Altair.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Ui.Altair.approved.txt
@@ -9,7 +9,9 @@ namespace GraphQL.Server.Ui.Altair
     {
         public AltairOptions() { }
         public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
-        public System.Collections.Generic.Dictionary<string, string> Headers { get; set; }
+        public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
+        public System.Func<GraphQL.Server.Ui.Altair.AltairOptions, System.IO.Stream> IndexStream { get; set; }
+        public System.Func<GraphQL.Server.Ui.Altair.AltairOptions, string, string> PostConfigure { get; set; }
         public Microsoft.AspNetCore.Http.PathString SubscriptionsEndPoint { get; set; }
     }
 }

--- a/tests/ApiApprovalTests/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -9,7 +9,9 @@ namespace GraphQL.Server.Ui.GraphiQL
     {
         public GraphiQLOptions() { }
         public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
-        public System.Collections.Generic.Dictionary<string, string> Headers { get; set; }
+        public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
+        public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, System.IO.Stream> IndexStream { get; set; }
+        public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, string, string> PostConfigure { get; set; }
         public Microsoft.AspNetCore.Http.PathString SubscriptionsEndPoint { get; set; }
     }
 }

--- a/tests/ApiApprovalTests/GraphQL.Server.Ui.Playground.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Ui.Playground.approved.txt
@@ -25,11 +25,13 @@ namespace GraphQL.Server.Ui.Playground
         public int EditorFontSize { get; set; }
         public bool EditorReuseHeaders { get; set; }
         public GraphQL.Server.Ui.Playground.EditorTheme EditorTheme { get; set; }
-        public System.Collections.Generic.Dictionary<string, object> GraphQLConfig { get; set; }
+        public System.Collections.Generic.Dictionary<string, object>? GraphQLConfig { get; set; }
         public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
-        public System.Collections.Generic.Dictionary<string, object> Headers { get; set; }
+        public System.Collections.Generic.Dictionary<string, object>? Headers { get; set; }
         public bool HideTracingResponse { get; set; }
+        public System.Func<GraphQL.Server.Ui.Playground.PlaygroundOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Collections.Generic.Dictionary<string, object> PlaygroundSettings { get; set; }
+        public System.Func<GraphQL.Server.Ui.Playground.PlaygroundOptions, string, string> PostConfigure { get; set; }
         public int PrettierPrintWidth { get; set; }
         public int PrettierTabWidth { get; set; }
         public bool PrettierUseTabs { get; set; }

--- a/tests/ApiApprovalTests/GraphQL.Server.Ui.Voyager.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Ui.Voyager.approved.txt
@@ -9,7 +9,9 @@ namespace GraphQL.Server.Ui.Voyager
     {
         public VoyagerOptions() { }
         public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
-        public System.Collections.Generic.Dictionary<string, object> Headers { get; set; }
+        public System.Collections.Generic.Dictionary<string, object>? Headers { get; set; }
+        public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, System.IO.Stream> IndexStream { get; set; }
+        public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, string, string> PostConfigure { get; set; }
     }
 }
 namespace Microsoft.AspNetCore.Builder

--- a/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
+++ b/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\..\src\Authorization.AspNetCore\Authorization.AspNetCore.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.13" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" Condition="'$(TargetFramework)' == 'net5'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.19" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" Condition="'$(TargetFramework)' == 'net5'" />
   </ItemGroup>
 
 </Project>

--- a/tests/Samples.Server.Tests/ResponseTests.cs
+++ b/tests/Samples.Server.Tests/ResponseTests.cs
@@ -109,6 +109,15 @@ namespace Samples.Server.Tests
                 new StringContent("Oops", Encoding.UTF8, "application/json"),
                 HttpStatusCode.BadRequest,
                 "Body text could not be parsed. Body text should start with '{' for normal graphql query or with '[' for batched query."
+            },
+
+            // GET with an empty QueryString should be a bad request
+            new object[]
+            {
+                HttpMethod.Get,
+                null,
+                HttpStatusCode.BadRequest,
+                "GraphQL query is missing."
             }
         };
 

--- a/tests/Samples.Server.Tests/ResponseTests.cs
+++ b/tests/Samples.Server.Tests/ResponseTests.cs
@@ -90,15 +90,12 @@ namespace Samples.Server.Tests
                 "Invalid HTTP method. Only GET and POST are supported. See: http://graphql.org/learn/serving-over-http/.",
             },
 
-            // POST with an invalid mime type should be a bad request
-            // I couldn't manage to hit this, asp.net core kept rejecting it too early
-
-            // POST with unsupported mime type should be a bad request
+            // POST with unsupported mime type should be a unsupported media type
             new object[]
             {
                 HttpMethod.Post,
                 new StringContent(Serializer.ToJson(new GraphQLRequest { Query = "query { __schema { queryType { name } } }" }), Encoding.UTF8, "something/unknown"),
-                HttpStatusCode.BadRequest,
+                HttpStatusCode.UnsupportedMediaType,
                 "Invalid 'Content-Type' header: non-supported media type. Must be of 'application/json', 'application/graphql' or 'application/x-www-form-urlencoded'. See: http://graphql.org/learn/serving-over-http/."
             },
 
@@ -108,7 +105,16 @@ namespace Samples.Server.Tests
                 HttpMethod.Post,
                 new StringContent("Oops", Encoding.UTF8, "application/json"),
                 HttpStatusCode.BadRequest,
-                "Body text could not be parsed. Body text should start with '{' for normal graphql query or with '[' for batched query."
+                "JSON body text could not be parsed. Body text should start with '{' for normal graphql query or with '[' for batched query."
+            },
+
+            // POST with JSON mime type that is invalid JSON should be a bad request
+            new object[]
+            {
+                HttpMethod.Post,
+                new StringContent("{oops}", Encoding.UTF8, "application/json"),
+                HttpStatusCode.BadRequest,
+                "JSON body text could not be parsed. 'o' is an invalid start of a property name. Expected a '\"'. Path: $ | LineNumber: 0 | BytePositionInLine: 1."
             },
 
             // GET with an empty QueryString should be a bad request

--- a/tests/Samples.Server.Tests/ShouldBeExtensions.cs
+++ b/tests/Samples.Server.Tests/ShouldBeExtensions.cs
@@ -53,6 +53,6 @@ namespace Samples.Server.Tests
             actualJson.ShouldBe(expectedJson);
         }
 
-        private static string NormalizeJson(this string json) => json.Replace("'", @"\u0027");
+        private static string NormalizeJson(this string json) => json.Replace("'", @"\u0027").Replace("\"", @"\u0022");
     }
 }


### PR DESCRIPTION
Hello,

I recently had to add tabs by default on the playground and couldn't find an easy way to do this.
This will allow the Playground UI to show the tabs added by default in the playground options setup.

The result:

![image](https://user-images.githubusercontent.com/37178554/145323228-7d12447b-9b32-4020-8c47-44c4e4e2573a.png)

Thank you.