### PR TITLE
Wrap subscription exceptions passed along via OnError

### DIFF
--- a/src/Transports.Subscriptions.Abstractions/Subscription.cs
+++ b/src/Transports.Subscriptions.Abstractions/Subscription.cs
@@ -63,6 +63,8 @@ namespace GraphQL.Server.Transports.Subscriptions.Abstractions
         /// </summary>
         public void OnError(Exception error)
         {
+            _logger.LogDebug("Subscription: {subscriptionId} got error", Id);
+
             // exceptions should already be wrapped by the GraphQL engine
             if (error is not ExecutionError executionError)
             {


### PR DESCRIPTION
- Required by https://github.com/graphql-dotnet/graphql-dotnet/pull/3004 to retain existing behavior in respect to source-raised errors
- Even if the above PR is not merged, this change does not hurt existing implementations
- As a behavioral change, I suggest that OnError also call OnComplete -- see comments in code for details