### PR TITLE
[Experimental] Added support for graphql-transport-ws

### DIFF
--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -36,6 +36,8 @@ namespace GraphQL.Samples.Server
             MicrosoftDI.GraphQLBuilderExtensions.AddGraphQL(services)
                 .AddServer(true)
                 .AddSchema<ChatSchema>()
+                // Required for subscriptions
+                .AddDocumentExecuter<SubscriptionDocumentExecuter>()
                 .ConfigureExecution(options =>
                 {
                     options.EnableMetrics = Environment.IsDevelopment();
@@ -58,7 +60,8 @@ namespace GraphQL.Samples.Server
 
             app.UseWebSockets();
 
-            app.UseGraphQLWebSockets<ChatSchema>();
+            // Note: the new GraphQLTransportWs is not compatible with Playground
+            app.UseGraphQLWebSockets<ChatSchema>(subprotocol: GraphQL.Server.Transports.WebSockets.WebSocketsSubprotocol.GraphQLWs);
             app.UseGraphQL<ChatSchema, GraphQLHttpMiddlewareWithLogs<ChatSchema>>();
 
             app.UseGraphQLPlayground(new PlaygroundOptions

--- a/src/Transports.AspNetCore.SystemTextJson/OperationMessageConverter.cs
+++ b/src/Transports.AspNetCore.SystemTextJson/OperationMessageConverter.cs
@@ -20,14 +20,20 @@ namespace GraphQL.Server
         {
             writer.WriteStartObject();
 
-            writer.WritePropertyName("id");
-            writer.WriteStringValue(message.Id);
+            if (message.Id != null)
+            {
+                writer.WritePropertyName("id");
+                writer.WriteStringValue(message.Id);
+            }
 
             writer.WritePropertyName("type");
             writer.WriteStringValue(message.Type);
 
-            writer.WritePropertyName("payload");
-            JsonSerializer.Serialize(writer, message.Payload, options);
+            if (message.Payload != null)
+            {
+                writer.WritePropertyName("payload");
+                JsonSerializer.Serialize(writer, message.Payload, options);
+            }
 
             writer.WriteEndObject();
         }

--- a/src/Transports.Subscriptions.Abstractions/MessageType.cs
+++ b/src/Transports.Subscriptions.Abstractions/MessageType.cs
@@ -7,7 +7,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     ///     https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
     /// </summary>
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public class MessageType
+    public partial class MessageType
     {
         /// <summary>
         ///     Client sends this message after plain websocket connection to start the communication with the server
@@ -89,5 +89,39 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         ///     id: string : operation id
         /// </summary>
         public const string GQL_STOP = "stop"; // Client -> Server
+    }
+
+    /// <summary>
+    ///     New GraphQL over WebSocket Protocol message types defined in
+    ///     https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
+    /// </summary> 
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public partial class MessageType
+    {
+        /// <summary>
+        /// Requests an operation specified in the message payload. This message provides a unique ID field to connect published messages to the operation requested by this message.
+        /// If there is already an active subscriber for an operation matching the provided ID, regardless of the operation type, the server must close the socket immediately with the event 4409: Subscriber for <unique-operation-id> already exists.
+        /// </summary>
+        public const string GQL_SUBSRIBE = "subscribe"; // Client -> Server
+
+        /// <summary>
+        /// Operation execution result(s) from the source stream created by the binding Subscribe message. After all results have been emitted, the Complete message will follow indicating stream completion.
+        /// </summary>
+        public const string GQL_NEXT = "next"; // Server -> Client
+
+        /// <summary>
+        /// Useful for detecting failed connections, displaying latency metrics or other types of network probing.
+        /// A Pong must be sent in response from the receiving party as soon as possible.
+        /// The Ping message can be sent at any time within the established socket.
+        /// The optional payload field can be used to transfer additional details about the ping.
+        /// </summary>
+        public const string GQL_PING = "ping"; // Bidirectional
+
+        /// <summary>
+        /// The response to the Ping message. Must be sent as soon as the Ping message is received.
+        /// The Pong message can be sent at any time within the established socket.Furthermore, the Pong message may even be sent unsolicited as an unidirectional heartbeat.
+        /// The optional payload field can be used to transfer additional details about the pong.
+        /// </summary>
+        public const string GQL_PONG = "pong"; // Bidirectional
     }
 }

--- a/src/Transports.Subscriptions.Abstractions/Subscription.cs
+++ b/src/Transports.Subscriptions.Abstractions/Subscription.cs
@@ -18,16 +18,19 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         private readonly ILogger<Subscription> _logger;
         private IWriterPipeline? _writer;
         private IDisposable? _unsubscribe;
+        private readonly string _dataEventType;
 
         public Subscription(string id,
             OperationMessagePayload payload,
             SubscriptionExecutionResult result,
             IWriterPipeline writer,
             Action<Subscription>? completed,
+            string dataEventType,
             ILogger<Subscription> logger)
         {
             _writer = writer;
             _completed = completed;
+            _dataEventType = dataEventType;
             _logger = logger;
             Id = id;
             OriginalPayload = payload;
@@ -62,7 +65,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
             _logger.LogDebug("Subscription: {subscriptionId} got data", Id);
             _writer?.Post(new OperationMessage
             {
-                Type = MessageType.GQL_DATA,
+                Type = _dataEventType,
                 Id = Id,
                 Payload = value
             });

--- a/src/Transports.Subscriptions.WebSockets/Extensions/GraphQLWebSocketsApplicationBuilderExtensions.cs
+++ b/src/Transports.Subscriptions.WebSockets/Extensions/GraphQLWebSocketsApplicationBuilderExtensions.cs
@@ -16,12 +16,14 @@ namespace Microsoft.AspNetCore.Builder
         /// <typeparam name="TSchema">The implementation of <see cref="ISchema"/> to use</typeparam>
         /// <param name="builder">The application builder</param>
         /// <param name="path">The path to the GraphQL web socket endpoint which defaults to '/graphql'</param>
+        /// <param name="subprotocol">The subprotocol of websockets</param>
         /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
         public static IApplicationBuilder UseGraphQLWebSockets<TSchema>(
             this IApplicationBuilder builder,
-            string path = "/graphql")
+            string path = "/graphql",
+            WebSocketsSubprotocol subprotocol = WebSocketsSubprotocol.GraphQLWs)
             where TSchema : ISchema
-            => builder.UseGraphQLWebSockets<TSchema>(new PathString(path));
+            => builder.UseGraphQLWebSockets<TSchema>(new PathString(path), subprotocol);
 
         /// <summary>
         /// Add GraphQL web sockets middleware to the request pipeline
@@ -29,15 +31,17 @@ namespace Microsoft.AspNetCore.Builder
         /// <typeparam name="TSchema">The implementation of <see cref="ISchema"/> to use</typeparam>
         /// <param name="builder">The application builder</param>
         /// <param name="path">The path to the GraphQL endpoint</param>
+        /// <param name="subprotocol">The subprotocol of websockets</param>
         /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
         public static IApplicationBuilder UseGraphQLWebSockets<TSchema>(
             this IApplicationBuilder builder,
-            PathString path)
+            PathString path,
+            WebSocketsSubprotocol subprotocol = WebSocketsSubprotocol.GraphQLWs)
             where TSchema : ISchema
         {
             return builder.UseWhen(
                 context => context.Request.Path.StartsWithSegments(path, out var remaining) && string.IsNullOrEmpty(remaining),
-                b => b.UseMiddleware<GraphQLWebSocketsMiddleware<TSchema>>());
+                b => b.UseMiddleware<GraphQLWebSocketsMiddleware<TSchema>>(subprotocol));
         }
     }
 }

