### PR TITLE
Make WebSocketConnection.Connect virtual

### DIFF
--- a/src/Transports.Subscriptions.WebSockets/WebSocketConnection.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketConnection.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Transports.WebSockets
             _server = subscriptionServer;
         }
 
-        public async Task Connect()
+        public virtual async Task Connect()
         {
             try
             {

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
@@ -21,7 +21,7 @@ namespace GraphQL.Server.Transports.WebSockets
     public class WebSocketConnection
     {
         public WebSocketConnection(GraphQL.Server.Transports.WebSockets.WebSocketTransport transport, GraphQL.Server.Transports.Subscriptions.Abstractions.SubscriptionServer subscriptionServer) { }
-        public System.Threading.Tasks.Task Connect() { }
+        public virtual System.Threading.Tasks.Task Connect() { }
     }
     public class WebSocketConnectionFactory<TSchema> : GraphQL.Server.Transports.WebSockets.IWebSocketConnectionFactory<TSchema>
         where TSchema : GraphQL.Types.ISchema


### PR DESCRIPTION
I'm trying to write an alternate implementation of `IWebSocketConnectionFactory<TSchema>` and cannot do so without this change.

For the next major version, `IWebSocketConnectionFactory.CreateConnection` should return an interface instead of a class.