### PR TITLE
Support APQ middleware; return BadRequest for any validation error

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,8 @@
     <AssemblyName>GraphQL.Server.$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>GraphQL.Server.$(MSBuildProjectName)</RootNamespace>
     <PackageId>GraphQL.Server.$(MSBuildProjectName)</PackageId>
+
+    <GraphQLVersion>5.3.0</GraphQLVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/samples/Samples.Server/Samples.Server.csproj
+++ b/samples/Samples.Server/Samples.Server.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.DataLoader" Version="5.1.1" />
+    <PackageReference Include="GraphQL.DataLoader" Version="$(GraphQLVersion)" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="GraphQL.MicrosoftDI" Version="5.1.1" />
-    <PackageReference Include="GraphQL.SystemTextJson" Version="5.1.1" />
+    <PackageReference Include="GraphQL.MicrosoftDI" Version="$(GraphQLVersion)" />
+    <PackageReference Include="GraphQL.SystemTextJson" Version="$(GraphQLVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -1,6 +1,5 @@
 using GraphQL.DataLoader;
 using GraphQL.Execution;
-using GraphQL.Instrumentation;
 using GraphQL.MicrosoftDI;
 using GraphQL.Samples.Schemas.Chat;
 using GraphQL.Server;
@@ -34,8 +33,7 @@ public class Startup
             .AddTransient<IAuthorizationErrorMessageBuilder, DefaultAuthorizationErrorMessageBuilder>(); // required by CustomErrorInfoProvider
 
         services.AddGraphQL(builder => builder
-            .AddMetrics()
-            .AddDocumentExecuter<ApolloTracingDocumentExecuter>()
+            .AddApolloTracing()
             .AddHttpMiddleware<ChatSchema, GraphQLHttpMiddlewareWithLogs<ChatSchema>>()
             .AddWebSocketsHttpMiddleware<ChatSchema>()
             .AddSchema<ChatSchema>()

--- a/samples/Samples.Server/StartupWithRouting.cs
+++ b/samples/Samples.Server/StartupWithRouting.cs
@@ -35,8 +35,7 @@ public class StartupWithRouting
             .AddTransient<IAuthorizationErrorMessageBuilder, DefaultAuthorizationErrorMessageBuilder>(); // required by CustomErrorInfoProvider
 
         services.AddGraphQL(builder => builder
-            .AddMetrics()
-            .AddDocumentExecuter<ApolloTracingDocumentExecuter>()
+            .AddApolloTracing()
             .AddHttpMiddleware<ChatSchema, GraphQLHttpMiddlewareWithLogs<ChatSchema>>()
             .AddWebSocketsHttpMiddleware<ChatSchema>()
             .AddSchema<ChatSchema>()

--- a/samples/Samples.Server/StartupWithRouting.cs
+++ b/samples/Samples.Server/StartupWithRouting.cs
@@ -1,6 +1,5 @@
 using GraphQL.DataLoader;
 using GraphQL.Execution;
-using GraphQL.Instrumentation;
 using GraphQL.MicrosoftDI;
 using GraphQL.Samples.Schemas.Chat;
 using GraphQL.Server;

--- a/src/All/All.csproj
+++ b/src/All/All.csproj
@@ -18,9 +18,9 @@
     <ProjectReference Include="..\Ui.Playground\Ui.Playground.csproj" />
     <ProjectReference Include="..\Ui.Voyager\Ui.Voyager.csproj" />
 
-    <PackageReference Include="GraphQL.MemoryCache" Version="5.1.1" />
-    <PackageReference Include="GraphQL.MicrosoftDI" Version="5.1.1" />
-    <PackageReference Include="GraphQL.SystemTextJson" Version="5.1.1" />
+    <PackageReference Include="GraphQL.MemoryCache" Version="$(GraphQLVersion)" />
+    <PackageReference Include="GraphQL.MicrosoftDI" Version="$(GraphQLVersion)" />
+    <PackageReference Include="GraphQL.SystemTextJson" Version="$(GraphQLVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
+++ b/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="GraphQL" Version="5.1.1" />
+    <PackageReference Include="GraphQL" Version="$(GraphQLVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -157,12 +157,6 @@ public class GraphQLHttpMiddleware<TSchema> : IMiddleware
                 Extensions = urlGQLRequest.Extensions ?? bodyGQLRequest?.Extensions,
                 OperationName = urlGQLRequest.OperationName ?? bodyGQLRequest?.OperationName
             };
-
-            if (string.IsNullOrWhiteSpace(gqlRequest.Query))
-            {
-                await HandleNoQueryErrorAsync(context);
-                return;
-            }
         }
 
         // Prepare context and execute
@@ -284,7 +278,7 @@ public class GraphQLHttpMiddleware<TSchema> : IMiddleware
     protected virtual Task WriteResponseAsync<TResult>(HttpResponse httpResponse, IGraphQLSerializer serializer, CancellationToken cancellationToken, TResult result)
     {
         httpResponse.ContentType = "application/json";
-        httpResponse.StatusCode = 200; // OK
+        httpResponse.StatusCode = result is not ExecutionResult executionResult || executionResult.Executed ? 200 : 400; // BadRequest when fails validation; OK otherwise
 
         return serializer.WriteAsync(httpResponse.Body, result, cancellationToken);
     }

--- a/src/Transports.AspNetCore/Transports.AspNetCore.csproj
+++ b/src/Transports.AspNetCore/Transports.AspNetCore.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="GraphQL" Version="5.1.1" />
+    <PackageReference Include="GraphQL" Version="$(GraphQLVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5'" />
   </ItemGroup>

--- a/src/Transports.Subscriptions.Abstractions/Transports.Subscriptions.Abstractions.csproj
+++ b/src/Transports.Subscriptions.Abstractions/Transports.Subscriptions.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="5.1.1" />
+    <PackageReference Include="GraphQL" Version="$(GraphQLVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />


### PR DESCRIPTION
- Bump GraphQL.NET to 5.3.0
- Support Automatic Persisted Queries (by the nature of allowing empty queries)
- Return BadRequest for validation errors

These changes already exist in #774; merging this PR may reduce the diff.