### PR TITLE
Bump to GraphQL v6/7 beta

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <RootNamespace>GraphQL.Server.$(MSBuildProjectName)</RootNamespace>
     <PackageId>GraphQL.Server.$(MSBuildProjectName)</PackageId>
 
-    <GraphQLVersion>5.3.0</GraphQLVersion>
+    <GraphQLVersion>6.0.0-preview-602</GraphQLVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/samples/Samples.Server/Startup.cs
+++ b/samples/Samples.Server/Startup.cs
@@ -1,13 +1,10 @@
-using GraphQL.DataLoader;
 using GraphQL.Execution;
-using GraphQL.MicrosoftDI;
 using GraphQL.Samples.Schemas.Chat;
 using GraphQL.Server.Transports.AspNetCore;
 using GraphQL.Server.Ui.Altair;
 using GraphQL.Server.Ui.GraphiQL;
 using GraphQL.Server.Ui.Playground;
 using GraphQL.Server.Ui.Voyager;
-using GraphQL.SystemTextJson;
 
 namespace GraphQL.Samples.Server;
 

--- a/samples/Samples.Server/StartupWithRouting.cs
+++ b/samples/Samples.Server/StartupWithRouting.cs
@@ -1,13 +1,10 @@
-using GraphQL.DataLoader;
 using GraphQL.Execution;
-using GraphQL.MicrosoftDI;
 using GraphQL.Samples.Schemas.Chat;
 using GraphQL.Server.Transports.AspNetCore;
 using GraphQL.Server.Ui.Altair;
 using GraphQL.Server.Ui.GraphiQL;
 using GraphQL.Server.Ui.Playground;
 using GraphQL.Server.Ui.Voyager;
-using GraphQL.SystemTextJson;
 
 namespace GraphQL.Samples.Server;
 

--- a/src/Transports.AspNetCore/AuthorizationValidationRule.cs
+++ b/src/Transports.AspNetCore/AuthorizationValidationRule.cs
@@ -14,7 +14,7 @@ public class AuthorizationValidationRule : IValidationRule
     }
 
     /// <inheritdoc/>
-    public virtual ValueTask<INodeVisitor?> ValidateAsync(ValidationContext context)
+    public virtual async ValueTask<INodeVisitor?> ValidateAsync(ValidationContext context)
     {
         var httpContext = _contextAccessor.HttpContext
             ?? throw new InvalidOperationException("HttpContext could not be retrieved from IHttpContextAccessor.");
@@ -27,6 +27,6 @@ public class AuthorizationValidationRule : IValidationRule
 
         var visitor = new AuthorizationVisitor(context, user, authService);
         // if the schema fails authentication, report the error and do not perform any additional authorization checks.
-        return visitor.ValidateSchema(context) ? new(visitor) : default;
+        return await visitor.ValidateSchemaAsync(context) ? visitor : null;
     }
 }

--- a/src/Transports.AspNetCore/AuthorizationVisitor.cs
+++ b/src/Transports.AspNetCore/AuthorizationVisitor.cs
@@ -32,6 +32,6 @@ public class AuthorizationVisitor : AuthorizationVisitorBase
         => ClaimsPrincipal.IsInRole(role);
 
     /// <inheritdoc/>
-    protected override AuthorizationResult Authorize(string policy)
-        => AuthorizationService.AuthorizeAsync(ClaimsPrincipal, policy).GetAwaiter().GetResult();
+    protected override ValueTask<AuthorizationResult> AuthorizeAsync(string policy)
+        => new(AuthorizationService.AuthorizeAsync(ClaimsPrincipal, policy));
 }

--- a/src/Transports.AspNetCore/AuthorizationVisitorBase.Validation.cs
+++ b/src/Transports.AspNetCore/AuthorizationVisitorBase.Validation.cs
@@ -6,14 +6,14 @@ public partial class AuthorizationVisitorBase
     /// Validates authorization rules for the schema.
     /// Returns a value indicating if validation was successful.
     /// </summary>
-    public virtual bool ValidateSchema(ValidationContext context)
-        => Validate(context.Schema, null, context);
+    public virtual ValueTask<bool> ValidateSchemaAsync(ValidationContext context)
+        => ValidateAsync(context.Schema, null, context);
 
     /// <summary>
     /// Validate a node that is current within the context.
     /// </summary>
