### PR TITLE
Support absolute and relative URLs

### DIFF
--- a/samples/Samples.Complex/Startup.cs
+++ b/samples/Samples.Complex/Startup.cs
@@ -61,7 +61,7 @@ public class Startup
         app.UseGraphQLPlayground(new PlaygroundOptions
         {
             BetaUpdates = true,
-            RequestCredentials = RequestCredentials.Omit,
+            RequestCredentials = Server.Ui.Playground.RequestCredentials.Omit,
             HideTracingResponse = false,
 
             EditorCursorShape = EditorCursorShape.Line,

--- a/samples/Samples.Complex/StartupWithRouting.cs
+++ b/samples/Samples.Complex/StartupWithRouting.cs
@@ -66,7 +66,7 @@ public class StartupWithRouting
             endpoints.MapGraphQLPlayground(new PlaygroundOptions
             {
                 BetaUpdates = true,
-                RequestCredentials = RequestCredentials.Omit,
+                RequestCredentials = Server.Ui.Playground.RequestCredentials.Omit,
                 HideTracingResponse = false,
 
                 EditorCursorShape = EditorCursorShape.Line,

--- a/samples/Samples.MultipleSchemas/Pages/Index.cshtml
+++ b/samples/Samples.MultipleSchemas/Pages/Index.cshtml
@@ -3,10 +3,10 @@
 <html>
   <body>
     <p>
-      <a href="/cats/ui">Cats</a>
+      <a href="/cats/ui/playground">Cats</a>
     </p>
     <p>
-      <a href="/dogs/ui">Dogs</a>
+      <a href="/dogs/ui/playground">Dogs</a>
     </p>
   </body>
 </html>

--- a/samples/Samples.MultipleSchemas/Pages/Index.cshtml
+++ b/samples/Samples.MultipleSchemas/Pages/Index.cshtml
@@ -3,10 +3,10 @@
 <html>
   <body>
     <p>
-      <a href="/cats">Cats</a>
+      <a href="/cats/ui">Cats</a>
     </p>
     <p>
-      <a href="/dogs">Dogs</a>
+      <a href="/dogs/ui">Dogs</a>
     </p>
   </body>
 </html>

--- a/samples/Samples.MultipleSchemas/Program.cs
+++ b/samples/Samples.MultipleSchemas/Program.cs
@@ -16,21 +16,21 @@ app.UseWebSockets();
 app.UseGraphQL<MultipleSchema.Cats.CatsSchema>("/cats/graphql");
 // configure the graphql endpoint at "/dogs/graphql"
 app.UseGraphQL<MultipleSchema.Dogs.DogsSchema>("/dogs/graphql");
-// configure Playground at "/cats"
+// configure Playground at "/cats/ui" with relative link to api
 app.UseGraphQLPlayground(
     new GraphQL.Server.Ui.Playground.PlaygroundOptions
     {
-        GraphQLEndPoint = "/cats/graphql",
-        SubscriptionsEndPoint = "/cats/graphql",
+        GraphQLEndPoint = "graphql",
+        SubscriptionsEndPoint = "graphql",
     },
-    "/cats");
-// configure Playground at "/dogs"
+    "/cats/ui");
+// configure Playground at "/dogs/ui" with relative link to api
 app.UseGraphQLPlayground(
     new GraphQL.Server.Ui.Playground.PlaygroundOptions
     {
-        GraphQLEndPoint = "/dogs/graphql",
-        SubscriptionsEndPoint = "/dogs/graphql",
+        GraphQLEndPoint = "graphql",
+        SubscriptionsEndPoint = "graphql",
     },
-    "/dogs");
+    "/dogs/ui");
 app.MapRazorPages();
 await app.RunAsync();

--- a/samples/Samples.MultipleSchemas/Program.cs
+++ b/samples/Samples.MultipleSchemas/Program.cs
@@ -16,21 +16,21 @@ app.UseWebSockets();
 app.UseGraphQL<MultipleSchema.Cats.CatsSchema>("/cats/graphql");
 // configure the graphql endpoint at "/dogs/graphql"
 app.UseGraphQL<MultipleSchema.Dogs.DogsSchema>("/dogs/graphql");
-// configure Playground at "/cats/ui" with relative link to api
+// configure Playground at "/cats/ui/playground" with relative link to api
 app.UseGraphQLPlayground(
     new GraphQL.Server.Ui.Playground.PlaygroundOptions
     {
-        GraphQLEndPoint = "graphql",
-        SubscriptionsEndPoint = "graphql",
+        GraphQLEndPoint = "../graphql",
+        SubscriptionsEndPoint = "../graphql",
     },
-    "/cats/ui");
-// configure Playground at "/dogs/ui" with relative link to api
+    "/cats/ui/playground");
+// configure Playground at "/dogs/ui/playground" with relative link to api
 app.UseGraphQLPlayground(
     new GraphQL.Server.Ui.Playground.PlaygroundOptions
     {
-        GraphQLEndPoint = "graphql",
-        SubscriptionsEndPoint = "graphql",
+        GraphQLEndPoint = "../graphql",
+        SubscriptionsEndPoint = "../graphql",
     },
-    "/dogs/ui");
+    "/dogs/ui/playground");
 app.MapRazorPages();
 await app.RunAsync();

--- a/src/Ui.Altair/AltairOptions.cs
+++ b/src/Ui.Altair/AltairOptions.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace GraphQL.Server.Ui.Altair;
 
 /// <summary>
@@ -10,12 +8,12 @@ public class AltairOptions
     /// <summary>
     /// The GraphQL EndPoint.
     /// </summary>
-    public PathString GraphQLEndPoint { get; set; } = "/graphql";
+    public string GraphQLEndPoint { get; set; } = "/graphql";
 
     /// <summary>
     /// Subscriptions EndPoint.
     /// </summary>
-    public PathString SubscriptionsEndPoint { get; set; } = "/graphql";
+    public string SubscriptionsEndPoint { get; set; } = "/graphql";
 
     /// <summary>
     /// Altair headers configuration.

--- a/src/Ui.Altair/Internal/AltairPageModel.cs
+++ b/src/Ui.Altair/Internal/AltairPageModel.cs
@@ -46,10 +46,10 @@ internal sealed class AltairPageModel
 
     // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
     private static string StringEncode(string value) => value
