### PR TITLE
Split POST parsing into separate method

### DIFF
--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -304,7 +304,7 @@ public abstract class GraphQLHttpMiddleware
     /// <summary>
     /// Parses a request into a single or batch <see cref="GraphQLRequest"/> instance.
     /// <br/><br/>
-    /// In case of an error, this method will handle the request (e.g. by callling
+    /// In case of an error, this method will handle the request (e.g. by calling
     /// <see cref="WriteErrorResponseAsync(HttpContext, HttpStatusCode, ExecutionError)">WriteErrorResponseAsync</see>)
     /// and return <see langword="null"/>.
     /// </summary>

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -350,9 +350,9 @@ public abstract class GraphQLHttpMiddleware
             default:
                 if (httpRequest.HasFormContentType)
                 {
-                    var formCollection = await httpRequest.ReadFormAsync(context.RequestAborted);
                     try
                     {
+                        var formCollection = await httpRequest.ReadFormAsync(context.RequestAborted);
                         return (DeserializeFromFormBody(formCollection), null);
                     }
                     catch (Exception ex)

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -248,69 +248,17 @@ public abstract class GraphQLHttpMiddleware
                 return;
             }
 
-            switch (mediaTypeHeader.MediaType?.ToLowerInvariant())
+            if (!TryGetEncoding(mediaTypeHeader.CharSet, out var sourceEncoding))
             {
-                case MEDIATYPE_GRAPHQLJSON:
-                case MEDIATYPE_JSON:
-                    IList<GraphQLRequest?>? deserializationResult;
-                    try
-                    {
-#if NET5_0_OR_GREATER
-                        if (!TryGetEncoding(mediaTypeHeader.CharSet, out var sourceEncoding))
-                        {
-                            await HandleContentTypeCouldNotBeParsedErrorAsync(context, _next);
-                            return;
-                        }
-                        // Wrap content stream into a transcoding stream that buffers the data transcoded from the sourceEncoding to utf-8.
-                        if (sourceEncoding != null && sourceEncoding != System.Text.Encoding.UTF8)
-                        {
-                            using var tempStream = System.Text.Encoding.CreateTranscodingStream(httpRequest.Body, innerStreamEncoding: sourceEncoding, outerStreamEncoding: System.Text.Encoding.UTF8, leaveOpen: true);
-                            deserializationResult = await _serializer.ReadAsync<IList<GraphQLRequest?>>(tempStream, context.RequestAborted);
-                        }
-                        else
-                        {
-                            deserializationResult = await _serializer.ReadAsync<IList<GraphQLRequest?>>(httpRequest.Body, context.RequestAborted);
-                        }
-#else
-                        deserializationResult = await _serializer.ReadAsync<IList<GraphQLRequest?>>(httpRequest.Body, context.RequestAborted);
-#endif
-                    }
-                    catch (Exception ex)
-                    {
-                        if (!await HandleDeserializationErrorAsync(context, _next, ex))
-                            throw;
-                        return;
-                    }
-                    // https://github.com/graphql-dotnet/server/issues/751
-                    if (deserializationResult is GraphQLRequest[] array && array.Length == 1)
-                        bodyGQLRequest = deserializationResult[0];
-                    else
-                        bodyGQLBatchRequest = deserializationResult;
-                    break;
-
-                case MEDIATYPE_GRAPHQL:
-                    bodyGQLRequest = await DeserializeFromGraphBodyAsync(httpRequest.Body);
-                    break;
-
-                default:
-                    if (httpRequest.HasFormContentType)
-                    {
-                        var formCollection = await httpRequest.ReadFormAsync(context.RequestAborted);
-                        try
-                        {
-                            bodyGQLRequest = DeserializeFromFormBody(formCollection);
-                        }
-                        catch (Exception ex)
-                        {
-                            if (!await HandleDeserializationErrorAsync(context, _next, ex))
-                                throw;
-                            return;
-                        }
-                        break;
-                    }
-                    await HandleInvalidContentTypeErrorAsync(context, _next);
-                    return;
+                await HandleContentTypeCouldNotBeParsedErrorAsync(context, _next);
+                return;
             }
