### PR TITLE
Dispose all subscriptions when connection broken

### DIFF
--- a/src/Transports.Subscriptions.Abstractions/IServerOperations.cs
+++ b/src/Transports.Subscriptions.Abstractions/IServerOperations.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 
 namespace GraphQL.Server.Transports.Subscriptions.Abstractions
 {
-    public interface IServerOperations
+    public interface IServerOperations //todo: inherit IDisposable
     {
         Task Terminate();
 

--- a/src/Transports.Subscriptions.Abstractions/ISubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/ISubscriptionManager.cs
@@ -6,7 +6,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     /// <summary>
     ///     Manages operation execution and manages created subscriptions
     /// </summary>
-    public interface ISubscriptionManager : IEnumerable<Subscription>
+    public interface ISubscriptionManager : IEnumerable<Subscription> //todo: add IDisposable
     {
         /// <summary>
         ///     Execute operation and subscribe if subscription

--- a/src/Transports.Subscriptions.Abstractions/Subscription.cs
+++ b/src/Transports.Subscriptions.Abstractions/Subscription.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     /// <summary>
     ///     Internal observer of the subscription
     /// </summary>
-    public class Subscription : IObserver<ExecutionResult>
+    public class Subscription : IObserver<ExecutionResult>, IDisposable
     {
         private readonly Action<Subscription> _completed;
         private readonly ILogger<Subscription> _logger;
@@ -79,6 +79,11 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             var stream = result.Streams.Values.Single();
             _unsubscribe = stream.Synchronize().Subscribe(this);
             _logger.LogDebug("Subscription: {subscriptionId} subscribed", Id);
+        }
+
+        public void Dispose()
+        {
+            _unsubscribe.Dispose();
         }
     }
 }

--- a/src/Transports.Subscriptions.Abstractions/Subscription.cs
+++ b/src/Transports.Subscriptions.Abstractions/Subscription.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Reactive.Linq;
@@ -12,16 +14,16 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     /// </summary>
     public class Subscription : IObserver<ExecutionResult>, IDisposable
     {
-        private readonly Action<Subscription> _completed;
+        private Action<Subscription>? _completed;
         private readonly ILogger<Subscription> _logger;
-        private readonly IWriterPipeline _writer;
-        private IDisposable _unsubscribe;
+        private IWriterPipeline? _writer;
+        private IDisposable? _unsubscribe;
 
         public Subscription(string id,
             OperationMessagePayload payload,
             SubscriptionExecutionResult result,
             IWriterPipeline writer,
-            Action<Subscription> completed,
+            Action<Subscription>? completed,
             ILogger<Subscription> logger)
         {
             _writer = writer;
@@ -40,7 +42,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public void OnCompleted()
         {
             _logger.LogDebug("Subscription: {subscriptionId} completing", Id);
-            _writer.Post(new OperationMessage
+            _writer?.Post(new OperationMessage
             {
                 Type = MessageType.GQL_COMPLETE,
                 Id = Id
@@ -48,6 +50,9 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
 
             _completed?.Invoke(this);
             _unsubscribe?.Dispose();
+            _completed = null;
+            _writer = null;
+            _unsubscribe = null;
         }
 
         public void OnError(Exception error) => throw new NotImplementedException();
@@ -55,7 +60,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public void OnNext(ExecutionResult value)
         {
             _logger.LogDebug("Subscription: {subscriptionId} got data", Id);
-            _writer.Post(new OperationMessage
+            _writer?.Post(new OperationMessage
             {
                 Type = MessageType.GQL_DATA,
                 Id = Id,
@@ -66,24 +71,31 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public Task UnsubscribeAsync()
         {
             _logger.LogDebug("Subscription: {subscriptionId} unsubscribing", Id);
-            _unsubscribe.Dispose();
-            return _writer.SendAsync(new OperationMessage
+            _unsubscribe?.Dispose();
+            var writer = _writer;
+            _writer = null;
+            _unsubscribe = null;
+            _completed = null;
+            return writer?.SendAsync(new OperationMessage
             {
                 Type = MessageType.GQL_COMPLETE,
                 Id = Id
-            });
+            }) ?? Task.CompletedTask;
         }
 
         private void Subscribe(SubscriptionExecutionResult result)
         {
-            var stream = result.Streams.Values.Single();
+            var stream = result.Streams!.Values.Single();
             _unsubscribe = stream.Synchronize().Subscribe(this);
             _logger.LogDebug("Subscription: {subscriptionId} subscribed", Id);
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
-            _unsubscribe.Dispose();
+            _unsubscribe?.Dispose();
+            _unsubscribe = null;
+            _writer = null;
+            _completed = null;
         }
     }
 }

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
@@ -147,7 +147,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             return null;
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             _disposed = true;
             while (_subscriptions.Count > 0)

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
@@ -159,8 +159,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
                             _logger.LogError($"Failed to dispose subscription '{subscriptionPair.Key}': ${ex}");
                         }
                     }
-
-                }
+]                }
             }
         }
     }

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
@@ -77,9 +77,6 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             OperationMessagePayload payload,
             MessageHandlingContext context)
         {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(SubscriptionManager));