+        .Replace("\\", "\\\\")  // encode  \  as  \\
         .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
         .Replace("'", "\\'")    // encode  '  as  \'
-        .Replace("\"", "\\\"")  // encode  "  as  \"
-        .Replace("\\", "\\\\"); // encode  \  as  \\
+        .Replace("\"", "\\\""); // encode  "  as  \"
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.Altair/Internal/AltairPageModel.cs
+++ b/src/Ui.Altair/Internal/AltairPageModel.cs
@@ -38,6 +38,11 @@ internal sealed class AltairPageModel
                 .Replace("@Model.SubscriptionsEndPoint", StringEncode(_options.SubscriptionsEndPoint))
                 .Replace("@Model.Headers", JsonSerialize(headers));
 
+            // Here, fully-qualified, absolute and relative URLs are supported for both the
+            // GraphQLEndPoint and SubscriptionsEndPoint.  Those paths can be passed unmodified
+            // to 'fetch', but for websocket connectivity, fully-qualified URLs are required.
+            // So within the javascript, we convert the absolute/relative URLs to fully-qualified URLs.
+
             _altairCSHtml = _options.PostConfigure(_options, builder.ToString());
         }
 

--- a/src/Ui.Altair/Internal/AltairPageModel.cs
+++ b/src/Ui.Altair/Internal/AltairPageModel.cs
@@ -48,7 +48,8 @@ internal sealed class AltairPageModel
     private static string StringEncode(string value) => value
         .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
         .Replace("'", "\\'")    // encode  '  as  \'
-        .Replace("\"", "\\\""); // encode  "  as  \"
+        .Replace("\"", "\\\"")  // encode  "  as  \"
+        .Replace("\\", "\\\\"); // encode  \  as  \\
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.Altair/Internal/AltairPageModel.cs
+++ b/src/Ui.Altair/Internal/AltairPageModel.cs
@@ -34,8 +34,8 @@ internal sealed class AltairPageModel
             }
 
             var builder = new StringBuilder(streamReader.ReadToEnd())
-                .Replace("@Model.GraphQLEndPoint", _options.GraphQLEndPoint)
-                .Replace("@Model.SubscriptionsEndPoint", _options.SubscriptionsEndPoint)
+                .Replace("@Model.GraphQLEndPoint", StringEncode(_options.GraphQLEndPoint))
+                .Replace("@Model.SubscriptionsEndPoint", StringEncode(_options.SubscriptionsEndPoint))
                 .Replace("@Model.Headers", JsonSerialize(headers));
 
             _altairCSHtml = _options.PostConfigure(_options, builder.ToString());
@@ -43,6 +43,12 @@ internal sealed class AltairPageModel
 
         return _altairCSHtml;
     }
+
+    // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+    private static string StringEncode(string value) => value
+        .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
+        .Replace("'", "\\'")    // encode  '  as  \'
+        .Replace("\"", "\\\""); // encode  "  as  \"
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.Altair/Internal/altair.cshtml
+++ b/src/Ui.Altair/Internal/altair.cshtml
@@ -37,7 +37,7 @@
 
   <script>
     function getSubscriptionsEndPoint() {
-      var subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
+      const subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
       if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
         // if location includes protocol (e.g. "wss://") then return exact string
         return subscriptionsEndPoint;

--- a/src/Ui.Altair/Internal/altair.cshtml
+++ b/src/Ui.Altair/Internal/altair.cshtml
@@ -36,9 +36,24 @@
   <script rel="preload" as="script" type="text/javascript" src="//cdn.jsdelivr.net/npm/altair-static/build/dist/main.js"></script>
 
   <script>
+    function getSubscriptionsEndPoint() {
+      var subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
+      if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
+        // if location includes protocol (e.g. "wss://") then return exact string
+        return subscriptionsEndPoint;
+      } else if (subscriptionsEndPoint[0] == '/') {
+        // if location is relative (e.g. "api") then prepend host and current path
+        let currentUrl = /^[^?]*\//.exec(window.location.pathname);
+        currentUrl = currentUrl && currentUrl[0] ? currentUrl[0] : '/';
+        return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + currentUrl + subscriptionsEndPoint;
+      }
+      // if location is is absolute (e.g. "/api") then prepend host only
+      return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + subscriptionsEndPoint;
+    }
+
     var altairOptions = {
-        endpointURL: window.location.protocol + "//" + window.location.host + "@Model.GraphQLEndPoint",
-        subscriptionsEndpoint: (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.SubscriptionsEndPoint",
+        endpointURL: "@Model.GraphQLEndPoint",
+        subscriptionsEndpoint: getSubscriptionsEndPoint(),
         initialHeaders: @Model.Headers,
     };
 

--- a/src/Ui.Altair/Internal/altair.cshtml
+++ b/src/Ui.Altair/Internal/altair.cshtml
@@ -37,15 +37,20 @@
 
   <script>
     function getSubscriptionsEndPoint() {
-      const subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
+      let subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
       if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
         // if location includes protocol (e.g. "wss://") then return exact string
         return subscriptionsEndPoint;
       } else if (subscriptionsEndPoint[0] != '/') {
         // if location is relative (e.g. "api") then prepend host and current path
-        let currentUrl = /^[^?]*\//.exec(window.location.pathname);
-        currentUrl = currentUrl && currentUrl[0] ? currentUrl[0] : '/';
-        return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + currentUrl + subscriptionsEndPoint;
+        let currentUrl = /^[^?]*(?=\/)/.exec(window.location.pathname);
+        currentUrl = currentUrl ? currentUrl[0] : '';
+        while (subscriptionsEndPoint.substring(0, 3) == '../') {
+          subscriptionsEndPoint = subscriptionsEndPoint.substring(3);
+          currentUrl = /^[^?]*(?=\/)/.exec(currentUrl);
+          currentUrl = currentUrl ? currentUrl[0] : '';
+        }
+        return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + currentUrl + '/' + subscriptionsEndPoint;
       }
       // if location is is absolute (e.g. "/api") then prepend host only
       return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + subscriptionsEndPoint;

--- a/src/Ui.Altair/Internal/altair.cshtml
+++ b/src/Ui.Altair/Internal/altair.cshtml
@@ -41,7 +41,7 @@
       if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
         // if location includes protocol (e.g. "wss://") then return exact string
         return subscriptionsEndPoint;
-      } else if (subscriptionsEndPoint[0] == '/') {
+      } else if (subscriptionsEndPoint[0] != '/') {
         // if location is relative (e.g. "api") then prepend host and current path
         let currentUrl = /^[^?]*\//.exec(window.location.pathname);
         currentUrl = currentUrl && currentUrl[0] ? currentUrl[0] : '/';

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace GraphQL.Server.Ui.GraphiQL;
 
 /// <summary>
@@ -10,12 +8,12 @@ public class GraphiQLOptions
     /// <summary>
     /// The GraphQL EndPoint.
     /// </summary>
-    public PathString GraphQLEndPoint { get; set; } = "/graphql";
+    public string GraphQLEndPoint { get; set; } = "/graphql";
 
     /// <summary>
     /// Subscriptions EndPoint.
     /// </summary>
-    public PathString SubscriptionsEndPoint { get; set; } = "/graphql";
+    public string SubscriptionsEndPoint { get; set; } = "/graphql";
 
     /// <summary>
     /// HTTP headers with which the GraphiQL will be initialized.

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -44,4 +44,13 @@ public class GraphiQLOptions
     /// Enables the explorer extension when <see langword="true"/>.
     /// </summary>
     public bool ExplorerExtensionEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Indicates whether the user agent should send cookies from the other domain
+    /// in the case of cross-origin requests.
+    /// </summary>
+    /// <remarks>
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials"/>
+    /// </remarks>
+    public RequestCredentials RequestCredentials { get; set; } = RequestCredentials.Include;
 }

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -52,5 +52,5 @@ public class GraphiQLOptions
     /// <remarks>
     /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials"/>.
     /// </remarks>