--- a/src/Transports.Subscriptions.WebSockets/IWebSocketConnectionFactory.cs
+++ b/src/Transports.Subscriptions.WebSockets/IWebSocketConnectionFactory.cs
@@ -6,6 +6,6 @@ namespace GraphQL.Server.Transports.WebSockets
     public interface IWebSocketConnectionFactory<TSchema>
         where TSchema : ISchema
     {
-        WebSocketConnection CreateConnection(WebSocket socket, string connectionId);
+        WebSocketConnection CreateConnection(WebSocket socket, string connectionId, WebSocketsSubprotocol subprotocol);
     }
 }

--- a/src/Transports.Subscriptions.WebSockets/WebsocketSubprotocol.cs
+++ b/src/Transports.Subscriptions.WebSockets/WebsocketSubprotocol.cs
@@ -1,0 +1,17 @@
+namespace GraphQL.Server.Transports.WebSockets
+{
+    public enum WebSocketsSubprotocol
+    {
+        /// <summary>
+        /// Old Protocol
+        /// https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
+        /// </summary>
+        GraphQLWs,
+
+        /// <summary>
+        /// New Protocol
+        /// https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
+        /// </summary>
+        GraphQLTransportWs,
+    }
+}

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.Abstractions.approved.txt
@@ -66,8 +66,12 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         public const string GQL_CONNECTION_TERMINATE = "connection_terminate";
         public const string GQL_DATA = "data";
         public const string GQL_ERROR = "error";