+
+            var singleOrBatchRequest = await ReadFormContentAsync(context, _next, mediaTypeHeader.MediaType, sourceEncoding);
+            if (singleOrBatchRequest.HasValue)
+                (bodyGQLRequest, bodyGQLBatchRequest) = singleOrBatchRequest.Value;
+            else
+                return;
         }
 
         if (bodyGQLBatchRequest == null)
@@ -350,6 +298,72 @@ public abstract class GraphQLHttpMiddleware
         else
         {
             await HandleBatchedRequestsNotSupportedAsync(context, _next);
+        }
+    }
+
+    /// <summary>
+    /// Parses a request into a single or batch <see cref="GraphQLRequest"/> instance.
+    /// In case of an error, write the response and return <see langword="null"/>.
+    /// </summary>
+    protected virtual async Task<(GraphQLRequest? SingleRequest, IList<GraphQLRequest?>? BatchRequest)?> ReadFormContentAsync(
+        HttpContext context, RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding)
+    {
+        var httpRequest = context.Request;
+
+        switch (mediaType?.ToLowerInvariant())
+        {
+            case MEDIATYPE_GRAPHQLJSON:
+            case MEDIATYPE_JSON:
+                IList<GraphQLRequest?>? deserializationResult;
+                try
+                {
+#if NET5_0_OR_GREATER
+                    // Wrap content stream into a transcoding stream that buffers the data transcoded from the sourceEncoding to utf-8.
+                    if (sourceEncoding != null && sourceEncoding != System.Text.Encoding.UTF8)
+                    {
+                        using var tempStream = System.Text.Encoding.CreateTranscodingStream(httpRequest.Body, innerStreamEncoding: sourceEncoding, outerStreamEncoding: System.Text.Encoding.UTF8, leaveOpen: true);
+                        deserializationResult = await _serializer.ReadAsync<IList<GraphQLRequest?>>(tempStream, context.RequestAborted);
+                    }
+                    else
+                    {
+                        deserializationResult = await _serializer.ReadAsync<IList<GraphQLRequest?>>(httpRequest.Body, context.RequestAborted);
+                    }
+#else
+                    deserializationResult = await _serializer.ReadAsync<IList<GraphQLRequest?>>(httpRequest.Body, context.RequestAborted);
+#endif
+                }
+                catch (Exception ex)
+                {
+                    if (!await HandleDeserializationErrorAsync(context, _next, ex))
+                        throw;
+                    return null;
+                }
+                // https://github.com/graphql-dotnet/server/issues/751
+                if (deserializationResult is GraphQLRequest[] array && array.Length == 1)
+                    return (deserializationResult[0], null);
+                else
+                    return (null, deserializationResult);
+
+            case MEDIATYPE_GRAPHQL:
+                return (await DeserializeFromGraphBodyAsync(httpRequest.Body, sourceEncoding), null);
+
+            default:
+                if (httpRequest.HasFormContentType)
+                {
+                    var formCollection = await httpRequest.ReadFormAsync(context.RequestAborted);
+                    try
+                    {
+                        return (DeserializeFromFormBody(formCollection), null);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!await HandleDeserializationErrorAsync(context, _next, ex))
+                            throw;
+                        return null;
+                    }
+                }
+                await HandleInvalidContentTypeErrorAsync(context, _next);
+                return null;
         }
     }
 
@@ -669,10 +683,10 @@ public abstract class GraphQLHttpMiddleware
     /// <summary>
     /// Reads body of content type: application/graphql
     /// </summary>
-    private static async Task<GraphQLRequest> DeserializeFromGraphBodyAsync(Stream bodyStream)
+    private static async Task<GraphQLRequest> DeserializeFromGraphBodyAsync(Stream bodyStream, System.Text.Encoding? encoding)
     {
         // do not close underlying HTTP connection
-        using var streamReader = new StreamReader(bodyStream, leaveOpen: true);
+        using var streamReader = new StreamReader(bodyStream, encoding, leaveOpen: true);
 
         // read query text
         string query = await streamReader.ReadToEndAsync();
@@ -681,7 +695,6 @@ public abstract class GraphQLHttpMiddleware
         return new GraphQLRequest { Query = query };
     }
 
-#if NET5_0_OR_GREATER
     private static bool TryGetEncoding(string? charset, out System.Text.Encoding? encoding)
     {
         encoding = null;
@@ -708,5 +721,4 @@ public abstract class GraphQLHttpMiddleware
 
         return true;
     }
