### PR TITLE
Add underlying support for AWS AppSync subscription variant

### DIFF
--- a/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.cs
@@ -471,6 +471,10 @@ public abstract partial class BaseSubscriptionServer : IOperationMessageProcesso
 
     /// <summary>
     /// Sends a notification that the specified subscription has been set up successfully.
+    /// Note that both graphql-ws and subscriptions-transport-ws protocols do not need
+    /// such notification but some custom protocol may require it; for example, see start_ack message
+    /// from https://docs.aws.amazon.com/appsync/latest/devguide/real-time-websocket-client.html
+    /// protocol for AWS AppSync. 
     /// </summary>
     protected virtual Task SendSubscriptionSuccessfulAsync(OperationMessage message) => Task.CompletedTask;
 

--- a/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.cs
@@ -381,6 +381,7 @@ public abstract partial class BaseSubscriptionServer : IOperationMessageProcesso
                 // validation rules are in place, that should not be possible.
                 if (result.Streams?.Count == 1)
                 {
+                    await SendSubscriptionSuccessfulAsync(message);
                     // do not return a result, but set up a subscription
                     var stream = result.Streams!.Single().Value;
                     // note that this may immediately trigger some notifications
@@ -467,6 +468,11 @@ public abstract partial class BaseSubscriptionServer : IOperationMessageProcesso
     /// Sends an execution error to the client during set-up of a GraphQL request (typically subscription).
     /// </summary>
     protected abstract Task SendErrorResultAsync(string id, ExecutionResult result);
+
+    /// <summary>
+    /// Sends a notification that the specified subscription has been set up successfully.
+    /// </summary>
+    protected virtual Task SendSubscriptionSuccessfulAsync(OperationMessage message) => Task.CompletedTask;
 
     /// <summary>
     /// Sends a data packet to the client for a GraphQL request (typically a subscription event).

--- a/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -220,6 +220,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         protected virtual System.Threading.Tasks.Task SendErrorResultAsync(string id, GraphQL.ExecutionError executionError) { }
         protected abstract System.Threading.Tasks.Task SendErrorResultAsync(string id, GraphQL.ExecutionResult result);
         protected virtual System.Threading.Tasks.Task SendSingleResultAsync(GraphQL.Transport.OperationMessage message, GraphQL.ExecutionResult result) { }
+        protected virtual System.Threading.Tasks.Task SendSubscriptionSuccessfulAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task SubscribeAsync(GraphQL.Transport.OperationMessage message, bool overwrite) { }
         protected bool TryInitialize() { }
         protected virtual System.Threading.Tasks.Task UnsubscribeAsync(string? id) { }

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -238,6 +238,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         protected virtual System.Threading.Tasks.Task SendErrorResultAsync(string id, GraphQL.ExecutionError executionError) { }
         protected abstract System.Threading.Tasks.Task SendErrorResultAsync(string id, GraphQL.ExecutionResult result);
         protected virtual System.Threading.Tasks.Task SendSingleResultAsync(GraphQL.Transport.OperationMessage message, GraphQL.ExecutionResult result) { }
+        protected virtual System.Threading.Tasks.Task SendSubscriptionSuccessfulAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task SubscribeAsync(GraphQL.Transport.OperationMessage message, bool overwrite) { }
         protected bool TryInitialize() { }
         protected virtual System.Threading.Tasks.Task UnsubscribeAsync(string? id) { }

--- a/tests/Transports.AspNetCore.Tests/WebSockets/BaseSubscriptionServerTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/BaseSubscriptionServerTests.cs
@@ -402,6 +402,7 @@ public class BaseSubscriptionServerTests : IDisposable
             .Returns(Task.FromResult<ExecutionResult>(result))
             .Verifiable();
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message, overwrite).Verifiable();
+        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message).Verifiable();
         await _server.Do_SubscribeAsync(message, overwrite);
         _server.Get_Subscriptions.Contains(message.Id).ShouldBeTrue();
         _mockServer.Verify();
@@ -445,7 +446,9 @@ public class BaseSubscriptionServerTests : IDisposable
                 .Verifiable();
         }
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message1, overwrite).Verifiable();
+        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message1).Verifiable();
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message2, overwrite).Verifiable();
+        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message2).Verifiable();
         await _server.Do_SubscribeAsync(message1, overwrite);
         _server.Get_Subscriptions.Contains(message1.Id).ShouldBeTrue();
         await _server.Do_SubscribeAsync(message2, overwrite);