+        public const string GQL_NEXT = "next";
+        public const string GQL_PING = "ping";
+        public const string GQL_PONG = "pong";
         public const string GQL_START = "start";
         public const string GQL_STOP = "stop";
+        public const string GQL_SUBSRIBE = "subscribe";
         public MessageType() { }
     }
     [System.Runtime.Serialization.DataContract]
@@ -98,7 +102,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     }
     public class Subscription : System.IDisposable, System.IObserver<GraphQL.ExecutionResult>
     {
-        public Subscription(string id, GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload payload, GraphQL.Subscription.SubscriptionExecutionResult result, GraphQL.Server.Transports.Subscriptions.Abstractions.IWriterPipeline writer, System.Action<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription>? completed, Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> logger) { }
+        public Subscription(string id, GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload payload, GraphQL.Subscription.SubscriptionExecutionResult result, GraphQL.Server.Transports.Subscriptions.Abstractions.IWriterPipeline writer, System.Action<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription>? completed, string dataEventType, Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> logger) { }
         public string Id { get; }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessagePayload OriginalPayload { get; }
         public virtual void Dispose() { }
@@ -110,8 +114,8 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
     public class SubscriptionManager : GraphQL.Server.Transports.Subscriptions.Abstractions.ISubscriptionManager, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription>, System.Collections.IEnumerable, System.IDisposable
     {
         [System.Obsolete]
-        public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
-        public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory) { }
+        public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, string dataEventType) { }
+        public SubscriptionManager(GraphQL.Server.IGraphQLExecuter executer, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, string dataEventType) { }
         public GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription this[string id] { get; }
         public virtual void Dispose() { }
         public System.Collections.Generic.IEnumerator<GraphQL.Server.Transports.Subscriptions.Abstractions.Subscription> GetEnumerator() { }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.Subscriptions.WebSockets.approved.txt
@@ -12,13 +12,13 @@ namespace GraphQL.Server.Transports.WebSockets
     public class GraphQLWebSocketsMiddleware<TSchema>
         where TSchema : GraphQL.Types.ISchema
     {
-        public GraphQLWebSocketsMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.WebSockets.GraphQLWebSocketsMiddleware<TSchema>> logger) { }
+        public GraphQLWebSocketsMiddleware(GraphQL.Server.Transports.WebSockets.WebSocketsSubprotocol subprotocol, Microsoft.AspNetCore.Http.RequestDelegate next, Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.WebSockets.GraphQLWebSocketsMiddleware<TSchema>> logger) { }
         public System.Threading.Tasks.Task InvokeAsync(Microsoft.AspNetCore.Http.HttpContext context) { }
     }
     public interface IWebSocketConnectionFactory<TSchema>
         where TSchema : GraphQL.Types.ISchema
     {
-        GraphQL.Server.Transports.WebSockets.WebSocketConnection CreateConnection(System.Net.WebSockets.WebSocket socket, string connectionId);
+        GraphQL.Server.Transports.WebSockets.WebSocketConnection CreateConnection(System.Net.WebSockets.WebSocket socket, string connectionId, GraphQL.Server.Transports.WebSockets.WebSocketsSubprotocol subprotocol);
     }
     public class WebSocketConnection : System.IDisposable
     {
@@ -32,7 +32,7 @@ namespace GraphQL.Server.Transports.WebSockets
         [System.Obsolete]
         public WebSocketConnectionFactory(Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.WebSockets.WebSocketConnectionFactory<TSchema>> logger, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, GraphQL.Server.IGraphQLExecuter<TSchema> executer, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.IOperationMessageListener> messageListeners, GraphQL.IDocumentWriter documentWriter) { }
         public WebSocketConnectionFactory(Microsoft.Extensions.Logging.ILogger<GraphQL.Server.Transports.WebSockets.WebSocketConnectionFactory<TSchema>> logger, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, GraphQL.Server.IGraphQLExecuter<TSchema> executer, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.Subscriptions.Abstractions.IOperationMessageListener> messageListeners, GraphQL.IDocumentWriter documentWriter, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory) { }
-        public GraphQL.Server.Transports.WebSockets.WebSocketConnection CreateConnection(System.Net.WebSockets.WebSocket socket, string connectionId) { }
+        public GraphQL.Server.Transports.WebSockets.WebSocketConnection CreateConnection(System.Net.WebSockets.WebSocket socket, string connectionId, GraphQL.Server.Transports.WebSockets.WebSocketsSubprotocol subprotocol) { }
     }
     public class WebSocketReaderPipeline : GraphQL.Server.Transports.Subscriptions.Abstractions.IReaderPipeline
     {
@@ -61,6 +61,11 @@ namespace GraphQL.Server.Transports.WebSockets
         public bool Post(GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessage message) { }
         public System.Threading.Tasks.Task SendAsync(GraphQL.Server.Transports.Subscriptions.Abstractions.OperationMessage message) { }
     }
