### PR TITLE
Provide service provider to subscription execution

### DIFF
--- a/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
+++ b/src/Transports.Subscriptions.Abstractions/SubscriptionManager.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using GraphQL.NewtonsoftJson;
 using GraphQL.Server.Transports.Subscriptions.Abstractions.Internal;
 using GraphQL.Subscription;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace GraphQL.Server.Transports.Subscriptions.Abstractions
@@ -17,17 +18,23 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         private readonly IGraphQLExecuter _executer;
 
         private readonly ILogger<SubscriptionManager> _logger;
+        private readonly IServiceScopeFactory _serviceScopeFactory;
         private readonly ILoggerFactory _loggerFactory;
         private volatile bool _disposed;
 
-        private readonly ConcurrentDictionary<string, Subscription> _subscriptions =
-            new ConcurrentDictionary<string, Subscription>();
+        private readonly ConcurrentDictionary<string, Subscription> _subscriptions = new();
 
         public SubscriptionManager(IGraphQLExecuter executer, ILoggerFactory loggerFactory)
+            : this(executer, loggerFactory, null)
+        {
+        }
+
+        public SubscriptionManager(IGraphQLExecuter executer, ILoggerFactory loggerFactory, IServiceScopeFactory serviceScopeFactory)
         {
             _executer = executer;
             _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<SubscriptionManager>();
+            _serviceScopeFactory = serviceScopeFactory;
         }
 
         public Subscription this[string id] => _subscriptions[id];
@@ -82,13 +89,30 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
                 payload.OperationName,
                 payload.Query);
 
