### PR TITLE
Add WebSocket support to IUserContextBuilder

### DIFF
--- a/src/Transports.AspNetCore/Extensions/GraphQLBuilderUserContextExtensions.cs
+++ b/src/Transports.AspNetCore/Extensions/GraphQLBuilderUserContextExtensions.cs
@@ -92,7 +92,8 @@ public static class GraphQLBuilderUserContextExtensions
         where TUserContext : class, IDictionary<string, object?>
     {
         builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>(creator ?? throw new ArgumentNullException(nameof(creator))));
-        builder.ConfigureExecutionOptions(options => {
+        builder.ConfigureExecutionOptions(options =>
+        {
             if (options.UserContext == null || options.UserContext.Count == 0 && options.UserContext.GetType() == typeof(Dictionary<string, object>))
             {
                 var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
@@ -111,7 +112,8 @@ public static class GraphQLBuilderUserContextExtensions
         if (creator == null)
             throw new ArgumentNullException(nameof(creator));
         builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>((context, payload) => new(creator(context, payload))));
-        builder.ConfigureExecutionOptions(async options => {
+        builder.ConfigureExecutionOptions(async options =>
+        {
             if (options.UserContext == null || options.UserContext.Count == 0 && options.UserContext.GetType() == typeof(Dictionary<string, object>))
             {
                 var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();

--- a/src/Transports.AspNetCore/Extensions/GraphQLBuilderUserContextExtensions.cs
+++ b/src/Transports.AspNetCore/Extensions/GraphQLBuilderUserContextExtensions.cs
@@ -49,7 +49,6 @@ public static class GraphQLBuilderUserContextExtensions
         return builder;
     }
 
-
     /// <inheritdoc cref="AddUserContextBuilder{TUserContext}(IGraphQLBuilder, Func{HttpContext, TUserContext})"/>
     public static IGraphQLBuilder AddUserContextBuilder<TUserContext>(this IGraphQLBuilder builder, Func<HttpContext, object?, TUserContext> creator)
         where TUserContext : class, IDictionary<string, object?>

--- a/src/Transports.AspNetCore/Extensions/GraphQLBuilderUserContextExtensions.cs
+++ b/src/Transports.AspNetCore/Extensions/GraphQLBuilderUserContextExtensions.cs
@@ -9,73 +9,17 @@ namespace GraphQL.Server;
 public static class GraphQLBuilderUserContextExtensions
 {
     /// <summary>
-    /// Adds an <see cref="IUserContextBuilder"/> as a singleton.
+    /// Registers the specified <typeparamref name="TUserContextBuilder"/> as a singleton of
+    /// type <see cref="IUserContextBuilder"/> and configures it to be used for each GraphQL request.
+    /// <br/><br/>
+    /// Requires <see cref="IHttpContextAccessor"/> to be registered within the dependency injection framework
+    /// if calling <see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)"/> directly.
     /// </summary>
-    /// <typeparam name="TUserContextBuilder">The type of the <see cref="IUserContextBuilder"/> implementation.</typeparam>
-    /// <param name="builder">The GraphQL builder.</param>
-    /// <returns>The GraphQL builder.</returns>
     public static IGraphQLBuilder AddUserContextBuilder<TUserContextBuilder>(this IGraphQLBuilder builder)
         where TUserContextBuilder : class, IUserContextBuilder
     {
         builder.Services.Register<IUserContextBuilder, TUserContextBuilder>(DI.ServiceLifetime.Singleton);
-        builder.ConfigureExecutionOptions(async options =>
-        {
-            if (options.UserContext == null || options.UserContext.Count == 0 && options.UserContext.GetType() == typeof(Dictionary<string, object>))
-            {
-                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
-                var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
-                var contextBuilder = requestServices.GetRequiredService<IUserContextBuilder>();
-                options.UserContext = await contextBuilder.BuildUserContextAsync(httpContext, null);
-            }
-        });
-
-        return builder;
-    }
-
-    /// <summary>
-    /// Set up a delegate to create the UserContext for each GraphQL request
-    /// </summary>
-    /// <typeparam name="TUserContext"></typeparam>
-    /// <param name="builder">The GraphQL builder.</param>
-    /// <param name="creator">A delegate used to create the user context from the <see cref="HttpContext"/>.</param>
-    /// <returns>The GraphQL builder.</returns>
-    public static IGraphQLBuilder AddUserContextBuilder<TUserContext>(this IGraphQLBuilder builder, Func<HttpContext, TUserContext> creator)
-        where TUserContext : class, IDictionary<string, object?>
-    {
-        builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>(creator));
-        builder.ConfigureExecutionOptions(options =>
-        {
-            if (options.UserContext == null || options.UserContext.Count == 0 && options.UserContext.GetType() == typeof(Dictionary<string, object>))
-            {
-                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
-                var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
-                options.UserContext = creator(httpContext);
-            }
-        });
-
-        return builder;
-    }
-
-    /// <summary>
-    /// Set up a delegate to create the UserContext for each GraphQL request
-    /// </summary>
-    /// <typeparam name="TUserContext"></typeparam>
-    /// <param name="builder">The GraphQL builder.</param>
-    /// <param name="creator">A delegate used to create the user context from the <see cref="HttpContext"/>.</param>
-    /// <returns>The GraphQL builder.</returns>
-    public static IGraphQLBuilder AddUserContextBuilder<TUserContext>(this IGraphQLBuilder builder, Func<HttpContext, Task<TUserContext>> creator)
-        where TUserContext : class, IDictionary<string, object?>
-    {
-        builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>(context => new(creator(context))));
-        builder.ConfigureExecutionOptions(async options =>
-        {
-            if (options.UserContext == null || options.UserContext.Count == 0 && options.UserContext.GetType() == typeof(Dictionary<string, object>))
-            {
-                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
-                var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
-                options.UserContext = await creator(httpContext);
-            }
-        });
+        builder.Services.TryRegister<IConfigureExecution, UserContextConfigurator>(DI.ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
 
         return builder;
     }
@@ -86,19 +30,32 @@ public static class GraphQLBuilderUserContextExtensions
     /// Requires <see cref="IHttpContextAccessor"/> to be registered within the dependency injection framework
     /// if calling <see cref="DocumentExecuter.ExecuteAsync(ExecutionOptions)"/> directly.
     /// </summary>
+    public static IGraphQLBuilder AddUserContextBuilder<TUserContext>(this IGraphQLBuilder builder, Func<HttpContext, TUserContext> creator)
+        where TUserContext : class, IDictionary<string, object?>
+    {
+        builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>(creator));
+        builder.Services.TryRegister<IConfigureExecution, UserContextConfigurator>(DI.ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
+
+        return builder;
+    }
+
+    /// <inheritdoc cref="AddUserContextBuilder{TUserContext}(IGraphQLBuilder, Func{HttpContext, TUserContext})"/>
+    public static IGraphQLBuilder AddUserContextBuilder<TUserContext>(this IGraphQLBuilder builder, Func<HttpContext, Task<TUserContext>> creator)
+        where TUserContext : class, IDictionary<string, object?>
+    {
+        builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>(context => new(creator(context))));
+        builder.Services.TryRegister<IConfigureExecution, UserContextConfigurator>(DI.ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
+
+        return builder;
+    }
+
+
+    /// <inheritdoc cref="AddUserContextBuilder{TUserContext}(IGraphQLBuilder, Func{HttpContext, TUserContext})"/>
     public static IGraphQLBuilder AddUserContextBuilder<TUserContext>(this IGraphQLBuilder builder, Func<HttpContext, object?, TUserContext> creator)
         where TUserContext : class, IDictionary<string, object?>
     {
         builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>(creator ?? throw new ArgumentNullException(nameof(creator))));
-        builder.ConfigureExecutionOptions(options =>
-        {
-            if (options.UserContext == null || options.UserContext.Count == 0 && options.UserContext.GetType() == typeof(Dictionary<string, object>))
-            {
-                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
-                var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
-                options.UserContext = creator(httpContext, null);
-            }
-        });
+        builder.Services.TryRegister<IConfigureExecution, UserContextConfigurator>(DI.ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
 
         return builder;
     }
@@ -110,17 +67,38 @@ public static class GraphQLBuilderUserContextExtensions
         if (creator == null)
             throw new ArgumentNullException(nameof(creator));
         builder.Services.Register<IUserContextBuilder>(new UserContextBuilder<TUserContext>((context, payload) => new(creator(context, payload))));
-        builder.ConfigureExecutionOptions(async options =>
+        builder.Services.TryRegister<IConfigureExecution, UserContextConfigurator>(DI.ServiceLifetime.Singleton, RegistrationCompareMode.ServiceTypeAndImplementationType);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Checks if <see cref="ExecutionOptions.UserContext"/> is still at its initial "default" value, and if so,
+    /// creates the user context from the registered <see cref="IUserContextBuilder"/>.
+    /// <br/><br/>
+    /// Typically the middleware initializes the user context, which is specifically necessary for WebSocket requests
+    /// and batched requests, in which case this code executes allocation-free -- but it may be useful when GraphQL
+    /// is served via a MVC controller action, for example.
+    /// </summary>
+    private class UserContextConfigurator : IConfigureExecution
+    {
+        public Task<ExecutionResult> ExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
         {
             if (options.UserContext == null || options.UserContext.Count == 0 && options.UserContext.GetType() == typeof(Dictionary<string, object>))
             {
-                var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
-                var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
-                options.UserContext = await creator(httpContext, null);
+                return SetAndExecuteAsync(options, next);
             }
-        });
+            return next(options);
+        }
 
-        return builder;
+        private async Task<ExecutionResult> SetAndExecuteAsync(ExecutionOptions options, ExecutionDelegate next)
+        {
+            var requestServices = options.RequestServices ?? throw new MissingRequestServicesException();
+            var httpContext = requestServices.GetRequiredService<IHttpContextAccessor>().HttpContext!;
+            var contextBuilder = requestServices.GetRequiredService<IUserContextBuilder>();
+            options.UserContext = await contextBuilder.BuildUserContextAsync(httpContext, null);
+            return await next(options);
+        }
     }
 
     /// <summary>

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -169,6 +169,7 @@ public abstract class GraphQLHttpMiddleware
     private readonly IGraphQLTextSerializer _serializer;
     //private readonly IEnumerable<IWebSocketHandler>? _webSocketHandlers;
     private readonly RequestDelegate _next;
+    //private readonly IUserContextBuilder _userContextBuilderForWebSockets;
 
     private const string QUERY_KEY = "query";
     private const string VARIABLES_KEY = "variables";
@@ -195,6 +196,7 @@ public abstract class GraphQLHttpMiddleware
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         Options = options ?? throw new ArgumentNullException(nameof(options));
         //_webSocketHandlers = webSocketHandlers;
+        //_userContextBuilderForWebSockets = new UserContextBuilder<IDictionary<string, object?>>(BuildUserContextAsync);
     }
 
     /// <inheritdoc/>
@@ -392,7 +394,7 @@ public abstract class GraphQLHttpMiddleware
         GraphQLRequest gqlRequest)
     {
         // Normal execution with single graphql request
-        var userContext = await BuildUserContextAsync(context);
+        var userContext = await BuildUserContextAsync(context, null);
         var result = await ExecuteRequestAsync(context, gqlRequest, context.RequestServices, userContext);
         var statusCode = Options.ValidationErrorsReturnBadRequest && !result.Executed
             ? HttpStatusCode.BadRequest
@@ -408,7 +410,7 @@ public abstract class GraphQLHttpMiddleware
         RequestDelegate next,
         IList<GraphQLRequest?> gqlRequests)
     {
-        var userContext = await BuildUserContextAsync(context);
+        var userContext = await BuildUserContextAsync(context, null);
         var results = new ExecutionResult[gqlRequests.Count];
         if (gqlRequests.Count == 1)
         {
@@ -485,12 +487,12 @@ public abstract class GraphQLHttpMiddleware
     /// In this manner, both scoped and singleton <see cref="IUserContextBuilder"/>
     /// instances are supported, although singleton instances are recommended.
     /// </summary>
-    protected virtual async ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context)
+    protected virtual async ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context, object? payload)
     {
         var userContextBuilder = context.RequestServices.GetService<IUserContextBuilder>();
         var userContext = userContextBuilder == null
             ? new Dictionary<string, object?>()
-            : await userContextBuilder.BuildUserContextAsync(context);
+            : await userContextBuilder.BuildUserContextAsync(context, payload);
         return userContext;
     }
 
@@ -549,10 +551,8 @@ public abstract class GraphQLHttpMiddleware
             return;
         }
 
-        // Prepare user context
-        var userContext = await BuildUserContextAsync(context);
         // Connect, then wait until the websocket has disconnected (and all subscriptions ended)
-        await selectedHandler.ExecuteAsync(context, socket, selectedProtocol, userContext);
+        await selectedHandler.ExecuteAsync(context, socket, selectedProtocol, _userContextBuilderForWebSockets);
     }
 
     *****************************/

--- a/src/Transports.AspNetCore/IUserContextBuilder.cs
+++ b/src/Transports.AspNetCore/IUserContextBuilder.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 namespace GraphQL.Server.Transports.AspNetCore;
 
 /// <summary>
-/// Creates a user context from a <see cref="HttpContext"/>.
+/// Creates a user context from a <see cref="HttpContext"/> and/or the WebSocket initialization message's payload.
 /// <br/><br/>
 /// The generated user context may be used for one or more GraphQL requests or
 /// subscriptions over the same HTTP connection.
@@ -13,5 +13,17 @@ namespace GraphQL.Server.Transports.AspNetCore;
 public interface IUserContextBuilder
 {
     /// <inheritdoc cref="IUserContextBuilder"/>
-    ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context);
+    /// <param name="context">The <see cref="HttpContext"/> of the HTTP connection.</param>
+    /// <param name="payload">
+    /// The payload of the WebSocket connection request, if applicable.  Typically this is either <see langword="null"/> or
+    /// an object that has not fully been deserialized yet; when using the Newtonsoft.Json deserializer, this will be a JObject,
+    /// and when using System.Text.Json this will be a <see cref="System.Text.Json.JsonElement">JsonElement</see>.  You may call
+    /// <see cref="IGraphQLSerializer.ReadNode{T}(object?)"/> to deserialize the node into the expected type.  To deserialize
+    /// into a nested set of <see cref="IDictionary{TKey, TValue}">IDictionary&lt;string, object?&gt;</see> maps, call
+    /// <see cref="IGraphQLSerializer.ReadNode{T}(object?)"/> with <see cref="Inputs"/> as the generic type.
+    /// <br/><br/>
+    /// To determine if this is a WebSocket connection request, check
+    /// <paramref name="context"/>.<see cref="HttpContext.WebSockets">WebSockets</see>.<see cref="WebSocketManager.IsWebSocketRequest">IsWebSocketRequest</see>.
+    /// </param>
+    ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context, object? payload);
 }

--- a/src/Transports.AspNetCore/UserContextBuilder.cs
+++ b/src/Transports.AspNetCore/UserContextBuilder.cs
@@ -27,7 +27,7 @@ public class UserContextBuilder<TUserContext> : IUserContextBuilder
         if (func == null)
             throw new ArgumentNullException(nameof(func));
 
-        _func = (context, payload) => new(func(context));
+        _func = (context, _) => new(func(context));
     }
 
     /// <inheritdoc cref="UserContextBuilder(Func{HttpContext, ValueTask{TUserContext}})"/>