+    public enum WebSocketsSubprotocol
+    {
+        GraphQLWs = 0,
+        GraphQLTransportWs = 1,
+    }
     public class WebsocketWriterStream : System.IO.Stream
     {
         public WebsocketWriterStream(System.Net.WebSockets.WebSocket webSocket) { }
@@ -82,9 +87,9 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class GraphQLWebSocketsApplicationBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLWebSockets<TSchema>(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, Microsoft.AspNetCore.Http.PathString path)
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLWebSockets<TSchema>(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, Microsoft.AspNetCore.Http.PathString path, GraphQL.Server.Transports.WebSockets.WebSocketsSubprotocol subprotocol = 0)
             where TSchema : GraphQL.Types.ISchema { }
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLWebSockets<TSchema>(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, string path = "/graphql")
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLWebSockets<TSchema>(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, string path = "/graphql", GraphQL.Server.Transports.WebSockets.WebSocketsSubprotocol subprotocol = 0)
             where TSchema : GraphQL.Types.ISchema { }
     }
     public class GraphQLWebSocketsEndpointConventionBuilder : Microsoft.AspNetCore.Builder.IEndpointConventionBuilder

--- a/tests/Transports.Subscriptions.Abstractions.Tests/BaseSubscriptionManagerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/BaseSubscriptionManagerFacts.cs
@@ -8,9 +8,9 @@ using Xunit;
 
 namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
 {
-    public class SubscriptionManagerFacts
+    public abstract class BaseSubscriptionManagerFacts
     {
-        public SubscriptionManagerFacts()
+        public BaseSubscriptionManagerFacts(string dataEventType)
         {
             _writer = Substitute.For<IWriterPipeline>();
             _executer = Substitute.For<IGraphQLExecuter>();
@@ -22,7 +22,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                         { "1", Substitute.For<IObservable<ExecutionResult>>() }
                     }
                 });
-            _sut = new SubscriptionManager(_executer, new NullLoggerFactory());
+            _sut = new SubscriptionManager(_executer, new NullLoggerFactory(), dataEventType);
             _server = new TestableServerOperations(null, _writer, _sut);
         }
 

--- a/tests/Transports.Subscriptions.Abstractions.Tests/BaseSubscriptionServerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/BaseSubscriptionServerFacts.cs
@@ -8,9 +8,9 @@ using Xunit;
 
 namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
 {
-    public class SubscriptionServerFacts
+    public abstract class BaseSubscriptionServerFacts
     {
-        public SubscriptionServerFacts()
+        public BaseSubscriptionServerFacts(string dataEventType)
         {
             _messageListener = Substitute.For<IOperationMessageListener>();
             _transport = new TestableSubscriptionTransport();
@@ -25,7 +25,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                         { "1", Substitute.For<IObservable<ExecutionResult>>() }
                     }
                 });
