### PR TITLE
Fix noisy warning

### DIFF
--- a/tests/Samples.Server.Tests/Serializer.cs
+++ b/tests/Samples.Server.Tests/Serializer.cs
@@ -16,7 +16,14 @@ internal static class Serializer
         => ToJson(Array.ConvertAll(requests, r => r.ToDictionary()));
 
     public static string ToJson(object obj)
-        => JsonSerializer.Serialize(obj, new JsonSerializerOptions { IgnoreNullValues = true });
+        => JsonSerializer.Serialize(obj, new JsonSerializerOptions
+        {
+#if NET6_0_OR_GREATER
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+#else
+            IgnoreNullValues = true
+#endif
+        });
 
     internal static FormUrlEncodedContent ToFormUrlEncodedContent(GraphQLRequest request)
     {


### PR DESCRIPTION
Open https://github.com/graphql-dotnet/server/pull/810/files and scroll to the page end. You will see `Unchanged files with check annotations` section with 20! equal warnings.