--- a/src/Transports.AspNetCore/UserContextBuilder.cs
+++ b/src/Transports.AspNetCore/UserContextBuilder.cs
@@ -10,28 +10,54 @@ namespace GraphQL.Server.Transports.AspNetCore;
 public class UserContextBuilder<TUserContext> : IUserContextBuilder
     where TUserContext : IDictionary<string, object?>
 {
-    private readonly Func<HttpContext, ValueTask<TUserContext>> _func;
+    private readonly Func<HttpContext, object?, ValueTask<IDictionary<string, object?>>> _func;
 
     /// <summary>
     /// Initializes a new instance with the specified delegate.
     /// </summary>
     public UserContextBuilder(Func<HttpContext, ValueTask<TUserContext>> func)
     {
-        _func = func ?? throw new ArgumentNullException(nameof(func));
+        if (func == null)
+            throw new ArgumentNullException(nameof(func));
+
+        _func = async (context, payload) => await func(context);
     }
 
-    /// <summary>
-    /// Initializes a new instance with the specified delegate.
-    /// </summary>
+    /// <inheritdoc cref="UserContextBuilder(Func{HttpContext, ValueTask{TUserContext}})"/>
     public UserContextBuilder(Func<HttpContext, TUserContext> func)
     {
         if (func == null)
             throw new ArgumentNullException(nameof(func));
 
-        _func = x => new(func(x));
+        _func = (context, payload) => new(func(context));
+    }
+
+    /// <inheritdoc cref="UserContextBuilder(Func{HttpContext, ValueTask{TUserContext}})"/>
+    public UserContextBuilder(Func<HttpContext, object?, ValueTask<TUserContext>> func)
+    {
+        if (func == null)
+            throw new ArgumentNullException(nameof(func));
+
+        if (func is Func<HttpContext, object?, ValueTask<IDictionary<string, object?>>> func2)
+        {
+            _func = func2;
+        }
+        else
+        {
+            _func = async (context, payload) => await func(context, payload);
+        }
+    }
+
+    /// <inheritdoc cref="UserContextBuilder(Func{HttpContext, ValueTask{TUserContext}})"/>
+    public UserContextBuilder(Func<HttpContext, object?, TUserContext> func)
+    {
+        if (func == null)
+            throw new ArgumentNullException(nameof(func));
+
+        _func = (context, payload) => new(func(context, payload));
     }
 
     /// <inheritdoc/>
-    public async ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context)
-        => await _func(context);
+    public ValueTask<IDictionary<string, object?>> BuildUserContextAsync(HttpContext context, object? payload)
+        => _func(context, payload);
 }