-
             var writer = context.Writer;
             _logger.LogDebug("Executing operation: {operationName} query: {query}",
                 payload.OperationName,

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,7 +11,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     ///     Subscription server
     ///     Acts as a message pump reading, handling and writing messages
     /// </summary>
-    public class SubscriptionServer : IServerOperations
+    public class SubscriptionServer : IServerOperations, IDisposable
     {
         private readonly ILogger<SubscriptionServer> _logger;
         private readonly IEnumerable<IOperationMessageListener> _messageListeners;
@@ -136,5 +137,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             TransportWriter = Transport.Writer;
             _logger.LogDebug("Writer pipeline created");
         }
+
+        public void Dispose() => (Subscriptions as IDisposable)?.Dispose();
     }
 }

--- a/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionServer.cs
@@ -138,6 +138,6 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             _logger.LogDebug("Writer pipeline created");
         }
 
-        public void Dispose() => (Subscriptions as IDisposable)?.Dispose();
+        public virtual void Dispose() => (Subscriptions as IDisposable)?.Dispose();
     }
 }

--- a/src/Transports.Subscriptions.WebSockets/WebSocketConnection.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketConnection.cs
@@ -24,7 +24,7 @@ namespace GraphQL.Server.Transports.WebSockets
             await _transport.CloseAsync();
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             _server.Dispose();
             _transport.Dispose();

--- a/src/Transports.Subscriptions.WebSockets/WebSocketConnection.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketConnection.cs
@@ -26,6 +26,7 @@ namespace GraphQL.Server.Transports.WebSockets
 
         public void Dispose()
         {
+            _server.Dispose();
             _transport.Dispose();
         }
     }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