-            var result = await _executer.ExecuteAsync(
-                payload.OperationName,
-                payload.Query,
-                payload.Variables?.ToInputs(),
-                context,
-                null // TODO: find later a better way to specify services
-            ).ConfigureAwait(false);
+            ExecutionResult result;
+            if (_serviceScopeFactory != null)
+            {
+                using (var scope = _serviceScopeFactory.CreateScope())
+                {
+                    result = await _executer.ExecuteAsync(
+                        payload.OperationName,
+                        payload.Query,
+                        payload.Variables?.ToInputs(),
+                        context,
+                        scope.ServiceProvider
+                    ).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                result = await _executer.ExecuteAsync(
+                    payload.OperationName,
+                    payload.Query,
+                    payload.Variables?.ToInputs(),
+                    context,
+                    null
+                ).ConfigureAwait(false);
+            }
 
             if (result.Errors != null && result.Errors.Any())
             {

--- a/src/Transports.Subscriptions.WebSockets/WebSocketConnectionFactory.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketConnectionFactory.cs
@@ -50,7 +50,11 @@ namespace GraphQL.Server.Transports.WebSockets
             _logger.LogDebug("Creating server for connection {connectionId}", connectionId);
 
             var transport = new WebSocketTransport(socket, _documentWriter);
-            var manager = new SubscriptionManager(_executer, _loggerFactory, _serviceScopeFactory);
+            var manager = _serviceScopeFactory != null
+                ? new SubscriptionManager(_executer, _loggerFactory, _serviceScopeFactory)
+#pragma warning disable CS0612 // Type or member is obsolete
+                : new SubscriptionManager(_executer, _loggerFactory);
+#pragma warning restore CS0612 // Type or member is obsolete
             var server = new SubscriptionServer(
                 transport,
                 manager,

--- a/src/Transports.Subscriptions.WebSockets/WebSocketConnectionFactory.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebSocketConnectionFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.WebSockets;
 using GraphQL.Server.Transports.Subscriptions.Abstractions;
@@ -17,7 +18,9 @@ namespace GraphQL.Server.Transports.WebSockets
         private readonly IDocumentWriter _documentWriter;
         private readonly IServiceScopeFactory _serviceScopeFactory;
 
-        public WebSocketConnectionFactory(ILogger<WebSocketConnectionFactory<TSchema>> logger,
+        [Obsolete]
+        public WebSocketConnectionFactory(
+            ILogger<WebSocketConnectionFactory<TSchema>> logger,
             ILoggerFactory loggerFactory,
             IGraphQLExecuter<TSchema> executer,
             IEnumerable<IOperationMessageListener> messageListeners,
@@ -26,7 +29,8 @@ namespace GraphQL.Server.Transports.WebSockets
         {
         }
 
-        public WebSocketConnectionFactory(ILogger<WebSocketConnectionFactory<TSchema>> logger,
+        public WebSocketConnectionFactory(
+            ILogger<WebSocketConnectionFactory<TSchema>> logger,
             ILoggerFactory loggerFactory,
             IGraphQLExecuter<TSchema> executer,
             IEnumerable<IOperationMessageListener> messageListeners,

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
@@ -110,6 +110,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     public class SubscriptionManager : GraphQL.Server.Transports.Subscriptions.Abstractions.ISubscriptionManager, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription>, System.Collections.IEnumerable, System.IDisposable
     {
         public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
+        public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory) { }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription this[string id] { get; }
         public virtual void Dispose() { }
         public System.Collections.Generic.IEnumerator<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> GetEnumerator() { }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
@@ -109,6 +109,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     }
     public class SubscriptionManager : GraphQL.Server.Transports.Subscriptions.Abstractions.ISubscriptionManager, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription>, System.Collections.IEnumerable, System.IDisposable
     {
+        [System.Obsolete]
         public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory) { }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription this[string id] { get; }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
@@ -29,6 +29,7 @@ namespace GraphQL.Server.Transports.WebSockets
     public class WebSocketConnectionFactory<TSchema> : GraphQL.Server.Transports.WebSockets.IWebSocketConnectionFactory<TSchema>
         where TSchema : GraphQL.Types.ISchema
     {
+        [System.Obsolete]
         public WebSocketConnectionFactory(Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.WebSockets.WebSocketConnectionFactory<TSchema>> logger, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, GraphQL.Server.IGraphQLExecuter<TSchema> executer, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.IOperationMessageListener> messageListeners, GraphQL.IDocumentWriter documentWriter) { }
         public WebSocketConnectionFactory(Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.WebSockets.WebSocketConnectionFactory<TSchema>> logger, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, GraphQL.Server.IGraphQLExecuter<TSchema> executer, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.IOperationMessageListener> messageListeners, GraphQL.IDocumentWriter documentWriter, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory) { }
         public GraphQL.Server.Transports.WebSockets.WebSocketConnection CreateConnection(System.Net.WebSockets.WebSocket socket, string connectionId) { }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
@@ -30,6 +30,7 @@ namespace GraphQL.Server.Transports.WebSockets
         where TSchema : GraphQL.Types.ISchema
     {
         public WebSocketConnectionFactory(Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.WebSockets.WebSocketConnectionFactory<TSchema>> logger, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, GraphQL.Server.IGraphQLExecuter<TSchema> executer, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.IOperationMessageListener> messageListeners, GraphQL.IDocumentWriter documentWriter) { }
+        public WebSocketConnectionFactory(Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.WebSockets.WebSocketConnectionFactory<TSchema>> logger, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, GraphQL.Server.IGraphQLExecuter<TSchema> executer, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.IOperationMessageListener> messageListeners, GraphQL.IDocumentWriter documentWriter, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory) { }
         public GraphQL.Server.Transports.WebSockets.WebSocketConnection CreateConnection(System.Net.WebSockets.WebSocket socket, string connectionId) { }
     }
     public class WebSocketReaderPipeline : GraphQL.Server.Transports.Subscriptions.Abstractions.IReaderPipeline


### PR DESCRIPTION
Fixes #690 

The new `IGraphQLBuilder` extension methods rely on the service provider to be passed to the document executer.  Without it, many of the extension methods will not function as intended.

This PR creates a scope for the duration of the execution.  The scope and acquired services are disposed immediately after execution completes.  In this way, there are no unintended extremely-long lifetimes of scoped objects.  Also, since execution only occurs at the start of a subscription, there is no need to hold the scope indefinitely.  Services that provide the `IObservable` instances must still be singletons, as is required now, because if they were scoped then (a) they would not share the event stream data across multiple instances (b) they would be disposed when the execution is disposed.