--- a/src/Transports.AspNetCore/UserContextBuilder.cs
+++ b/src/Transports.AspNetCore/UserContextBuilder.cs
@@ -18,7 +18,7 @@ public class UserContextBuilder<TUserContext> : IUserContextBuilder
         if (func == null)
             throw new ArgumentNullException(nameof(func));
 
-        _func = async (context, payload) => await func(context);
+        _func = async (context, _) => await func(context);
     }
 
     /// <inheritdoc cref="UserContextBuilder(Func{HttpContext, ValueTask{TUserContext}})"/>

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -9,6 +9,10 @@ namespace GraphQL.Server
             where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
         public static GraphQL.DI.IGraphQLBuilder AddUserContextBuilder<TUserContext>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, TUserContext> creator)
             where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
+        public static GraphQL.DI.IGraphQLBuilder AddUserContextBuilder<TUserContext>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, object?, System.Threading.Tasks.Task<TUserContext>> creator)
+            where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
+        public static GraphQL.DI.IGraphQLBuilder AddUserContextBuilder<TUserContext>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, object?, TUserContext> creator)
+            where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
     }
 }
 namespace GraphQL.Server.Transports.AspNetCore
@@ -32,7 +36,7 @@ namespace GraphQL.Server.Transports.AspNetCore
     {
         public GraphQLHttpMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, GraphQL.IGraphQLTextSerializer serializer, GraphQL.Server.Transports.AspNetCore.GraphQLHttpMiddlewareOptions options) { }
         protected GraphQL.Server.Transports.AspNetCore.GraphQLHttpMiddlewareOptions Options { get; }