-    public RequestCredentials RequestCredentials { get; set; } = RequestCredentials.Include;
+    public RequestCredentials RequestCredentials { get; set; } = RequestCredentials.SameOrigin;
 }

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -50,7 +50,7 @@ public class GraphiQLOptions
     /// in the case of cross-origin requests.
     /// </summary>
     /// <remarks>
-    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials"/>
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials"/>.
     /// </remarks>
     public RequestCredentials RequestCredentials { get; set; } = RequestCredentials.Include;
 }

--- a/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
+++ b/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
@@ -49,6 +49,11 @@ internal sealed class GraphiQLPageModel
                 .Replace("@Model.GraphiQLElement", _options.ExplorerExtensionEnabled ? "GraphiQLWithExtensions.GraphiQLWithExtensions" : "GraphiQL")
                 .Replace("@Model.RequestCredentials", requestCredentials);
 
+            // Here, fully-qualified, absolute and relative URLs are supported for both the
+            // GraphQLEndPoint and SubscriptionsEndPoint.  Those paths can be passed unmodified
+            // to 'fetch', but for websocket connectivity, fully-qualified URLs are required.
+            // So within the javascript, we convert the absolute/relative URLs to fully-qualified URLs.
+
             _graphiQLCSHtml = _options.PostConfigure(_options, builder.ToString());
         }
 

--- a/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
+++ b/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
@@ -34,8 +34,8 @@ internal sealed class GraphiQLPageModel
             }
 
             var builder = new StringBuilder(streamReader.ReadToEnd())
-                .Replace("@Model.GraphQLEndPoint", _options.GraphQLEndPoint)
-                .Replace("@Model.SubscriptionsEndPoint", _options.SubscriptionsEndPoint)
+                .Replace("@Model.GraphQLEndPoint", StringEncode(_options.GraphQLEndPoint))
+                .Replace("@Model.SubscriptionsEndPoint", StringEncode(_options.SubscriptionsEndPoint))
                 .Replace("@Model.Headers", JsonSerialize(headers))
                 .Replace("@Model.HeaderEditorEnabled", _options.HeaderEditorEnabled ? "true" : "false")
                 .Replace("@Model.GraphiQLElement", _options.ExplorerExtensionEnabled ? "GraphiQLWithExtensions.GraphiQLWithExtensions" : "GraphiQL");
@@ -45,6 +45,12 @@ internal sealed class GraphiQLPageModel
 
         return _graphiQLCSHtml;
     }
+
+    // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+    private static string StringEncode(string value) => value
+        .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
+        .Replace("'", "\\'")    // encode  '  as  \'
+        .Replace("\"", "\\\""); // encode  "  as  \"
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
+++ b/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
@@ -48,10 +48,10 @@ internal sealed class GraphiQLPageModel
 
     // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
     private static string StringEncode(string value) => value
+        .Replace("\\", "\\\\")  // encode  \  as  \\
         .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
         .Replace("'", "\\'")    // encode  '  as  \'
-        .Replace("\"", "\\\"")  // encode  "  as  \"
-        .Replace("\\", "\\\\"); // encode  \  as  \\
+        .Replace("\"", "\\\""); // encode  "  as  \"
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
+++ b/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
@@ -33,12 +33,21 @@ internal sealed class GraphiQLPageModel
                     headers[item.Key] = item.Value;
             }
 
+            var requestCredentials = _options.RequestCredentials switch
+            {
+                RequestCredentials.Include => "include",
+                RequestCredentials.SameOrigin => "same-origin",
+                RequestCredentials.Omit => "omit",
+                _ => throw new InvalidOperationException("The RequestCredentials property is invalid."),
+            };
+
             var builder = new StringBuilder(streamReader.ReadToEnd())
                 .Replace("@Model.GraphQLEndPoint", StringEncode(_options.GraphQLEndPoint))
                 .Replace("@Model.SubscriptionsEndPoint", StringEncode(_options.SubscriptionsEndPoint))
                 .Replace("@Model.Headers", JsonSerialize(headers))
                 .Replace("@Model.HeaderEditorEnabled", _options.HeaderEditorEnabled ? "true" : "false")
-                .Replace("@Model.GraphiQLElement", _options.ExplorerExtensionEnabled ? "GraphiQLWithExtensions.GraphiQLWithExtensions" : "GraphiQL");
+                .Replace("@Model.GraphiQLElement", _options.ExplorerExtensionEnabled ? "GraphiQLWithExtensions.GraphiQLWithExtensions" : "GraphiQL")
+                .Replace("@Model.RequestCredentials", requestCredentials);
 
             _graphiQLCSHtml = _options.PostConfigure(_options, builder.ToString());
         }

