### PR TITLE
Add interfaces for WebSocket connections

### DIFF
--- a/src/Transports.AspNetCore/Extensions/GraphQLBuilderUserContextExtensions.cs
+++ b/src/Transports.AspNetCore/Extensions/GraphQLBuilderUserContextExtensions.cs
@@ -1,5 +1,6 @@
 using GraphQL.DI;
 using GraphQL.Server.Transports.AspNetCore;
+using GraphQL.Server.Transports.AspNetCore.WebSockets;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -98,6 +99,37 @@ public static class GraphQLBuilderUserContextExtensions
             options.UserContext = await contextBuilder.BuildUserContextAsync(httpContext, null);
             return await next(options);
         }
+    }
+
+    /// <summary>
+    /// Registers <typeparamref name="TWebSocketAuthenticationService"/> with the dependency injection framework
+    /// as a singleton of type <see cref="IWebSocketAuthenticationService"/>.
+    /// </summary>
+    public static IGraphQLBuilder AddWebSocketAuthentication<TWebSocketAuthenticationService>(this IGraphQLBuilder builder)
+        where TWebSocketAuthenticationService : class, IWebSocketAuthenticationService
+    {
+        builder.Services.Register<IWebSocketAuthenticationService, TWebSocketAuthenticationService>(DI.ServiceLifetime.Singleton);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers a service of type <see cref="IWebSocketAuthenticationService"/> with the specified factory delegate
+    /// with the dependency injection framework as a singleton.
+    /// </summary>
+    public static IGraphQLBuilder AddWebSocketAuthentication(this IGraphQLBuilder builder, Func<IServiceProvider, IWebSocketAuthenticationService> factory)
+    {
+        builder.Services.Register(factory, DI.ServiceLifetime.Singleton);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers a specified instance of type <see cref="IWebSocketAuthenticationService"/> with the
+    /// dependency injection framework.
+    /// </summary>
+    public static IGraphQLBuilder AddWebSocketAuthentication(this IGraphQLBuilder builder, IWebSocketAuthenticationService webSocketAuthenticationService)
+    {
+        builder.Services.Register(webSocketAuthenticationService);
+        return builder;
     }
 
     /// <summary>

--- a/src/Transports.AspNetCore/WebSockets/IOperationMessageProcessor.cs
+++ b/src/Transports.AspNetCore/WebSockets/IOperationMessageProcessor.cs
@@ -1,0 +1,21 @@
+using GraphQL.Transport;
+
+namespace GraphQL.Server.Transports.AspNetCore.WebSockets;
+
+/// <summary>
+/// Processes a stream of messages received from a WebSockets client.
+/// <see cref="IDisposable.Dispose"/> must be called when the connection terminates.
+/// Methods defined within this interface need not be thread-safe.
+/// </summary>
+public interface IOperationMessageProcessor : IDisposable
+{
+    /// <summary>
+    /// Starts the connection initialization timer, if configured.
+    /// </summary>
+    Task InitializeConnectionAsync();
+
+    /// <summary>
+    /// Called when a message is received from the client.
+    /// </summary>
+    Task OnMessageReceivedAsync(OperationMessage message);
+}

--- a/src/Transports.AspNetCore/WebSockets/IOperationMessageProcessor.cs
+++ b/src/Transports.AspNetCore/WebSockets/IOperationMessageProcessor.cs
@@ -4,7 +4,8 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets;
 
 /// <summary>
 /// Processes a stream of messages received from a WebSockets client.
-/// <see cref="IDisposable.Dispose"/> must be called when the connection terminates.
+/// <see cref="IDisposable.Dispose"/> must be called when the WebSocket connection
+/// has received a close message, and/or when the connection terminates.
 /// Methods defined within this interface need not be thread-safe.
 /// </summary>
 public interface IOperationMessageProcessor : IDisposable

--- a/src/Transports.AspNetCore/WebSockets/IWebSocketAuthenticationService.cs
+++ b/src/Transports.AspNetCore/WebSockets/IWebSocketAuthenticationService.cs
@@ -1,0 +1,25 @@
+using GraphQL.Transport;
+using Microsoft.AspNetCore.Http;
+
+namespace GraphQL.Server.Transports.AspNetCore.WebSockets;
+
+/// <summary>
+/// Authenticates an incoming GraphQL over WebSockets request with the
+/// connection initialization message.  A typical implementation will
+/// set the <see cref="HttpContext.User"/> property after reading the
+/// authorization token.  This service must be registered as a singleton
+/// in the dependency injection framework.
+/// </summary>
+public interface IWebSocketAuthenticationService
+{
+    /// <summary>
+    /// Authenticates an incoming GraphQL over WebSockets request with the connection initialization message.  The implementation should
+    /// set the <paramref name="connection"/>.<see cref="IWebSocketConnection.HttpContext">HttpContext</see>.<see cref="HttpContext.User">User</see>
+    /// property after validating the provided credentials.
+    /// <br/><br/>
+    /// After calling this method to authenticate the request, the infrastructure will authorize the incoming request via the
+    /// <see cref="GraphQLHttpMiddlewareOptions.AuthorizationRequired"/>, <see cref="GraphQLHttpMiddlewareOptions.AuthorizedRoles"/> and
+    /// <see cref="GraphQLHttpMiddlewareOptions.AuthorizedPolicy"/> properties.
+    /// </summary>
+    Task AuthenticateAsync(IWebSocketConnection connection, string subProtocol, OperationMessage operationMessage);
+}

--- a/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
@@ -1,0 +1,50 @@
+using GraphQL.Transport;
+using Microsoft.AspNetCore.Http;
+
+namespace GraphQL.Server.Transports.AspNetCore.WebSockets;
+
+/// <summary>
+/// Represents a WebSocket connection, dispatching received messages over
+/// the connection to the specified <see cref="IOperationMessageProcessor"/>,
+/// and sending requested messages out the connection when requested.
+/// <br/><br/>
+/// <see cref="ExecuteAsync(IOperationMessageProcessor)"/> may be only called once.
+/// All members must be thread-safe.
+/// </summary>
+public interface IWebSocketConnection
+{
+    /// <summary>
+    /// Listens to incoming messages over the WebSocket connection,
+    /// dispatching the messages to the specified <paramref name="operationMessageProcessor"/>.
+    /// Returns or throws <see cref="OperationCanceledException"/> when the WebSocket connection is closed.
+    /// </summary>
+    Task ExecuteAsync(IOperationMessageProcessor operationMessageProcessor);
+
+    /// <summary>
+    /// Sends a message.
+    /// </summary>
+    Task SendMessageAsync(OperationMessage message);
+
+    /// <summary>
+    /// Closes the WebSocket connection.
+    /// </summary>
+    Task CloseConnectionAsync();
+
+    /// <summary>
+    /// Closes the WebSocket connection with the specified error information.
+    /// </summary>
+    Task CloseConnectionAsync(int eventId, string? description);
+
+    /// <summary>
+    /// Returns the last UTC time that a message was sent.
+    /// </summary>
+    DateTime LastMessageSentAt { get; }
+
+    /// <inheritdoc cref="HttpContext.RequestAborted"/>
+    CancellationToken RequestAborted { get; }
+
+    /// <summary>
+    /// Returns the <see cref="Microsoft.AspNetCore.Http.HttpContext"/> associated with this request.
+    /// </summary>
+    HttpContext HttpContext { get; }
+}

--- a/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
@@ -11,7 +11,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets;
 /// <see cref="ExecuteAsync(IOperationMessageProcessor)"/> may be only called once.
 /// All members must be thread-safe.
 /// </summary>
-public interface IWebSocketConnection
+public interface IWebSocketConnection : IDisposable
 {
     /// <summary>
     /// Listens to incoming messages over the WebSocket connection,
@@ -21,17 +21,17 @@ public interface IWebSocketConnection
     Task ExecuteAsync(IOperationMessageProcessor operationMessageProcessor);
 
     /// <summary>
-    /// Sends a message.
+    /// Sends a message to the client.
     /// </summary>
     Task SendMessageAsync(OperationMessage message);
 
     /// <summary>
-    /// Closes the WebSocket connection.
+    /// Performs a graceful shutdown of the WebSocket connection with event ID 1000.
     /// </summary>
     Task CloseConnectionAsync();
 
     /// <summary>
-    /// Closes the WebSocket connection with the specified error information.
+    /// Performs a graceful shutdown of the WebSocket connection with the specified error information.
     /// </summary>
     Task CloseConnectionAsync(int eventId, string? description);
 

--- a/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
@@ -36,7 +36,7 @@ public interface IWebSocketConnection : IDisposable
     Task CloseAsync(int eventId, string? description);
 
     /// <summary>
-    /// Returns the last UTC time that a message was sent.
+    /// Returns the last UTC time that a message was sent to the client. This property is needed to implement the idle timeout to only send a keep-alive message after ## seconds of "no traffic". 
     /// </summary>
     DateTime LastMessageSentAt { get; }
 

--- a/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
@@ -36,7 +36,8 @@ public interface IWebSocketConnection : IDisposable
     Task CloseAsync(int eventId, string? description);
 
     /// <summary>
-    /// Returns the last UTC time that a message was sent to the client. This property is needed to implement the idle timeout to only send a keep-alive message after ## seconds of "no traffic". 
+    /// Returns the last UTC time that a message was sent to the client.
+    /// This property is needed to implement the idle timeout to only send a keep-alive message after ## seconds of "no traffic". 
     /// </summary>
     DateTime LastMessageSentAt { get; }
 

--- a/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
@@ -28,7 +28,7 @@ public interface IWebSocketConnection : IDisposable
     /// <summary>
     /// Performs a graceful shutdown of the WebSocket connection with event ID 1000.
     /// </summary>
-    Task CloseConnectionAsync();
+    Task CloseAsync();
 
     /// <summary>
     /// Performs a graceful shutdown of the WebSocket connection with the specified error information.

--- a/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/IWebSocketConnection.cs
@@ -33,7 +33,7 @@ public interface IWebSocketConnection : IDisposable
     /// <summary>
     /// Performs a graceful shutdown of the WebSocket connection with the specified error information.
     /// </summary>
-    Task CloseConnectionAsync(int eventId, string? description);
+    Task CloseAsync(int eventId, string? description);
 
     /// <summary>
     /// Returns the last UTC time that a message was sent.

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -171,7 +171,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
     {
         System.Threading.Tasks.Task AuthenticateAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, string subProtocol, GraphQL.Transport.OperationMessage operationMessage);
     }
-    public interface IWebSocketConnection
+    public interface IWebSocketConnection : System.IDisposable
     {
         Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }
         System.DateTime LastMessageSentAt { get; }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -176,8 +176,8 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }
         System.DateTime LastMessageSentAt { get; }
         System.Threading.CancellationToken RequestAborted { get; }
-        System.Threading.Tasks.Task CloseConnectionAsync();
-        System.Threading.Tasks.Task CloseConnectionAsync(int eventId, string? description);
+        System.Threading.Tasks.Task CloseAsync();
+        System.Threading.Tasks.Task CloseAsync(int eventId, string? description);
         System.Threading.Tasks.Task ExecuteAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IOperationMessageProcessor operationMessageProcessor);
         System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message);
     }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -144,6 +144,10 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         System.Threading.Tasks.Task InitializeConnectionAsync();
         System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message);
     }
