### PR TITLE
Include MicrosoftDI and SystemTextJson packages

### DIFF
--- a/samples/Samples.Server/Samples.Server.csproj
+++ b/samples/Samples.Server/Samples.Server.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="GraphQL.DataLoader" Version="$(GraphQLVersion)" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="GraphQL.MicrosoftDI" Version="$(GraphQLVersion)" />
     <PackageReference Include="GraphQL.SystemTextJson" Version="$(GraphQLVersion)" />
   </ItemGroup>
 

--- a/samples/Samples.Server/Samples.Server.csproj
+++ b/samples/Samples.Server/Samples.Server.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="GraphQL.DataLoader" Version="$(GraphQLVersion)" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="GraphQL.SystemTextJson" Version="$(GraphQLVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Transports.AspNetCore/Transports.AspNetCore.csproj
+++ b/src/Transports.AspNetCore/Transports.AspNetCore.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' AND '$(TargetFramework)' != 'netcoreapp2.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="GraphQL.SystemTextJson" Version="$(GraphQLVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.1'">

--- a/src/Transports.AspNetCore/Transports.AspNetCore.csproj
+++ b/src/Transports.AspNetCore/Transports.AspNetCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="$(GraphQLVersion)" />
+    <PackageReference Include="GraphQL.MicrosoftDI" Version="$(GraphQLVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' AND '$(TargetFramework)' != 'netcoreapp2.1'">

--- a/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
+++ b/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
@@ -8,8 +8,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />
-    <PackageReference Include="GraphQL.SystemTextJson" Version="5.1.1" />
-    <PackageReference Include="GraphQL.NewtonsoftJson" Version="5.1.1" />
+    <PackageReference Include="GraphQL.NewtonsoftJson" Version="$(GraphQLVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
+++ b/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Castle.Core" Version="5.0.0" />
+    <PackageReference Include="GraphQL.SystemTextJson" Version="$(GraphQLVersion)" />
     <PackageReference Include="GraphQL.NewtonsoftJson" Version="$(GraphQLVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
These changes do not bring any dependencies that are not already required by ASP.NET Core:

### 1. ASP.NET Core already depends on Microsoft.Extensions.Options 2.0.0+:

For ASP.NET Core 3.1+ see:
- https://github.com/dotnet/aspnetcore/blob/main/eng/SharedFramework.External.props

For ASP.NET Core 2.1 see:
- https://www.nuget.org/packages/Microsoft.AspNetCore/2.1.7#dependencies-body-tab
- https://www.nuget.org/packages/Microsoft.AspNetCore.Hosting/2.1.1#dependencies-body-tab

### 2. .NET Core 3.1 already includes System.Text.Json

The reference to the `System.Text.Json` package for .NET Core 3.1 was removed in https://github.com/graphql-dotnet/graphql-dotnet/pull/3199

### Summary

Along with changing the extension methods to be within the GraphQL namespace, these changes simplify the required packages to use GraphQL.Server without creating any 3rd party dependencies.  Users may still utilize GraphQL.NewtonsoftJson if desired, and as far as I know, .NET Core will not load an assembly at runtime until referenced.  I cannot think of a good reason not to include these packages.

### Notes

For ASP.NET Core 2.1, users will still need to reference either the GraphQL.NewtonsoftJson or GraphQL.SystemTextJson package.  The Microsoft.AspNetCore.App package has an indirect dependency on Newtonsoft.Json 11.0.2+, as at the time it was the default serializer, but the GraphQL.NewtonsoftJson brings a newer version of Newtonsoft.Json so it is not included.

We may still include other GraphQL packages within the GraphQL.Server.All meta package as desired, such as GraphQL.DataLoader or GraphQL.MemoryCache.  The changes included here are typically required to use GraphQL.Server, and don't require external dependencies.