@@ -669,6 +672,7 @@ public class BaseSubscriptionServerTests : IDisposable
             .Returns(Task.FromResult<ExecutionResult>(result))
             .Verifiable();
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message, false).Verifiable();
+        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message).Verifiable();
         _mockServer.Protected().Setup<Task>("UnsubscribeAsync", message.Id).Verifiable();
         await _server.Do_SubscribeAsync(message, false);
         _server.Get_Subscriptions.Contains(message.Id).ShouldBeTrue();
@@ -710,6 +714,7 @@ public class BaseSubscriptionServerTests : IDisposable
             .Returns(Task.FromResult<ExecutionResult>(result))
             .Verifiable();
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message, false).Verifiable();
+        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message).Verifiable();
         _mockServer.Setup(x => x.Dispose()).CallBase().Verifiable();
         await _server.Do_SubscribeAsync(message, false);
         _server.Get_Subscriptions.Contains(message.Id).ShouldBeTrue();
@@ -739,6 +744,7 @@ public class BaseSubscriptionServerTests : IDisposable
         _mockServer.Protected().Setup<Task>("SendDataAsync", message.Id, result2).Returns(Task.CompletedTask).Verifiable();
         _mockServer.Protected().Setup<Task>("SendDataAsync", message.Id, result3).Returns(Task.CompletedTask).Verifiable();
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message, false).Verifiable();
+        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message).Verifiable();
         await _server.Do_SubscribeAsync(message, false);
         _server.Get_Subscriptions.Contains(message.Id).ShouldBeTrue();
         source.HasObservers.ShouldBeTrue();
@@ -779,6 +785,7 @@ public class BaseSubscriptionServerTests : IDisposable
                 .Verifiable();
         }
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message, false).Verifiable();
+        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message).Verifiable();
         await _server.Do_SubscribeAsync(message, false);
         _server.Get_Subscriptions.Contains(message.Id).ShouldBeTrue();
         source.HasObservers.ShouldBeTrue();
@@ -811,6 +818,7 @@ public class BaseSubscriptionServerTests : IDisposable
             .Returns(Task.CompletedTask)
             .Verifiable();
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message, false).Verifiable();
+        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message).Verifiable();
         await _server.Do_SubscribeAsync(message, false);
         _server.Get_Subscriptions.Contains(message.Id).ShouldBeTrue();
         source.HasObservers.ShouldBeTrue();
@@ -857,6 +865,7 @@ public class BaseSubscriptionServerTests : IDisposable
                 .Verifiable();
         }
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message, false).Verifiable();
+        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message).Verifiable();
         await _server.Do_SubscribeAsync(message, false);
         _server.Get_Subscriptions.Contains(message.Id).ShouldBeTrue();
         source.HasObservers.ShouldBeTrue();

--- a/tests/Transports.AspNetCore.Tests/WebSockets/BaseSubscriptionServerTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/BaseSubscriptionServerTests.cs
@@ -448,7 +448,8 @@ public class BaseSubscriptionServerTests : IDisposable
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message1, overwrite).Verifiable();
         _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message1).Verifiable();
         _mockServer.Protected().Setup<Task>("SubscribeAsync", message2, overwrite).Verifiable();
-        _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message2).Verifiable();
+        if (overwrite)
+            _mockServer.Protected().Setup<Task>("SendSubscriptionSuccessfulAsync", message2).Verifiable();
         await _server.Do_SubscribeAsync(message1, overwrite);
         _server.Get_Subscriptions.Contains(message1.Id).ShouldBeTrue();
         await _server.Do_SubscribeAsync(message2, overwrite);


### PR DESCRIPTION
For AWS, subscription operations differ from the `subscriptions-transport-ws` protocol in three ways:

1. Keep-alive messages are sent every minute by the server
2. The `connection_ack` message includes a keep-alive timeout period which the client should honor and terminate the connection if no keep-alive messages are received within this period
3. During a subscription request, a `start_ack` message is sent from the server to the client once the subscription has been set up without an error

The first two points above can be implemented easily in a derived class.  This PR adds a protected method for the third bullet point.  No functionality has changed, so the default behavior will meet the spec.  Adding this method could also assist with logging/debugging.

Note that as AWS AppSync uses the same WebSocket sub-protocol of `graphql-ws`, we cannot simply add a third protocol.  We could add an option to `GraphQLWebSocketOptions` for AWS AppSync compatibility, of course.

See https://docs.aws.amazon.com/appsync/latest/devguide/real-time-websocket-client.html