+    public interface IWebSocketAuthenticationService
+    {
+        System.Threading.Tasks.Task AuthenticateAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, string subProtocol, GraphQL.Transport.OperationMessage operationMessage);
+    }
     public interface IWebSocketConnection
     {
         Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -13,6 +13,10 @@ namespace GraphQL.Server
             where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
         public static GraphQL.DI.IGraphQLBuilder AddUserContextBuilder<TUserContext>(this GraphQL.DI.IGraphQLBuilder builder, System.Func<Microsoft.AspNetCore.Http.HttpContext, object?, TUserContext> creator)
             where TUserContext :  class, System.Collections.Generic.IDictionary<string, object?> { }
+        public static GraphQL.DI.IGraphQLBuilder AddWebSocketAuthentication(this GraphQL.DI.IGraphQLBuilder builder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService webSocketAuthenticationService) { }
+        public static GraphQL.DI.IGraphQLBuilder AddWebSocketAuthentication(this GraphQL.DI.IGraphQLBuilder builder, System.Func<System.IServiceProvider, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService> factory) { }
+        public static GraphQL.DI.IGraphQLBuilder AddWebSocketAuthentication<TWebSocketAuthenticationService>(this GraphQL.DI.IGraphQLBuilder builder)
+            where TWebSocketAuthenticationService :  class, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService { }
     }
 }
 namespace GraphQL.Server.Transports.AspNetCore

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -137,6 +137,24 @@ namespace GraphQL.Server.Transports.AspNetCore.Errors
         public WebSocketSubProtocolNotSupportedError(System.Collections.Generic.IEnumerable<string> requestedSubProtocols) { }
     }
 }