--- a/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
+++ b/src/Ui.GraphiQL/Internal/GraphiQLPageModel.cs
@@ -50,7 +50,8 @@ internal sealed class GraphiQLPageModel
     private static string StringEncode(string value) => value
         .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
         .Replace("'", "\\'")    // encode  '  as  \'
-        .Replace("\"", "\\\""); // encode  "  as  \"
+        .Replace("\"", "\\\"")  // encode  "  as  \"
+        .Replace("\\", "\\\\"); // encode  \  as  \\
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -169,7 +169,7 @@
     }
 
     function getSubscriptionsEndPoint() {
-      var subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
+      const subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
       if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
         // if location includes protocol (e.g. "wss://") then return exact string
         return subscriptionsEndPoint;

--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -173,7 +173,7 @@
       if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
         // if location includes protocol (e.g. "wss://") then return exact string
         return subscriptionsEndPoint;
-      } else if (subscriptionsEndPoint[0] == '/') {
+      } else if (subscriptionsEndPoint[0] != '/') {
         // if location is relative (e.g. "api") then prepend host and current path
         let currentUrl = /^[^?]*\//.exec(window.location.pathname);
         currentUrl = currentUrl && currentUrl[0] ? currentUrl[0] : '/';

--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -152,7 +152,7 @@
     function graphQLFetcher(graphQLParams, fetcherOpts = { headers: {} }) {
       // This example expects a GraphQL server at the path /graphql.
       // Change this to point wherever you host your GraphQL server.
-      return fetch(window.location.protocol + "//" + window.location.host + '@Model.GraphQLEndPoint', {
+      return fetch('@Model.GraphQLEndPoint', {
         method: 'post',
         headers: Object.assign(@Model.Headers, fetcherOpts.headers),
         body: JSON.stringify(graphQLParams),
@@ -168,8 +168,23 @@
       });
     }
 
+    function getSubscriptionsEndPoint() {
+      var subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
+      if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
+        // if location includes protocol (e.g. "wss://") then return exact string
+        return subscriptionsEndPoint;
+      } else if (subscriptionsEndPoint[0] == '/') {
+        // if location is relative (e.g. "api") then prepend host and current path
+        let currentUrl = /^[^?]*\//.exec(window.location.pathname);
+        currentUrl = currentUrl && currentUrl[0] ? currentUrl[0] : '/';
+        return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + currentUrl + subscriptionsEndPoint;
+      }
+      // if location is is absolute (e.g. "/api") then prepend host only
+      return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + subscriptionsEndPoint;
+    }
+
     // Enable Subscriptions via WebSocket
-    var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient((window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.SubscriptionsEndPoint", { reconnect: true });
+    var subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(getSubscriptionsEndPoint(), { reconnect: true });
     function subscriptionsFetcher(graphQLParams, fetcherOpts = { headers: {} }) {
       return window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, function (_graphQLParams) {
         return graphQLFetcher(_graphQLParams, fetcherOpts);

--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -169,15 +169,20 @@
     }
 
     function getSubscriptionsEndPoint() {
-      const subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
+      let subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
       if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
         // if location includes protocol (e.g. "wss://") then return exact string
         return subscriptionsEndPoint;
       } else if (subscriptionsEndPoint[0] != '/') {
         // if location is relative (e.g. "api") then prepend host and current path
-        let currentUrl = /^[^?]*\//.exec(window.location.pathname);
-        currentUrl = currentUrl && currentUrl[0] ? currentUrl[0] : '/';
-        return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + currentUrl + subscriptionsEndPoint;
+        let currentUrl = /^[^?]*(?=\/)/.exec(window.location.pathname);
+        currentUrl = currentUrl ? currentUrl[0] : '';
+        while (subscriptionsEndPoint.substring(0, 3) == '../') {
+          subscriptionsEndPoint = subscriptionsEndPoint.substring(3);
+          currentUrl = /^[^?]*(?=\/)/.exec(currentUrl);
+          currentUrl = currentUrl ? currentUrl[0] : '';
+        }
+        return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + currentUrl + '/' + subscriptionsEndPoint;
       }
       // if location is is absolute (e.g. "/api") then prepend host only
       return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + subscriptionsEndPoint;

--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -156,7 +156,7 @@
         method: 'post',
         headers: Object.assign(@Model.Headers, fetcherOpts.headers),
         body: JSON.stringify(graphQLParams),
-        credentials: 'include',
+        credentials: '@Model.RequestCredentials',
       }).then(function (response) {
         return response.text();
       }).then(function (responseBody) {

--- a/src/Ui.GraphiQL/RequestCredentials.cs
+++ b/src/Ui.GraphiQL/RequestCredentials.cs
@@ -1,0 +1,23 @@
+namespace GraphQL.Server.Ui.GraphiQL;
+
+/// <summary>
+/// Indicates whether the user agent should send cookies from the other domain
+/// in the case of cross-origin requests.
+/// </summary>
+public enum RequestCredentials
+{
+    /// <summary>
+    /// Never send or receive cookies.
+    /// </summary>
+    Omit,
+
+    /// <summary>
+    /// Always send user credentials (cookies, basic http auth, etc..), even for cross-origin calls.
+    /// </summary>
+    Include,
+
+    /// <summary>
+    /// Send user credentials (cookies, basic http auth, etc..) if the URL is on the same origin as the calling script.
+    /// </summary>
+    SameOrigin
+}

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -43,8 +43,8 @@ internal sealed class PlaygroundPageModel
             }
 
             var builder = new StringBuilder(streamReader.ReadToEnd())
-                .Replace("@Model.GraphQLEndPoint", _options.GraphQLEndPoint)
-                .Replace("@Model.SubscriptionsEndPoint", _options.SubscriptionsEndPoint)
+                .Replace("@Model.GraphQLEndPoint", StringEncode(_options.GraphQLEndPoint))
+                .Replace("@Model.SubscriptionsEndPoint", StringEncode(_options.SubscriptionsEndPoint))
                 .Replace("@Model.GraphQLConfig", JsonSerialize(_options.GraphQLConfig!))
                 .Replace("@Model.Headers", JsonSerialize(headers))
                 .Replace("@Model.PlaygroundSettings", JsonSerialize(_options.PlaygroundSettings));
@@ -54,6 +54,12 @@ internal sealed class PlaygroundPageModel
 
         return _playgroundCSHtml;
     }
+
+    // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+    private static string StringEncode(string value) => value
+        .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
+        .Replace("'", "\\'")    // encode  '  as  \'
+        .Replace("\"", "\\\""); // encode  "  as  \"
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -57,10 +57,10 @@ internal sealed class PlaygroundPageModel
 
     // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
     private static string StringEncode(string value) => value
+        .Replace("\\", "\\\\")  // encode  \  as  \\
         .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
         .Replace("'", "\\'")    // encode  '  as  \'
-        .Replace("\"", "\\\"")  // encode  "  as  \"
-        .Replace("\\", "\\\\"); // encode  \  as  \\
+        .Replace("\"", "\\\""); // encode  "  as  \"
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -59,7 +59,8 @@ internal sealed class PlaygroundPageModel
     private static string StringEncode(string value) => value
         .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
         .Replace("'", "\\'")    // encode  '  as  \'
-        .Replace("\"", "\\\""); // encode  "  as  \"
+        .Replace("\"", "\\\"")  // encode  "  as  \"
+        .Replace("\\", "\\\\"); // encode  \  as  \\
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.Playground/Internal/PlaygroundPageModel.cs
+++ b/src/Ui.Playground/Internal/PlaygroundPageModel.cs
@@ -49,6 +49,11 @@ internal sealed class PlaygroundPageModel
                 .Replace("@Model.Headers", JsonSerialize(headers))
                 .Replace("@Model.PlaygroundSettings", JsonSerialize(_options.PlaygroundSettings));
 
+            // Here, fully-qualified, absolute and relative URLs are supported for both the
+            // GraphQLEndPoint and SubscriptionsEndPoint.  Those paths can be passed unmodified
+            // to 'fetch', but for websocket connectivity, fully-qualified URLs are required.
+            // So within the javascript, we convert the absolute/relative URLs to fully-qualified URLs.
+
             _playgroundCSHtml = _options.PostConfigure(_options, builder.ToString());
         }
 

--- a/src/Ui.Playground/Internal/playground.cshtml
+++ b/src/Ui.Playground/Internal/playground.cshtml
@@ -48,7 +48,7 @@
   </div>
   <script>
     function getSubscriptionsEndPoint() {
-      var subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
+      const subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
       if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
         // if location includes protocol (e.g. "wss://") then return exact string
         return subscriptionsEndPoint;

--- a/src/Ui.Playground/Internal/playground.cshtml
+++ b/src/Ui.Playground/Internal/playground.cshtml
@@ -52,7 +52,7 @@
       if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
         // if location includes protocol (e.g. "wss://") then return exact string
         return subscriptionsEndPoint;
-      } else if (subscriptionsEndPoint[0] == '/') {
+      } else if (subscriptionsEndPoint[0] != '/') {
         // if location is relative (e.g. "api") then prepend host and current path
         let currentUrl = /^[^?]*\//.exec(window.location.pathname);
         currentUrl = currentUrl && currentUrl[0] ? currentUrl[0] : '/';

--- a/src/Ui.Playground/Internal/playground.cshtml
+++ b/src/Ui.Playground/Internal/playground.cshtml
@@ -48,15 +48,20 @@
   </div>
   <script>
     function getSubscriptionsEndPoint() {
-      const subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
+      let subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
       if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
         // if location includes protocol (e.g. "wss://") then return exact string
         return subscriptionsEndPoint;
       } else if (subscriptionsEndPoint[0] != '/') {
         // if location is relative (e.g. "api") then prepend host and current path
-        let currentUrl = /^[^?]*\//.exec(window.location.pathname);
-        currentUrl = currentUrl && currentUrl[0] ? currentUrl[0] : '/';
-        return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + currentUrl + subscriptionsEndPoint;
+        let currentUrl = /^[^?]*(?=\/)/.exec(window.location.pathname);
+        currentUrl = currentUrl ? currentUrl[0] : '';
+        while (subscriptionsEndPoint.substring(0, 3) == '../') {
+          subscriptionsEndPoint = subscriptionsEndPoint.substring(3);
+          currentUrl = /^[^?]*(?=\/)/.exec(currentUrl);
+          currentUrl = currentUrl ? currentUrl[0] : '';
+        }
+        return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + currentUrl + '/' + subscriptionsEndPoint;
       }
       // if location is is absolute (e.g. "/api") then prepend host only
       return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + subscriptionsEndPoint;

--- a/src/Ui.Playground/Internal/playground.cshtml
+++ b/src/Ui.Playground/Internal/playground.cshtml
@@ -47,12 +47,27 @@
     </div>
   </div>
   <script>
+    function getSubscriptionsEndPoint() {
+      var subscriptionsEndPoint = "@Model.SubscriptionsEndPoint";
+      if (/^(?:[a-z]+:)?\/\//i.test(subscriptionsEndPoint)) {
+        // if location includes protocol (e.g. "wss://") then return exact string
+        return subscriptionsEndPoint;
+      } else if (subscriptionsEndPoint[0] == '/') {
+        // if location is relative (e.g. "api") then prepend host and current path
+        let currentUrl = /^[^?]*\//.exec(window.location.pathname);
+        currentUrl = currentUrl && currentUrl[0] ? currentUrl[0] : '/';
+        return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + currentUrl + subscriptionsEndPoint;
+      }
+      // if location is is absolute (e.g. "/api") then prepend host only
+      return (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + subscriptionsEndPoint;
+    }
+
     window.addEventListener('load', function (event) {
       GraphQLPlayground.init(document.getElementById('root'),
         {
           setTitle: true,
-          endpoint: window.location.protocol + "//" + window.location.host + "@Model.GraphQLEndPoint",
-          subscriptionEndpoint: (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.SubscriptionsEndPoint",
+          endpoint: "@Model.GraphQLEndPoint",
+          subscriptionEndpoint: getSubscriptionsEndPoint(),
           config: @Model.GraphQLConfig,
           settings: @Model.PlaygroundSettings,
           headers: @Model.Headers,

--- a/src/Ui.Playground/PlaygroundOptions.cs
+++ b/src/Ui.Playground/PlaygroundOptions.cs
@@ -103,6 +103,13 @@ public class PlaygroundOptions
         set => PlaygroundSettings["prettier.useTabs"] = value;
     }
 
+    /// <summary>
+    /// Indicates whether the user agent should send cookies from the other domain
+    /// in the case of cross-origin requests.
+    /// </summary>
+    /// <remarks>
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials"/>.
+    /// </remarks>
     public RequestCredentials RequestCredentials
     {
         get => (string)PlaygroundSettings["request.credentials"] switch
@@ -172,11 +179,4 @@ public enum EditorTheme
 {
     Dark,
     Light
-}
-
-public enum RequestCredentials
-{
-    Omit,
-    Include,
-    SameOrigin
 }

--- a/src/Ui.Playground/PlaygroundOptions.cs
+++ b/src/Ui.Playground/PlaygroundOptions.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace GraphQL.Server.Ui.Playground;
 
 /// <summary>
@@ -10,12 +8,12 @@ public class PlaygroundOptions
     /// <summary>
     /// The GraphQL EndPoint.
     /// </summary>
-    public PathString GraphQLEndPoint { get; set; } = "/graphql";
+    public string GraphQLEndPoint { get; set; } = "/graphql";
 
     /// <summary>
     /// Subscriptions EndPoint.
     /// </summary>
-    public PathString SubscriptionsEndPoint { get; set; } = "/graphql";
+    public string SubscriptionsEndPoint { get; set; } = "/graphql";
 
     /// <summary>
     /// The GraphQL configuration.

--- a/src/Ui.Playground/RequestCredentials.cs
+++ b/src/Ui.Playground/RequestCredentials.cs
@@ -1,0 +1,23 @@
+namespace GraphQL.Server.Ui.Playground;
+
+/// <summary>
+/// Indicates whether the user agent should send cookies from the other domain
+/// in the case of cross-origin requests.
+/// </summary>
+public enum RequestCredentials
+{
+    /// <summary>
+    /// Never send or receive cookies.
+    /// </summary>
+    Omit,
+
+    /// <summary>
+    /// Always send user credentials (cookies, basic http auth, etc..), even for cross-origin calls.
+    /// </summary>
+    Include,
+
+    /// <summary>
+    /// Send user credentials (cookies, basic http auth, etc..) if the URL is on the same origin as the calling script.
+    /// </summary>
+    SameOrigin
+}

--- a/src/Ui.Voyager/Internal/VoyagerPageModel.cs
+++ b/src/Ui.Voyager/Internal/VoyagerPageModel.cs
@@ -34,7 +34,7 @@ internal sealed class VoyagerPageModel
             }
 
             var builder = new StringBuilder(streamReader.ReadToEnd())
-                .Replace("@Model.GraphQLEndPoint", _options.GraphQLEndPoint)
+                .Replace("@Model.GraphQLEndPoint", StringEncode(_options.GraphQLEndPoint))
                 .Replace("@Model.Headers", JsonSerialize(headers));
 
             _voyagerCSHtml = _options.PostConfigure(_options, builder.ToString());
@@ -42,6 +42,12 @@ internal sealed class VoyagerPageModel
 
         return _voyagerCSHtml;
     }
+
+    // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+    private static string StringEncode(string value) => value
+        .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
+        .Replace("'", "\\'")    // encode  '  as  \'
+        .Replace("\"", "\\\""); // encode  "  as  \"
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.Voyager/Internal/VoyagerPageModel.cs
+++ b/src/Ui.Voyager/Internal/VoyagerPageModel.cs
@@ -47,7 +47,8 @@ internal sealed class VoyagerPageModel
     private static string StringEncode(string value) => value
         .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
         .Replace("'", "\\'")    // encode  '  as  \'
-        .Replace("\"", "\\\""); // encode  "  as  \"
+        .Replace("\"", "\\\"")  // encode  "  as  \"
+        .Replace("\\", "\\\\"); // encode  \  as  \\
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.Voyager/Internal/VoyagerPageModel.cs
+++ b/src/Ui.Voyager/Internal/VoyagerPageModel.cs
@@ -45,10 +45,10 @@ internal sealed class VoyagerPageModel
 
     // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
     private static string StringEncode(string value) => value
+        .Replace("\\", "\\\\")  // encode  \  as  \\
         .Replace("<", "\\x3C")  // encode  <  as  \x3C   -- so "<!--", "<script" and "</script" are handled correctly
         .Replace("'", "\\'")    // encode  '  as  \'
-        .Replace("\"", "\\\"")  // encode  "  as  \"
-        .Replace("\\", "\\\\"); // encode  \  as  \\
+        .Replace("\"", "\\\""); // encode  "  as  \"
 
     private static string JsonSerialize(object value)
     {

--- a/src/Ui.Voyager/Internal/VoyagerPageModel.cs
+++ b/src/Ui.Voyager/Internal/VoyagerPageModel.cs
@@ -33,9 +33,18 @@ internal sealed class VoyagerPageModel
                     headers[item.Key] = item.Value;
             }
 
+            var requestCredentials = _options.RequestCredentials switch
+            {
+                RequestCredentials.Include => "include",
+                RequestCredentials.SameOrigin => "same-origin",
+                RequestCredentials.Omit => "omit",
+                _ => throw new InvalidOperationException("The RequestCredentials property is invalid."),
+            };
+
             var builder = new StringBuilder(streamReader.ReadToEnd())
                 .Replace("@Model.GraphQLEndPoint", StringEncode(_options.GraphQLEndPoint))
-                .Replace("@Model.Headers", JsonSerialize(headers));
+                .Replace("@Model.Headers", JsonSerialize(headers))
+                .Replace("@Model.RequestCredentials", requestCredentials);
 
             _voyagerCSHtml = _options.PostConfigure(_options, builder.ToString());
         }

--- a/src/Ui.Voyager/Internal/voyager.cshtml
+++ b/src/Ui.Voyager/Internal/voyager.cshtml
@@ -43,7 +43,7 @@
     // as long as it returns a Promise
     // Voyager passes introspectionQuery as an argument for this function
     function introspectionProvider(introspectionQuery) {
-      return fetch(window.location.protocol + "//" + window.location.host + "@Model.GraphQLEndPoint", {
+      return fetch("@Model.GraphQLEndPoint", {
         method: 'post',
         headers: @Model.Headers,
         body: JSON.stringify({query: introspectionQuery}),

--- a/src/Ui.Voyager/Internal/voyager.cshtml
+++ b/src/Ui.Voyager/Internal/voyager.cshtml
@@ -47,7 +47,7 @@
         method: 'post',
         headers: @Model.Headers,
         body: JSON.stringify({query: introspectionQuery}),
-        credentials: 'include',
+        credentials: '@Model.RequestCredentials',
       }).then(function (response) {
         return response.text();
       }).then(function (responseBody) {

--- a/src/Ui.Voyager/RequestCredentials.cs
+++ b/src/Ui.Voyager/RequestCredentials.cs
@@ -1,0 +1,23 @@
+namespace GraphQL.Server.Ui.Voyager;
+
+/// <summary>
+/// Indicates whether the user agent should send cookies from the other domain
+/// in the case of cross-origin requests.
+/// </summary>
+public enum RequestCredentials
+{
+    /// <summary>
+    /// Never send or receive cookies.
+    /// </summary>
+    Omit,
+
+    /// <summary>
+    /// Always send user credentials (cookies, basic http auth, etc..), even for cross-origin calls.
+    /// </summary>
+    Include,
+
+    /// <summary>
+    /// Send user credentials (cookies, basic http auth, etc..) if the URL is on the same origin as the calling script.
+    /// </summary>
+    SameOrigin
+}

--- a/src/Ui.Voyager/VoyagerOptions.cs
+++ b/src/Ui.Voyager/VoyagerOptions.cs
@@ -33,5 +33,5 @@ public class VoyagerOptions
     /// <remarks>
     /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials"/>.
     /// </remarks>
-    public RequestCredentials RequestCredentials { get; set; } = RequestCredentials.Include;
+    public RequestCredentials RequestCredentials { get; set; } = RequestCredentials.SameOrigin;
 }

--- a/src/Ui.Voyager/VoyagerOptions.cs
+++ b/src/Ui.Voyager/VoyagerOptions.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace GraphQL.Server.Ui.Voyager;
 
 /// <summary>
@@ -10,7 +8,7 @@ public class VoyagerOptions
     /// <summary>
     /// The GraphQL EndPoint.
     /// </summary>
-    public PathString GraphQLEndPoint { get; set; } = "/graphql";
+    public string GraphQLEndPoint { get; set; } = "/graphql";
 
     /// <summary>
     /// HTTP headers with which the Voyager will send introspection query.

--- a/src/Ui.Voyager/VoyagerOptions.cs
+++ b/src/Ui.Voyager/VoyagerOptions.cs
@@ -25,4 +25,13 @@ public class VoyagerOptions
     /// Gets or sets a delegate that is called after all transformations of the Voyager UI page.
     /// </summary>
     public Func<VoyagerOptions, string, string> PostConfigure { get; set; } = (options, result) => result;
+
+    /// <summary>
+    /// Indicates whether the user agent should send cookies from the other domain
+    /// in the case of cross-origin requests.
+    /// </summary>
+    /// <remarks>
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials"/>.
+    /// </remarks>
+    public RequestCredentials RequestCredentials { get; set; } = RequestCredentials.Include;
 }

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Altair.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Altair.approved.txt
@@ -8,11 +8,11 @@ namespace GraphQL.Server.Ui.Altair
     public class AltairOptions
     {
         public AltairOptions() { }
-        public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
+        public string GraphQLEndPoint { get; set; }
         public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.Altair.AltairOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.Altair.AltairOptions, string, string> PostConfigure { get; set; }
-        public Microsoft.AspNetCore.Http.PathString SubscriptionsEndPoint { get; set; }
+        public string SubscriptionsEndPoint { get; set; }
     }
 }
 namespace Microsoft.AspNetCore.Builder

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -9,12 +9,12 @@ namespace GraphQL.Server.Ui.GraphiQL
     {
         public GraphiQLOptions() { }
         public bool ExplorerExtensionEnabled { get; set; }
-        public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
+        public string GraphQLEndPoint { get; set; }
         public bool HeaderEditorEnabled { get; set; }
         public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, string, string> PostConfigure { get; set; }
-        public Microsoft.AspNetCore.Http.PathString SubscriptionsEndPoint { get; set; }
+        public string SubscriptionsEndPoint { get; set; }
     }
 }
 namespace Microsoft.AspNetCore.Builder

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -14,7 +14,14 @@ namespace GraphQL.Server.Ui.GraphiQL
         public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, string, string> PostConfigure { get; set; }
+        public GraphQL.Server.Ui.GraphiQL.RequestCredentials RequestCredentials { get; set; }
         public string SubscriptionsEndPoint { get; set; }
+    }
+    public enum RequestCredentials
+    {
+        Omit = 0,
+        Include = 1,
+        SameOrigin = 2,
     }
 }
 namespace Microsoft.AspNetCore.Builder

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Playground.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Playground.approved.txt
@@ -26,7 +26,7 @@ namespace GraphQL.Server.Ui.Playground
         public bool EditorReuseHeaders { get; set; }
         public GraphQL.Server.Ui.Playground.EditorTheme EditorTheme { get; set; }
         public System.Collections.Generic.Dictionary<string, object>? GraphQLConfig { get; set; }
-        public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
+        public string GraphQLEndPoint { get; set; }
         public System.Collections.Generic.Dictionary<string, object>? Headers { get; set; }
         public bool HideTracingResponse { get; set; }
         public System.Func<GraphQL.Server.Ui.Playground.PlaygroundOptions, System.IO.Stream> IndexStream { get; set; }
@@ -40,7 +40,7 @@ namespace GraphQL.Server.Ui.Playground
         public bool SchemaPollingEnabled { get; set; }
         public string SchemaPollingEndpointFilter { get; set; }
         public int SchemaPollingInterval { get; set; }
-        public Microsoft.AspNetCore.Http.PathString SubscriptionsEndPoint { get; set; }
+        public string SubscriptionsEndPoint { get; set; }
     }
     public enum RequestCredentials
     {

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Voyager.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Voyager.approved.txt
@@ -8,7 +8,7 @@ namespace GraphQL.Server.Ui.Voyager
     public class VoyagerOptions
     {
         public VoyagerOptions() { }
-        public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
+        public string GraphQLEndPoint { get; set; }
         public System.Collections.Generic.Dictionary<string, object>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, string, string> PostConfigure { get; set; }

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Voyager.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Voyager.approved.txt
@@ -1,5 +1,11 @@
 namespace GraphQL.Server.Ui.Voyager
 {
+    public enum RequestCredentials
+    {
+        Omit = 0,
+        Include = 1,
+        SameOrigin = 2,
+    }
     public class VoyagerMiddleware
     {
         public VoyagerMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, GraphQL.Server.Ui.Voyager.VoyagerOptions options) { }
@@ -12,6 +18,7 @@ namespace GraphQL.Server.Ui.Voyager
         public System.Collections.Generic.Dictionary<string, object>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, string, string> PostConfigure { get; set; }
+        public GraphQL.Server.Ui.Voyager.RequestCredentials RequestCredentials { get; set; }
     }
 }
 namespace Microsoft.AspNetCore.Builder

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Altair.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Altair.approved.txt
@@ -8,11 +8,11 @@ namespace GraphQL.Server.Ui.Altair
     public class AltairOptions
     {
         public AltairOptions() { }
-        public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
+        public string GraphQLEndPoint { get; set; }
         public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.Altair.AltairOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.Altair.AltairOptions, string, string> PostConfigure { get; set; }
-        public Microsoft.AspNetCore.Http.PathString SubscriptionsEndPoint { get; set; }
+        public string SubscriptionsEndPoint { get; set; }
     }
 }
 namespace Microsoft.AspNetCore.Builder

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -9,12 +9,12 @@ namespace GraphQL.Server.Ui.GraphiQL
     {
         public GraphiQLOptions() { }
         public bool ExplorerExtensionEnabled { get; set; }
-        public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
+        public string GraphQLEndPoint { get; set; }
         public bool HeaderEditorEnabled { get; set; }
         public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, string, string> PostConfigure { get; set; }
-        public Microsoft.AspNetCore.Http.PathString SubscriptionsEndPoint { get; set; }
+        public string SubscriptionsEndPoint { get; set; }
     }
 }
 namespace Microsoft.AspNetCore.Builder

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -14,7 +14,14 @@ namespace GraphQL.Server.Ui.GraphiQL
         public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.GraphiQL.GraphiQLOptions, string, string> PostConfigure { get; set; }
+        public GraphQL.Server.Ui.GraphiQL.RequestCredentials RequestCredentials { get; set; }
         public string SubscriptionsEndPoint { get; set; }
+    }
+    public enum RequestCredentials
+    {
+        Omit = 0,
+        Include = 1,
+        SameOrigin = 2,
     }
 }
 namespace Microsoft.AspNetCore.Builder

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Playground.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Playground.approved.txt
@@ -26,7 +26,7 @@ namespace GraphQL.Server.Ui.Playground
         public bool EditorReuseHeaders { get; set; }
         public GraphQL.Server.Ui.Playground.EditorTheme EditorTheme { get; set; }
         public System.Collections.Generic.Dictionary<string, object>? GraphQLConfig { get; set; }
-        public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
+        public string GraphQLEndPoint { get; set; }
         public System.Collections.Generic.Dictionary<string, object>? Headers { get; set; }
         public bool HideTracingResponse { get; set; }
         public System.Func<GraphQL.Server.Ui.Playground.PlaygroundOptions, System.IO.Stream> IndexStream { get; set; }
@@ -40,7 +40,7 @@ namespace GraphQL.Server.Ui.Playground
         public bool SchemaPollingEnabled { get; set; }
         public string SchemaPollingEndpointFilter { get; set; }
         public int SchemaPollingInterval { get; set; }
-        public Microsoft.AspNetCore.Http.PathString SubscriptionsEndPoint { get; set; }
+        public string SubscriptionsEndPoint { get; set; }
     }
     public enum RequestCredentials
     {

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Voyager.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Voyager.approved.txt
@@ -8,7 +8,7 @@ namespace GraphQL.Server.Ui.Voyager
     public class VoyagerOptions
     {
         public VoyagerOptions() { }
-        public Microsoft.AspNetCore.Http.PathString GraphQLEndPoint { get; set; }
+        public string GraphQLEndPoint { get; set; }
         public System.Collections.Generic.Dictionary<string, object>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, string, string> PostConfigure { get; set; }

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Voyager.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Voyager.approved.txt
@@ -1,5 +1,11 @@
 namespace GraphQL.Server.Ui.Voyager
 {
+    public enum RequestCredentials
+    {
+        Omit = 0,
+        Include = 1,
+        SameOrigin = 2,
+    }
     public class VoyagerMiddleware
     {
         public VoyagerMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, GraphQL.Server.Ui.Voyager.VoyagerOptions options) { }
@@ -12,6 +18,7 @@ namespace GraphQL.Server.Ui.Voyager
         public System.Collections.Generic.Dictionary<string, object>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, System.IO.Stream> IndexStream { get; set; }
         public System.Func<GraphQL.Server.Ui.Voyager.VoyagerOptions, string, string> PostConfigure { get; set; }
+        public GraphQL.Server.Ui.Voyager.RequestCredentials RequestCredentials { get; set; }
     }
 }
 namespace Microsoft.AspNetCore.Builder

--- a/tests/Samples.MultipleSchemas.Tests/EndToEndTests.cs
+++ b/tests/Samples.MultipleSchemas.Tests/EndToEndTests.cs
@@ -11,11 +11,11 @@ public class EndToEndTests
 
     [Fact]
     public Task Cats_Playground()
-        => new ServerTests<Program>().VerifyPlaygroundAsync("/cats");
+        => new ServerTests<Program>().VerifyPlaygroundAsync("/cats/ui/playground");
 
     [Fact]
     public Task Dogs_Playground()
-        => new ServerTests<Program>().VerifyPlaygroundAsync("/dogs");
+        => new ServerTests<Program>().VerifyPlaygroundAsync("/dogs/ui/playground");
 
     [Fact]
     public Task Cats_GraphQLGet()


### PR DESCRIPTION
For each of the 4 supported UI projects, this changes the endpoint paths from `PathString` to `string` and allows for the following:
- Fully qualified URL -- e.g. `https://localhost/graphql`
- Absolute URL -- e.g. `/graphql`
- Relative URL -- e.g. `graphql`

For subscription support for the latter 2 scenarios, it will take the current URL to create a path with `ws://` or `wss://` rather than `http://` or `https://` respectively.

Replaces:
- #587 
- #195 

Fixes:
- URLs are properly encoded for embedding inside a `<script>` tag

New feature:
- Allows configuring RequestCredentials in GraphiQL and Voyager

Todo:
- [x] Manually test fully qualified urls (see below code snippet)
- [x] Test relative urls (use in MultipleSchema sample)
- [x] Test absolute urls (used in all samples)