### PR TITLE
Add override for VisitOperationDefinitionAsync

### DIFF
--- a/src/Transports.AspNetCore/AuthorizationVisitorBase.GetRecursivelyReferencedUsedFragments.cs
+++ b/src/Transports.AspNetCore/AuthorizationVisitorBase.GetRecursivelyReferencedUsedFragments.cs
@@ -53,6 +53,9 @@ public partial class AuthorizationVisitorBase
             return default;
         }
 
+        protected override ValueTask VisitOperationDefinitionAsync(GraphQLOperationDefinition operationDefinition, GetRecursivelyReferencedFragmentsVisitorContext context)
+            => VisitAsync(operationDefinition.SelectionSet, context);
+
         protected override ValueTask VisitSelectionSetAsync(GraphQLSelectionSet selectionSet, GetRecursivelyReferencedFragmentsVisitorContext context)
             => VisitAsync(selectionSet.Selections, context);
 


### PR DESCRIPTION
With the addition of overriding the operation, all other node types should be skipped, I believe.