### PR TITLE
Restrict acceptable GraphQL.NET versions to v4

### DIFF
--- a/src/All/All.csproj
+++ b/src/All/All.csproj
@@ -21,9 +21,9 @@
     <ProjectReference Include="..\Ui.Playground\Ui.Playground.csproj" />
     <ProjectReference Include="..\Ui.Voyager\Ui.Voyager.csproj" />
 
-    <PackageReference Include="GraphQL.MemoryCache" Version="4.6.1" />
-    <PackageReference Include="GraphQL.MicrosoftDI" Version="4.6.1" />
-    <PackageReference Include="GraphQL.SystemReactive" Version="4.6.1" />
+    <PackageReference Include="GraphQL.MemoryCache" Version="[4.6.1,5.0.0)" />
+    <PackageReference Include="GraphQL.MicrosoftDI" Version="[4.6.1,5.0.0)" />
+    <PackageReference Include="GraphQL.SystemReactive" Version="[4.6.1,5.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <!--TODO: remove SystemReactive in v6 -->
-    <PackageReference Include="GraphQL.SystemReactive" Version="4.6.1" />
-    <PackageReference Include="GraphQL.DataLoader" Version="4.6.1" />
+    <PackageReference Include="GraphQL.SystemReactive" Version="[4.6.1,5.0.0)" />
+    <PackageReference Include="GraphQL.DataLoader" Version="[4.6.1,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/Transports.Subscriptions.Abstractions/Transports.Subscriptions.Abstractions.csproj
+++ b/src/Transports.Subscriptions.Abstractions/Transports.Subscriptions.Abstractions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.SystemReactive" Version="4.6.1" />
-    <PackageReference Include="GraphQL.NewtonsoftJson" Version="4.6.1" />
+    <PackageReference Include="GraphQL.SystemReactive" Version="[4.6.1,5.0.0)" />
+    <PackageReference Include="GraphQL.NewtonsoftJson" Version="[4.6.1,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This change is intended for GraphQL Server v5 only.

Tested built package with NuGet Package Explorer and it works properly.

Example of "All" nuget package:
![image](https://user-images.githubusercontent.com/6377684/158853225-56d4c8e8-c629-437d-bde1-3214ea27a470.png)