-        protected virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context) { }
+        protected virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context, object? payload) { }
         protected abstract System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(Microsoft.AspNetCore.Http.HttpContext context, GraphQL.Transport.GraphQLRequest? request, System.IServiceProvider serviceProvider, System.Collections.Generic.IDictionary<string, object?> userContext);
         protected abstract System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteScopedRequestAsync(Microsoft.AspNetCore.Http.HttpContext context, GraphQL.Transport.GraphQLRequest? request, System.Collections.Generic.IDictionary<string, object?> userContext);
         protected virtual System.Threading.Tasks.ValueTask<bool> HandleAuthorizeAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
@@ -87,14 +91,16 @@ namespace GraphQL.Server.Transports.AspNetCore
     }
     public interface IUserContextBuilder
     {
-        System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context, object? payload);
     }
     public class UserContextBuilder<TUserContext> : GraphQL.Server.Transports.AspNetCore.IUserContextBuilder
         where TUserContext : System.Collections.Generic.IDictionary<string, object?>
     {
         public UserContextBuilder(System.Func<Microsoft.AspNetCore.Http.HttpContext, System.Threading.Tasks.ValueTask<TUserContext>> func) { }
         public UserContextBuilder(System.Func<Microsoft.AspNetCore.Http.HttpContext, TUserContext> func) { }
-        public System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context) { }
+        public UserContextBuilder(System.Func<Microsoft.AspNetCore.Http.HttpContext, object?, System.Threading.Tasks.ValueTask<TUserContext>> func) { }
+        public UserContextBuilder(System.Func<Microsoft.AspNetCore.Http.HttpContext, object?, TUserContext> func) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context, object? payload) { }
     }
 }
 namespace GraphQL.Server.Transports.AspNetCore.Errors


### PR DESCRIPTION
This changes `IUserContextBuilder` to support WebSocket connections via the graphql-ws or graphql-transport-ws subprotocol. 

This is provided by:
- Adding `object? payload` to the interface method signature
- Changing the websocket support (not yet posted as a PR) to create the user context while the initialization message is being processed, after authentication has occurred.  (Now it runs before WebSocket authentication.)

So with this change:
1. You can access `HttpContext.User` to pull properties of the user
2. You can examine any other properties of the WebSocket connection initialization message while creating the user context

Breaking changes:
- Direct implementations of `IUserContextBuilder` need to be modified

Non-breaking:
- The user context builder methods still work without changes.  New methods were added if the code needs the payload.