-    private bool Validate(IProvideMetadata obj, ASTNode? node, ValidationContext context)
-        => Validate(BuildValidationInfo(node, obj, context));
+    private ValueTask<bool> ValidateAsync(IProvideMetadata obj, ASTNode? node, ValidationContext context)
+        => ValidateAsync(BuildValidationInfo(node, obj, context));
 
     /// <summary>
     /// Initializes a new <see cref="ValidationInfo"/> instance for the specified node.
@@ -69,7 +69,7 @@ public partial class AuthorizationVisitorBase
     /// as this is handled elsewhere.
     /// Returns a value indicating if validation was successful for this node.
     /// </summary>
-    protected virtual bool Validate(ValidationInfo info)
+    protected virtual async ValueTask<bool> ValidateAsync(ValidationInfo info)
     {
         bool requiresAuthorization = info.Obj.IsAuthorizationRequired();
         if (!requiresAuthorization)
@@ -85,7 +85,7 @@ public partial class AuthorizationVisitorBase
             {
                 if (!_policyResults.TryGetValue(policy, out var result))
                 {
-                    result = Authorize(policy);
+                    result = await AuthorizeAsync(policy);
                     _policyResults.Add(policy, result);
                 }
                 if (!result.Succeeded)
@@ -136,7 +136,7 @@ public partial class AuthorizationVisitorBase
     protected abstract bool IsInRole(string role);
 
     /// <inheritdoc cref="IAuthorizationService.AuthorizeAsync(ClaimsPrincipal, object, string)"/>
-    protected abstract AuthorizationResult Authorize(string policy);
+    protected abstract ValueTask<AuthorizationResult> AuthorizeAsync(string policy);
 
     /// <summary>
     /// Adds a error to the validation context indicating that the user is not authenticated

--- a/src/Transports.AspNetCore/AuthorizationVisitorBase.cs
+++ b/src/Transports.AspNetCore/AuthorizationVisitorBase.cs
@@ -137,7 +137,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
         if (node == context.Operation)
         {
             _checkTree = false;
-            await PopAndProcess();
+            await PopAndProcessAsync();
         }
         else if (node is GraphQLFragmentDefinition fragmentDefinition)
         {
@@ -152,12 +152,12 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
         }
         else if (_checkTree && node is GraphQLField)
         {
-            await PopAndProcess();
+            await PopAndProcessAsync();
         }
 
         // pop the current type info, and validate the type if it does not contain only fields marked
         // with AllowAnonymous (assuming it is not waiting on fragments)
-        async ValueTask PopAndProcess()
+        async ValueTask PopAndProcessAsync()
         {
             var info = _onlyAnonymousSelected.Pop();
             var type = context.TypeInfo.GetLastType()?.GetNamedType();

--- a/src/Transports.AspNetCore/AuthorizationVisitorBase.cs
+++ b/src/Transports.AspNetCore/AuthorizationVisitorBase.cs
@@ -19,7 +19,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
     private List<TodoInfo>? _todos;
 
     /// <inheritdoc/>
-    public virtual void Enter(ASTNode node, ValidationContext context)
+    public virtual async ValueTask EnterAsync(ASTNode node, ValidationContext context)
     {
         // if the node is the selected operation, or if it is a fragment referenced by the current operation,
         // then enable authorization checks on decendant nodes (_checkTree = true)
@@ -67,7 +67,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
                     // Fields, unlike types, are validated immediately.
                     if (!fieldAnonymousAllowed)
                     {
-                        Validate(field, node, context);
+                        await ValidateAsync(field, node, context);
                     }
                 }
 
@@ -112,7 +112,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
                     var arg = context.TypeInfo.GetArgument();
                     if (arg != null)
                     {
-                        Validate(arg, node, context);
+                        await ValidateAsync(arg, node, context);
                     }
                 }
             }
@@ -120,7 +120,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
     }
 
     /// <inheritdoc/>