+namespace GraphQL.Server.Transports.AspNetCore.WebSockets
+{
+    public interface IOperationMessageProcessor : System.IDisposable
+    {
+        System.Threading.Tasks.Task InitializeConnectionAsync();
+        System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message);
+    }
+    public interface IWebSocketConnection
+    {
+        Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }
+        System.DateTime LastMessageSentAt { get; }
+        System.Threading.CancellationToken RequestAborted { get; }
+        System.Threading.Tasks.Task CloseConnectionAsync();
+        System.Threading.Tasks.Task CloseConnectionAsync(int eventId, string? description);
+        System.Threading.Tasks.Task ExecuteAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IOperationMessageProcessor operationMessageProcessor);
+        System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message);
+    }
+}
 namespace Microsoft.AspNetCore.Builder
 {
     public class GraphQLEndpointConventionBuilder : Microsoft.AspNetCore.Builder.IEndpointConventionBuilder


### PR DESCRIPTION
Adds the basic interfaces for GraphQL WebSocket connection support:

This consists of three interfaces:
- `IWebSocketConnection` is responsible for reading from and writing to the underlying `WebSocket`, including serialization and deserialization, maintaining thread safety for outbound messages, and disposing of the `IOperationMessageProcessor` when the connection terminates.  Based on the assumption that all incoming and outgoing packets are serializable to/from the `OperationMessage` class.
- `IOperationMessageProcessor` performs all logic associated with a connection.
- `IWebSocketAuthenticationService` performs authentication in response to a ConnectionInit message.  This is required since browsers cannot send HTTP `Authorize` headers when opening a WebSocket connection, and so the two current GraphQL over WebSockets protocols in use today allow for authentication via the payload of the initialization message, which is required before any other communication occurs on the WebSocket channel.

Basic connection initialization is performed as follows:
1. Create `IWebSocketConnection` implementation with handle to the specific ASP.NET `WebSocket`.  This implementation now has `SendMessageAsync` and `CloseConnectionAsync` methods available for sending messages to the client.
2. Create `IOperationMessageProcessor` implementation with handle to the `IWebSocketConnection`.
3. Call `IWebSocketConnection.ExecuteAsync` is called with the `IOperationMessageProcessor` instance.

`ExecuteAsync` first calls `IOperationMessageProcessor.InitializeConnectionAsync` so that any connection timers can be initialized.  `ExecuteAsync` also contains the "message loop", reading messages from the underlying `WebSocket` and passing them to `IOperationMessageProcessor.OnMessageReceivedAsync`.

Note that in PR #802 I added `IWebSocketHandler`.  The handler is responsible for setting up the appropriate `IWebSocketConnection` and `IOperationMessageProcessor` class, depending on the requested sub-protocols, allowing for selecting a sub-protocol based on which one is most preferred by the server.  Any protocol that does not use `OperationMessage`s for communication can use a different implementation.  The GraphQL HTTP middleware supports multiple installed `IWebSocketHandler` instances, so a sub-protocol can be added or overridden without affecting any of the existing code.