-            _subscriptionManager = new SubscriptionManager(_documentExecuter, new NullLoggerFactory());
+            _subscriptionManager = new SubscriptionManager(_documentExecuter, new NullLoggerFactory(), dataEventType);
             _sut = new SubscriptionServer(
                 _transport,
                 _subscriptionManager,

--- a/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLTransportWsProtocolHandlerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLTransportWsProtocolHandlerFacts.cs
@@ -1,0 +1,10 @@
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
+{
+    public class GraphQLTransportWsProtocolHandlerFacts : BaseProtocolHandlerFacts
+    {
+        public GraphQLTransportWsProtocolHandlerFacts()
+            : base(MessageType.GQL_SUBSRIBE, MessageType.GQL_NEXT)
+        {
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLTransportWsSubscriptionManagerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLTransportWsSubscriptionManagerFacts.cs
@@ -1,0 +1,10 @@
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
+{
+    public class GraphQLTransportWsSubscriptionManagerFacts : BaseSubscriptionManagerFacts
+    {
+        public GraphQLTransportWsSubscriptionManagerFacts()
+            : base(MessageType.GQL_NEXT)
+        {
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLTransportWsSubscriptionServerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLTransportWsSubscriptionServerFacts.cs
@@ -1,0 +1,10 @@
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
+{
+    public class GraphQLTransportWsSubscriptionServerFacts : BaseSubscriptionServerFacts
+    {
+        public GraphQLTransportWsSubscriptionServerFacts()
+            : base(MessageType.GQL_NEXT)
+        {
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLWsProtocolHandlerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLWsProtocolHandlerFacts.cs
@@ -1,0 +1,10 @@
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
+{
+    internal class GraphQLWsProtocolHandlerFacts : BaseProtocolHandlerFacts
+    {
+        public GraphQLWsProtocolHandlerFacts():
+            base(MessageType.GQL_START, MessageType.GQL_DATA)
+        {
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLWsSubscriptionManagerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLWsSubscriptionManagerFacts.cs
@@ -1,0 +1,10 @@
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
+{
+    public class GraphQLWsSubscriptionManagerFacts : BaseSubscriptionManagerFacts
+    {
+        public GraphQLWsSubscriptionManagerFacts()
+            : base(MessageType.GQL_DATA)
+        {
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLWsSubscriptionServerFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/GraphQLWsSubscriptionServerFacts.cs
@@ -1,0 +1,10 @@
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
+{
+    public class GraphQLWsSubscriptionServerFacts : BaseSubscriptionServerFacts
+    {
+        public GraphQLWsSubscriptionServerFacts()
+            : base(MessageType.GQL_DATA)
+        {
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.Abstractions.Tests/Specs/GraphQLTransportWsChatSpec.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/Specs/GraphQLTransportWsChatSpec.cs
@@ -1,0 +1,10 @@
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests.Specs
+{
+    public class GraphQLTransportWsChatSpec : BaseChatSpec
+    {
+        public GraphQLTransportWsChatSpec()
+            : base(MessageType.GQL_SUBSRIBE, MessageType.GQL_NEXT)
+        {
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.Abstractions.Tests/Specs/GraphQLWsChatSpec.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/Specs/GraphQLWsChatSpec.cs
@@ -1,0 +1,10 @@
+namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests.Specs
+{
+    public class GraphQLWsChatSpec : BaseChatSpec
+    {
+        public GraphQLWsChatSpec()
+            : base(MessageType.GQL_START, MessageType.GQL_DATA)
+        {
+        }
+    }
+}

--- a/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionFacts.cs
+++ b/tests/Transports.Subscriptions.Abstractions.Tests/SubscriptionFacts.cs
@@ -18,8 +18,10 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
 
         private readonly IWriterPipeline _writer;
 
-        [Fact]
-        public void On_data_from_stream()
+        [Theory]
+        [InlineData(MessageType.GQL_DATA)]
+        [InlineData(MessageType.GQL_NEXT)]
+        public void On_data_from_stream(string dataEventType)
         {
             /* Given */
             string id = "1";
@@ -33,7 +35,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                 }
             };
             var expected = new ExecutionResult();
-            var sut = new Subscription(id, payload, result, _writer, null, new NullLogger<Subscription>());
+            var sut = new Subscription(id, payload, result, _writer, null, dataEventType, new NullLogger<Subscription>());
 
             /* When */
             stream.OnNext(expected);
@@ -42,11 +44,13 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             _writer.Received().Post(
                 Arg.Is<OperationMessage>(
                     message => message.Id == id
-                               && message.Type == MessageType.GQL_DATA));
+                               && message.Type == dataEventType));
         }
 
-        [Fact]
-        public void On_stream_complete()
+        [Theory]
+        [InlineData(MessageType.GQL_DATA)]
+        [InlineData(MessageType.GQL_NEXT)]
+        public void On_stream_complete(string dataEventType)
         {
             /* Given */
             string id = "1";
@@ -61,7 +65,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             };
 
             var completed = Substitute.For<Action<Subscription>>();
-            var sut = new Subscription(id, payload, result, _writer, completed, new NullLogger<Subscription>());
+            var sut = new Subscription(id, payload, result, _writer, completed, dataEventType, new NullLogger<Subscription>());
 
             /* When */
             stream.OnCompleted();
@@ -75,8 +79,10 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                                && message.Type == MessageType.GQL_COMPLETE));
         }
 
-        [Fact]
-        public void Subscribe_to_stream()
+        [Theory]
+        [InlineData(MessageType.GQL_DATA)]
+        [InlineData(MessageType.GQL_NEXT)]
+        public void Subscribe_to_stream(string dataEventType)
         {
             /* Given */
             string id = "1";
@@ -91,14 +97,16 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             };
 
             /* When */
-            var sut = new Subscription(id, payload, result, _writer, null, new NullLogger<Subscription>());
+            var sut = new Subscription(id, payload, result, _writer, null, dataEventType, new NullLogger<Subscription>());
 
             /* Then */
             Assert.True(stream.HasObservers);
         }
 
-        [Fact]
-        public void Subscribe_to_completed_stream_should_not_throw()
+        [Theory]
+        [InlineData(MessageType.GQL_DATA)]
+        [InlineData(MessageType.GQL_NEXT)]
+        public void Subscribe_to_completed_stream_should_not_throw(string dataEventType)
         {
             /* Given */
             string id = "1";
@@ -116,11 +124,13 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
 
             /* When */
             /* Then */
-            var sut = new Subscription(id, payload, result, _writer, null, new NullLogger<Subscription>());
+            var sut = new Subscription(id, payload, result, _writer, null, dataEventType, new NullLogger<Subscription>());
         }
 
-        [Fact]
-        public async Task Unsubscribe_from_stream()
+        [Theory]
+        [InlineData(MessageType.GQL_DATA)]
+        [InlineData(MessageType.GQL_NEXT)]
+        public async Task Unsubscribe_from_stream(string dataEventType)
         {
             /* Given */
             string id = "1";
@@ -135,7 +145,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                     { "op", stream }
                 }
             };
-            var sut = new Subscription(id, payload, result, _writer, null, new NullLogger<Subscription>());
+            var sut = new Subscription(id, payload, result, _writer, null, dataEventType, new NullLogger<Subscription>());
 
             /* When */
             await sut.UnsubscribeAsync();
@@ -144,8 +154,10 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
             unsubscribe.Received().Dispose();
         }
 
-        [Fact]
-        public async Task Write_Complete_on_unsubscribe()
+        [Theory]
+        [InlineData(MessageType.GQL_DATA)]
+        [InlineData(MessageType.GQL_NEXT)]
+        public async Task Write_Complete_on_unsubscribe(string dataEventType)
         {
             /* Given */
             string id = "1";
@@ -158,7 +170,7 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions.Tests
                 }
             };
 
-            var sut = new Subscription(id, payload, result, _writer, null, new NullLogger<Subscription>());
+            var sut = new Subscription(id, payload, result, _writer, null, dataEventType, new NullLogger<Subscription>());
 
             /* When */
             await sut.UnsubscribeAsync();


### PR DESCRIPTION
Add switchable support for `graphql-transport-ws` subprotocol defined at https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md.

I have tested locally with a static html client to verify the subscription flow worked, but I am not sure if there is any other scenario that not supported.

Related to #492 


<details>
<summary>The simple client</summary>

```html
<!DOCTYPE html>
<html>
<head>
  <title>ServerSentEvents</title>
  <script
    type="text/javascript"
    src="//unpkg.com/graphql-ws/umd/graphql-ws.min.js>
  </script>
</head>
<body>
  <div>Subscribe Messages</div>
  <div id="messages"></div>
  <script type="text/javascript">
    const messages = document.querySelector("#messages");
    const client = graphqlWs.createClient({
      url: 'ws://127.0.0.1:60341/graphql',
    });

    const payload = `
subscription MessageAdded {
  messageAdded {
    from { id displayName }
    content
  }
}
`;

    client.subscribe({
      query: payload,
     }, {
      next: (data) => {
        const div = document.createElement("div");
        div.innerHTML = JSON.stringify(data);
        messages.appendChild(div);
      },
      error: err => alert("Error! " + err),
      complete: () => alert("Completed"),
    });

  </script>
</body>
</html>
```
</details>