-    public virtual void Leave(ASTNode node, ValidationContext context)
+    public virtual async ValueTask LeaveAsync(ASTNode node, ValidationContext context)
     {
         if (!_checkTree)
         {
@@ -137,7 +137,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
         if (node == context.Operation)
         {
             _checkTree = false;
-            PopAndProcess();
+            await PopAndProcess();
         }
         else if (node is GraphQLFragmentDefinition fragmentDefinition)
         {
@@ -146,18 +146,18 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
             _checkTree = false;
             var fragmentName = fragmentDefinition.FragmentName.Name.StringValue;
             var ti = _onlyAnonymousSelected.Pop();
-            RecursiveResolve(fragmentName, ti, context);
+            await RecursiveResolveAsync(fragmentName, ti, context);
             _fragments ??= new();
             _fragments.TryAdd(fragmentName, ti);
         }
         else if (_checkTree && node is GraphQLField)
         {
-            PopAndProcess();
+            await PopAndProcess();
         }
 
         // pop the current type info, and validate the type if it does not contain only fields marked
         // with AllowAnonymous (assuming it is not waiting on fragments)
-        void PopAndProcess()
+        async ValueTask PopAndProcess()
         {
             var info = _onlyAnonymousSelected.Pop();
             var type = context.TypeInfo.GetLastType()?.GetNamedType();
@@ -165,7 +165,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
                 return;
             if (info.AnyAuthenticated || (!info.AnyAnonymous && (info.WaitingOnFragments?.Count ?? 0) == 0))
             {
-                Validate(type, node, context);
+                await ValidateAsync(type, node, context);
             }
             else if (info.WaitingOnFragments?.Count > 0)
             {
@@ -245,7 +245,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
     /// Runs when a fragment is added or updated; the fragment might not be waiting on any
     /// other fragments, or it still might be.
     /// </summary>
-    private void RecursiveResolve(string fragmentName, TypeInfo ti, ValidationContext context)
+    private async ValueTask RecursiveResolveAsync(string fragmentName, TypeInfo ti, ValidationContext context)
     {
         // first see if any other fragments are waiting on this fragment
         if (_fragments != null)
@@ -259,7 +259,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
                     ti2.AnyAuthenticated |= ti.AnyAuthenticated;
                     ti2.AnyAnonymous |= ti.AnyAnonymous;
                     _fragments[fragment.Key] = ti2;
-                    RecursiveResolve(fragment.Key, ti2, context);
+                    await RecursiveResolveAsync(fragment.Key, ti2, context);
                     goto Retry; // modifying a collection at runtime is not supported
                 }
             }
@@ -283,7 +283,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
                             count--;
                             if (todo.AnyAuthenticated || !todo.AnyAnonymous)
                             {
-                                Validate(todo.ValidationInfo);
+                                await ValidateAsync(todo.ValidationInfo);
                             }
                         }
                     }

--- a/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -26,25 +26,25 @@ namespace GraphQL.Server.Transports.AspNetCore
         protected Microsoft.AspNetCore.Authorization.IAuthorizationService AuthorizationService { get; }
         protected System.Security.Claims.ClaimsPrincipal ClaimsPrincipal { get; }
         protected override bool IsAuthenticated { get; }
-        protected override Microsoft.AspNetCore.Authorization.AuthorizationResult Authorize(string policy) { }
+        protected override System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Authorization.AuthorizationResult> AuthorizeAsync(string policy) { }
         protected override bool IsInRole(string role) { }
     }
     public abstract class AuthorizationVisitorBase : GraphQL.Validation.INodeVisitor
     {
         public AuthorizationVisitorBase(GraphQL.Validation.ValidationContext context) { }
         protected abstract bool IsAuthenticated { get; }
-        protected abstract Microsoft.AspNetCore.Authorization.AuthorizationResult Authorize(string policy);
-        public virtual void Enter(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
+        protected abstract System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Authorization.AuthorizationResult> AuthorizeAsync(string policy);
+        public virtual System.Threading.Tasks.ValueTask EnterAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
         protected virtual string GenerateResourceDescription(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info) { }
         protected System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedUsedFragments(GraphQL.Validation.ValidationContext validationContext) { }
         protected virtual void HandleNodeNotAuthorized(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info) { }
         protected virtual void HandleNodeNotInPolicy(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info, string policy, Microsoft.AspNetCore.Authorization.AuthorizationResult authorizationResult) { }
         protected virtual void HandleNodeNotInRoles(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info, System.Collections.Generic.List<string> roles) { }
         protected abstract bool IsInRole(string role);
-        public virtual void Leave(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
+        public virtual System.Threading.Tasks.ValueTask LeaveAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
         protected virtual bool SkipNode(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
-        protected virtual bool Validate(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info) { }
-        public virtual bool ValidateSchema(GraphQL.Validation.ValidationContext context) { }
+        protected virtual System.Threading.Tasks.ValueTask<bool> ValidateAsync(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info) { }
+        public virtual System.Threading.Tasks.ValueTask<bool> ValidateSchemaAsync(GraphQL.Validation.ValidationContext context) { }
         public readonly struct ValidationInfo : System.IEquatable<GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo>
         {
             public ValidationInfo(GraphQL.Types.IProvideMetadata Obj, GraphQLParser.AST.ASTNode? Node, GraphQL.Types.IFieldType? ParentFieldType, GraphQL.Types.IGraphType? ParentGraphType, GraphQL.Validation.ValidationContext Context) { }

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -33,25 +33,25 @@ namespace GraphQL.Server.Transports.AspNetCore
         protected Microsoft.AspNetCore.Authorization.IAuthorizationService AuthorizationService { get; }
         protected System.Security.Claims.ClaimsPrincipal ClaimsPrincipal { get; }
         protected override bool IsAuthenticated { get; }
-        protected override Microsoft.AspNetCore.Authorization.AuthorizationResult Authorize(string policy) { }
+        protected override System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Authorization.AuthorizationResult> AuthorizeAsync(string policy) { }
         protected override bool IsInRole(string role) { }
     }
     public abstract class AuthorizationVisitorBase : GraphQL.Validation.INodeVisitor
     {
         public AuthorizationVisitorBase(GraphQL.Validation.ValidationContext context) { }
         protected abstract bool IsAuthenticated { get; }
-        protected abstract Microsoft.AspNetCore.Authorization.AuthorizationResult Authorize(string policy);
-        public virtual void Enter(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
+        protected abstract System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Authorization.AuthorizationResult> AuthorizeAsync(string policy);
+        public virtual System.Threading.Tasks.ValueTask EnterAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
         protected virtual string GenerateResourceDescription(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info) { }
         protected System.Collections.Generic.List<GraphQLParser.AST.GraphQLFragmentDefinition>? GetRecursivelyReferencedUsedFragments(GraphQL.Validation.ValidationContext validationContext) { }
         protected virtual void HandleNodeNotAuthorized(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info) { }
         protected virtual void HandleNodeNotInPolicy(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info, string policy, Microsoft.AspNetCore.Authorization.AuthorizationResult authorizationResult) { }
         protected virtual void HandleNodeNotInRoles(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info, System.Collections.Generic.List<string> roles) { }
         protected abstract bool IsInRole(string role);
-        public virtual void Leave(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
+        public virtual System.Threading.Tasks.ValueTask LeaveAsync(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
         protected virtual bool SkipNode(GraphQLParser.AST.ASTNode node, GraphQL.Validation.ValidationContext context) { }
-        protected virtual bool Validate(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info) { }
-        public virtual bool ValidateSchema(GraphQL.Validation.ValidationContext context) { }
+        protected virtual System.Threading.Tasks.ValueTask<bool> ValidateAsync(GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo info) { }
+        public virtual System.Threading.Tasks.ValueTask<bool> ValidateSchemaAsync(GraphQL.Validation.ValidationContext context) { }
         public readonly struct ValidationInfo : System.IEquatable<GraphQL.Server.Transports.AspNetCore.AuthorizationVisitorBase.ValidationInfo>
         {
             public ValidationInfo(GraphQL.Types.IProvideMetadata Obj, GraphQLParser.AST.ASTNode? Node, GraphQL.Types.IFieldType? ParentFieldType, GraphQL.Types.IGraphType? ParentGraphType, GraphQL.Validation.ValidationContext Context) { }


### PR DESCRIPTION
Changes the authorization validation visitor to be async, eliminating `GetAwaiter().GetResult()` when calling `AuthorizationService.AuthorizeAsync`.