@@ -98,10 +98,10 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     }
     public class Subscription : System.IDisposable, System.IObserver<GraphQL.ExecutionResult>
     {
-        public Subscription(string id, GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload payload, GraphQL.Subscription.SubscriptionExecutionResult result, GraphQL.Server.Transports.Subscriptions.Abstractions.IWriterPipeline writer, System.Action<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> completed, Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> logger) { }
+        public Subscription(string id, GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload payload, GraphQL.Subscription.SubscriptionExecutionResult result, GraphQL.Server.Transports.Subscriptions.Abstractions.IWriterPipeline writer, System.Action<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription>? completed, Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> logger) { }
         public string Id { get; }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload OriginalPayload { get; }
-        public void Dispose() { }
+        public virtual void Dispose() { }
         public void OnCompleted() { }
         public void OnError(System.Exception error) { }
         public void OnNext(GraphQL.ExecutionResult value) { }
@@ -111,7 +111,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     {
         public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription this[string id] { get; }
-        public void Dispose() { }
+        public virtual void Dispose() { }
         public System.Collections.Generic.IEnumerator<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> GetEnumerator() { }
         public System.Threading.Tasks.Task SubscribeOrExecuteAsync(string id, GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload payload, GraphQL.Server.Transports.Subscriptions.Abstractions.MessageHandlingContext context) { }
         public System.Threading.Tasks.Task UnsubscribeAsync(string id) { }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
@@ -123,7 +123,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public GraphQL.Server.Transports.Subscriptions.Abstractions.IMessageTransport Transport { get; }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.IReaderPipeline TransportReader { get; set; }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.IWriterPipeline TransportWriter { get; set; }
-        public void Dispose() { }
+        public virtual void Dispose() { }
         public System.Threading.Tasks.Task OnConnect() { }
         public System.Threading.Tasks.Task OnDisconnect() { }
         public System.Threading.Tasks.Task Terminate() { }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
@@ -96,31 +96,34 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public System.Threading.Tasks.Task BeforeHandleAsync(GraphQL.Server.Transports.Subscriptions.Abstractions.MessageHandlingContext context) { }
         public System.Threading.Tasks.Task HandleAsync(GraphQL.Server.Transports.Subscriptions.Abstractions.MessageHandlingContext context) { }
     }
-    public class Subscription : System.IObserver<GraphQL.ExecutionResult>
+    public class Subscription : System.IDisposable, System.IObserver<GraphQL.ExecutionResult>
     {
         public Subscription(string id, GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload payload, GraphQL.Subscription.SubscriptionExecutionResult result, GraphQL.Server.Transports.Subscriptions.Abstractions.IWriterPipeline writer, System.Action<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> completed, Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> logger) { }
         public string Id { get; }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload OriginalPayload { get; }
+        public void Dispose() { }
         public void OnCompleted() { }
         public void OnError(System.Exception error) { }
         public void OnNext(GraphQL.ExecutionResult value) { }
         public System.Threading.Tasks.Task UnsubscribeAsync() { }
     }
-    public class SubscriptionManager : GraphQL.Server.Transports.Subscriptions.Abstractions.ISubscriptionManager, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription>, System.Collections.IEnumerable
+    public class SubscriptionManager : GraphQL.Server.Transports.Subscriptions.Abstractions.ISubscriptionManager, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription>, System.Collections.IEnumerable, System.IDisposable
     {
         public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription this[string id] { get; }
+        public void Dispose() { }
         public System.Collections.Generic.IEnumerator<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> GetEnumerator() { }
         public System.Threading.Tasks.Task SubscribeOrExecuteAsync(string id, GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload payload, GraphQL.Server.Transports.Subscriptions.Abstractions.MessageHandlingContext context) { }
         public System.Threading.Tasks.Task UnsubscribeAsync(string id) { }
     }
-    public class SubscriptionServer : GraphQL.Server.Transports.Subscriptions.Abstractions.IServerOperations
+    public class SubscriptionServer : GraphQL.Server.Transports.Subscriptions.Abstractions.IServerOperations, System.IDisposable
     {
         public SubscriptionServer(GraphQL.Server.Transports.Subscriptions.Abstractions.IMessageTransport transport, GraphQL.Server.Transports.Subscriptions.Abstractions.ISubscriptionManager subscriptions, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.IOperationMessageListener> messageListeners, Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.Subscriptions.Abstractions.SubscriptionServer> logger) { }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.ISubscriptionManager Subscriptions { get; }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.IMessageTransport Transport { get; }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.IReaderPipeline TransportReader { get; set; }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.IWriterPipeline TransportWriter { get; set; }
+        public void Dispose() { }
         public System.Threading.Tasks.Task OnConnect() { }
         public System.Threading.Tasks.Task OnDisconnect() { }
         public System.Threading.Tasks.Task Terminate() { }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
@@ -24,7 +24,7 @@ namespace GraphQL.Server.Transports.WebSockets
     {
         public WebSocketConnection(GraphQL.Server.Transports.WebSockets.WebSocketTransport transport, GraphQL.Server.Transports.Subscriptions.Abstractions.SubscriptionServer subscriptionServer) { }
         public virtual System.Threading.Tasks.Task Connect() { }
-        public void Dispose() { }
+        public virtual void Dispose() { }
     }
     public class WebSocketConnectionFactory<TSchema> : GraphQL.Server.Transports.WebSockets.IWebSocketConnectionFactory<TSchema>
         where TSchema : GraphQL.Types.ISchema


### PR DESCRIPTION
This code ensures that all existing subscriptions are disposed when the connection is disposed.  Of course if the shutdown is clean then there should be no difference. Also it prevents additional subscriptions from connecting after the connection is disposed. Also the subscription releases all held objects upon disposal - so in case the IObserverable does not properly release the observer after it is disposed, at least there won't be any held handles to the underlying WebSocket.