### PR TITLE
Add ExecutionResultActionResult

### DIFF
--- a/src/Transports.AspNetCore/ExecutionResultActionResult.cs
+++ b/src/Transports.AspNetCore/ExecutionResultActionResult.cs
@@ -1,0 +1,34 @@
+namespace GraphQL.Server.Transports.AspNetCore;
+
+/// <summary>
+/// An action result that formats the <see cref="ExecutionResult"/> as JSON.
+/// </summary>
+public sealed class ExecutionResultActionResult : IActionResult
+{
+    private readonly ExecutionResult _executionResult;
+    private readonly HttpStatusCode _statusCode;
+
+    /// <inheritdoc cref="ExecutionResultActionResult"/>
+    public ExecutionResultActionResult(ExecutionResult executionResult)
+    {
+        _executionResult = executionResult;
+        _statusCode = executionResult.Executed ? HttpStatusCode.OK : HttpStatusCode.BadRequest;
+    }
+
+    /// <inheritdoc cref="ExecutionResultActionResult"/>
+    public ExecutionResultActionResult(ExecutionResult executionResult, HttpStatusCode statusCode)
+    {
+        _executionResult = executionResult;
+        _statusCode = statusCode;
+    }
+
+    /// <inheritdoc/>
+    public async Task ExecuteResultAsync(ActionContext context)
+    {
+        var writer = context.HttpContext.RequestServices.GetRequiredService<IGraphQLSerializer>();
+        var response = context.HttpContext.Response;
+        response.ContentType = GraphQLHttpMiddleware.CONTENTTYPE_GRAPHQLJSON;
+        response.StatusCode = (int)_statusCode;
+        await writer.WriteAsync(response.Body, _executionResult, context.HttpContext.RequestAborted);
+    }
+}

--- a/src/Transports.AspNetCore/ExecutionResultActionResult.cs
+++ b/src/Transports.AspNetCore/ExecutionResultActionResult.cs
@@ -22,13 +22,16 @@ public sealed class ExecutionResultActionResult : IActionResult
         _statusCode = statusCode;
     }
 
+    /// <inheritdoc cref="HttpResponse.ContentType"/>
+    public string ContentType { get; set; } = GraphQLHttpMiddleware.CONTENTTYPE_GRAPHQLJSON;
+
     /// <inheritdoc/>
     public async Task ExecuteResultAsync(ActionContext context)
     {
-        var writer = context.HttpContext.RequestServices.GetRequiredService<IGraphQLSerializer>();
+        var serializer = context.HttpContext.RequestServices.GetRequiredService<IGraphQLSerializer>();
         var response = context.HttpContext.Response;
-        response.ContentType = GraphQLHttpMiddleware.CONTENTTYPE_GRAPHQLJSON;
+        response.ContentType = ContentType;
         response.StatusCode = (int)_statusCode;
-        await writer.WriteAsync(response.Body, _executionResult, context.HttpContext.RequestAborted);
+        await serializer.WriteAsync(response.Body, _executionResult, context.HttpContext.RequestAborted);
     }
 }

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -54,7 +54,7 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     private const string MEDIATYPE_GRAPHQLJSON = "application/graphql+json";
     private const string MEDIATYPE_JSON = "application/json";
     private const string MEDIATYPE_GRAPHQL = "application/graphql";
-    private const string CONTENTTYPE_GRAPHQLJSON = "application/graphql+json; charset=utf-8";
+    internal const string CONTENTTYPE_GRAPHQLJSON = "application/graphql+json; charset=utf-8";
 
     /// <summary>
     /// Initializes a new instance.

--- a/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -58,6 +58,7 @@ namespace GraphQL.Server.Transports.AspNetCore
     {
         public ExecutionResultActionResult(GraphQL.ExecutionResult executionResult) { }
         public ExecutionResultActionResult(GraphQL.ExecutionResult executionResult, System.Net.HttpStatusCode statusCode) { }
+        public string ContentType { get; set; }
         public System.Threading.Tasks.Task ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext context) { }
     }
     public class GraphQLHttpMiddleware : GraphQL.Server.Transports.AspNetCore.IUserContextBuilder

--- a/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -54,6 +54,12 @@ namespace GraphQL.Server.Transports.AspNetCore
             public GraphQL.Types.IGraphType? ParentGraphType { get; set; }
         }
     }
+    public sealed class ExecutionResultActionResult : Microsoft.AspNetCore.Mvc.IActionResult
+    {
+        public ExecutionResultActionResult(GraphQL.ExecutionResult executionResult) { }
+        public ExecutionResultActionResult(GraphQL.ExecutionResult executionResult, System.Net.HttpStatusCode statusCode) { }
+        public System.Threading.Tasks.Task ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext context) { }
+    }
     public class GraphQLHttpMiddleware : GraphQL.Server.Transports.AspNetCore.IUserContextBuilder
     {
         public GraphQLHttpMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, GraphQL.IGraphQLTextSerializer serializer, GraphQL.IDocumentExecuter documentExecuter, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.GraphQLHttpMiddlewareOptions options, Microsoft.Extensions.Hosting.IHostApplicationLifetime hostApplicationLifetime) { }

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -65,6 +65,7 @@ namespace GraphQL.Server.Transports.AspNetCore
     {
         public ExecutionResultActionResult(GraphQL.ExecutionResult executionResult) { }
         public ExecutionResultActionResult(GraphQL.ExecutionResult executionResult, System.Net.HttpStatusCode statusCode) { }
+        public string ContentType { get; set; }
         public System.Threading.Tasks.Task ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext context) { }
     }
     public class GraphQLHttpMiddleware : GraphQL.Server.Transports.AspNetCore.IUserContextBuilder

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -61,6 +61,12 @@ namespace GraphQL.Server.Transports.AspNetCore
             public GraphQL.Types.IGraphType? ParentGraphType { get; set; }
         }
     }
+    public sealed class ExecutionResultActionResult : Microsoft.AspNetCore.Mvc.IActionResult
+    {
+        public ExecutionResultActionResult(GraphQL.ExecutionResult executionResult) { }
+        public ExecutionResultActionResult(GraphQL.ExecutionResult executionResult, System.Net.HttpStatusCode statusCode) { }
+        public System.Threading.Tasks.Task ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext context) { }
+    }
     public class GraphQLHttpMiddleware : GraphQL.Server.Transports.AspNetCore.IUserContextBuilder
     {
         public GraphQLHttpMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, GraphQL.IGraphQLTextSerializer serializer, GraphQL.IDocumentExecuter documentExecuter, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.GraphQLHttpMiddlewareOptions options, GraphQL.Server.Transports.AspNetCore.IHostApplicationLifetime hostApplicationLifetime) { }


### PR DESCRIPTION
As there are many users who still use or prefer to use MVC controller actions to execute a GraphQL request, this `IActionResult` implementation allows for proper serializing of the `ExecutionResult`.  As this project caters to ASP.Net Core, it seems appropriate to add it here.  It is very small with only 9 executable lines of code; the whole file is just 35 lines.

Tests will be added after #838 is merged