-#endif
 }

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -303,7 +303,10 @@ public abstract class GraphQLHttpMiddleware
 
     /// <summary>
     /// Parses a request into a single or batch <see cref="GraphQLRequest"/> instance.
-    /// In case of an error, write the response and return <see langword="null"/>.
+    /// <br/><br/>
+    /// In case of an error, this method will handle the request (e.g. by callling
+    /// <see cref="WriteErrorResponseAsync(HttpContext, HttpStatusCode, ExecutionError)">WriteErrorResponseAsync</see>)
+    /// and return <see langword="null"/>.
     /// </summary>
     protected virtual async Task<(GraphQLRequest? SingleRequest, IList<GraphQLRequest?>? BatchRequest)?> ReadFormContentAsync(
         HttpContext context, RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding)

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -254,7 +254,7 @@ public abstract class GraphQLHttpMiddleware
                 return;
             }
 
-            var singleOrBatchRequest = await ReadFormContentAsync(context, _next, mediaTypeHeader.MediaType, sourceEncoding);
+            var singleOrBatchRequest = await ReadPostContentAsync(context, _next, mediaTypeHeader.MediaType, sourceEncoding);
             if (singleOrBatchRequest.HasValue)
                 (bodyGQLRequest, bodyGQLBatchRequest) = singleOrBatchRequest.Value;
             else
@@ -308,7 +308,7 @@ public abstract class GraphQLHttpMiddleware
     /// <see cref="WriteErrorResponseAsync(HttpContext, HttpStatusCode, ExecutionError)">WriteErrorResponseAsync</see>)
     /// and return <see langword="null"/>.
     /// </summary>
-    protected virtual async Task<(GraphQLRequest? SingleRequest, IList<GraphQLRequest?>? BatchRequest)?> ReadFormContentAsync(
+    protected virtual async Task<(GraphQLRequest? SingleRequest, IList<GraphQLRequest?>? BatchRequest)?> ReadPostContentAsync(
         HttpContext context, RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding)
     {
         var httpRequest = context.Request;
@@ -689,7 +689,7 @@ public abstract class GraphQLHttpMiddleware
     private static async Task<GraphQLRequest> DeserializeFromGraphBodyAsync(Stream bodyStream, System.Text.Encoding? encoding)
     {
         // do not close underlying HTTP connection
-        using var streamReader = new StreamReader(bodyStream, encoding, leaveOpen: true);
+        using var streamReader = new StreamReader(bodyStream, encoding ?? System.Text.Encoding.UTF8, true, 1024, leaveOpen: true);
 
         // read query text
         string query = await streamReader.ReadToEndAsync();

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -54,6 +54,10 @@ namespace GraphQL.Server.Transports.AspNetCore
         protected virtual System.Threading.Tasks.Task HandleWebSocketAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleWebSocketSubProtocolNotSupportedAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         public virtual System.Threading.Tasks.Task InvokeAsync(Microsoft.AspNetCore.Http.HttpContext context) { }
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "SingleRequest",
+                "BatchRequest"})]
+        protected virtual System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Transport.GraphQLRequest?, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?>?>?> ReadFormContentAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding) { }
         protected virtual string SelectResponseContentType(Microsoft.AspNetCore.Http.HttpContext context) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, string errorMessage) { }

--- a/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -61,7 +61,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "SingleRequest",
                 "BatchRequest"})]
-        protected virtual System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Transport.GraphQLRequest?, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?>?>?> ReadFormContentAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding) { }
+        protected virtual System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Transport.GraphQLRequest?, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?>?>?> ReadPostContentAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding) { }
         protected virtual string SelectResponseContentType(Microsoft.AspNetCore.Http.HttpContext context) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, string errorMessage) { }


### PR DESCRIPTION
Allows for overriding `ReadPostContentAsync` to support additional form content types.  One specific example is to support attached files for form content types.  See sample at https://github.com/Shane32/GraphQL.AspNetCore3/blob/3caec91cf9fdce9d6a141423ace5144194c2a225/src/Tests/Middleware/FileUploadTests.cs#L59

Mirrors https://github.com/Shane32/GraphQL.AspNetCore3/pull/40