### PR TITLE
Support application/graphql+json media type

### DIFF
--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -174,8 +174,10 @@ public abstract class GraphQLHttpMiddleware
     private const string VARIABLES_KEY = "variables";
     private const string EXTENSIONS_KEY = "extensions";
     private const string OPERATION_NAME_KEY = "operationName";
+    private const string MEDIATYPE_GRAPHQLJSON = "application/graphql+json";
     private const string MEDIATYPE_JSON = "application/json";
     private const string MEDIATYPE_GRAPHQL = "application/graphql";
+    private const string CONTENTTYPE_GRAPHQLJSON = "application/graphql+json; charset=utf-8";
 
     /// <summary>
     /// Gets the options configured for this instance.
@@ -248,8 +250,9 @@ public abstract class GraphQLHttpMiddleware
                 return;
             }
 
-            switch (mediaTypeHeader.MediaType)
+            switch (mediaTypeHeader.MediaType?.ToLowerInvariant())
             {
+                case MEDIATYPE_GRAPHQLJSON:
                 case MEDIATYPE_JSON:
                     IList<GraphQLRequest?>? deserializationResult;
                     try
@@ -495,11 +498,23 @@ public abstract class GraphQLHttpMiddleware
     }
 
     /// <summary>
+    /// Selects a response content type string based on the <see cref="HttpContext"/>.
+    /// Defaults to <see cref="CONTENTTYPE_GRAPHQLJSON"/>.  Override this value for compatibility
+    /// with non-conforming GraphQL clients.
+    /// <br/><br/>
+    /// Note that by default, the response will be written as UTF-8 encoded JSON, regardless
+    /// of the content-type value here.  For more complex behavior patterns, override
+    /// <see cref="WriteJsonResponseAsync{TResult}(HttpContext, HttpStatusCode, TResult)"/>.
+    /// </summary>
+    protected virtual string SelectResponseContentType(HttpContext context)
+        => CONTENTTYPE_GRAPHQLJSON;
+
+    /// <summary>
     /// Writes the specified object (usually a GraphQL response represented as an instance of <see cref="ExecutionResult"/>) as JSON to the HTTP response stream.
     /// </summary>
     protected virtual Task WriteJsonResponseAsync<TResult>(HttpContext context, HttpStatusCode httpStatusCode, TResult result)
     {
-        context.Response.ContentType = MEDIATYPE_JSON;
+        context.Response.ContentType = SelectResponseContentType(context);
         context.Response.StatusCode = (int)httpStatusCode;
 
         return _serializer.WriteAsync(context.Response.Body, result, context.RequestAborted);

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -49,6 +49,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         protected virtual System.Threading.Tasks.Task HandleRequestAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, GraphQL.Transport.GraphQLRequest gqlRequest) { }
         protected virtual System.Threading.Tasks.Task HandleWebSocketSubProtocolNotSupportedAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         public virtual System.Threading.Tasks.Task InvokeAsync(Microsoft.AspNetCore.Http.HttpContext context) { }
+        protected virtual string SelectResponseContentType(Microsoft.AspNetCore.Http.HttpContext context) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, string errorMessage) { }
         protected virtual System.Threading.Tasks.Task WriteJsonResponseAsync<TResult>(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, TResult result) { }


### PR DESCRIPTION
Note:
- All responses will now have the content type: `application/graphql+json; charset=utf-8`
- Since `application/graphql+json` is a subset of `application/json`, it _should_ be backwards compatible with any client.  Probably any browser client, anyway.
- `SelectResponseContentType` can be overridden to revert to old behavior.

Also:
- `application/graphql+json` is a supported content-type for incoming requests.
- Content-type header for incoming requests is now properly case insensitive

Tests are done already in https://github.com/Shane32/GraphQL.AspNetCore3/pull/20 but are not copied in here because I have not yet copied any of the other tests, since WebSocket support has not yet been copied in.