### PR TITLE
Change order of UI extension method arguments

### DIFF
--- a/samples/Samples.Authorization/Program.cs
+++ b/samples/Samples.Authorization/Program.cs
@@ -62,13 +62,13 @@ app.UseWebSockets();
 app.UseGraphQL("/graphql");
 // configure Playground at "/ui/graphql"
 app.UseGraphQLPlayground(
+    "/ui/graphql",
     new GraphQL.Server.Ui.Playground.PlaygroundOptions
     {
         GraphQLEndPoint = "/graphql",
         SubscriptionsEndPoint = "/graphql",
         RequestCredentials = GraphQL.Server.Ui.Playground.RequestCredentials.Include,
-    },
-    "/ui/graphql");
+    });
 // -------------------------------------
 
 app.MapRazorPages();

--- a/samples/Samples.Basic/Program.cs
+++ b/samples/Samples.Basic/Program.cs
@@ -17,11 +17,11 @@ app.UseWebSockets();
 app.UseGraphQL("/graphql");
 // configure Playground at "/"
 app.UseGraphQLPlayground(
+    "/",
     new GraphQL.Server.Ui.Playground.PlaygroundOptions
     {
         GraphQLEndPoint = "/graphql",
         SubscriptionsEndPoint = "/graphql",
-    },
-    "/");
+    });
 
 await app.RunAsync();

--- a/samples/Samples.Complex/Startup.cs
+++ b/samples/Samples.Complex/Startup.cs
@@ -58,7 +58,7 @@ public class Startup
 
         app.UseGraphQL<GraphQLHttpMiddlewareWithLogs<ChatSchema>>("/graphql", new GraphQLHttpMiddlewareOptions());
 
-        app.UseGraphQLPlayground(new PlaygroundOptions
+        app.UseGraphQLPlayground(options: new PlaygroundOptions
         {
             BetaUpdates = true,
             RequestCredentials = Server.Ui.Playground.RequestCredentials.Omit,
@@ -86,7 +86,7 @@ public class Startup
             },
         });
 
-        app.UseGraphQLGraphiQL(new GraphiQLOptions
+        app.UseGraphQLGraphiQL(options: new GraphiQLOptions
         {
             Headers = new Dictionary<string, string>
             {
@@ -94,7 +94,7 @@ public class Startup
             }
         });
 
-        app.UseGraphQLAltair(new AltairOptions
+        app.UseGraphQLAltair(options: new AltairOptions
         {
             Headers = new Dictionary<string, string>
             {
@@ -102,7 +102,7 @@ public class Startup
             }
         });
 
-        app.UseGraphQLVoyager(new VoyagerOptions
+        app.UseGraphQLVoyager(options: new VoyagerOptions
         {
             Headers = new Dictionary<string, object>
             {

--- a/samples/Samples.Complex/StartupWithRouting.cs
+++ b/samples/Samples.Complex/StartupWithRouting.cs
@@ -63,7 +63,7 @@ public class StartupWithRouting
         {
             endpoints.MapGraphQL<GraphQLHttpMiddlewareWithLogs<ChatSchema>>("/graphql", new GraphQLHttpMiddlewareOptions());
 
-            endpoints.MapGraphQLPlayground(new PlaygroundOptions
+            endpoints.MapGraphQLPlayground(options: new PlaygroundOptions
             {
                 BetaUpdates = true,
                 RequestCredentials = Server.Ui.Playground.RequestCredentials.Omit,
@@ -91,7 +91,7 @@ public class StartupWithRouting
                 },
             });
 
-            endpoints.MapGraphQLGraphiQL(new GraphiQLOptions
+            endpoints.MapGraphQLGraphiQL(options: new GraphiQLOptions
             {
                 Headers = new Dictionary<string, string>
                 {
@@ -99,7 +99,7 @@ public class StartupWithRouting
                 }
             });
 
-            endpoints.MapGraphQLAltair(new AltairOptions
+            endpoints.MapGraphQLAltair(options: new AltairOptions
             {
                 Headers = new Dictionary<string, string>
                 {
@@ -107,7 +107,7 @@ public class StartupWithRouting
                 }
             });
 
-            endpoints.MapGraphQLVoyager(new VoyagerOptions
+            endpoints.MapGraphQLVoyager(options: new VoyagerOptions
             {
                 Headers = new Dictionary<string, object>
                 {

--- a/samples/Samples.MultipleSchemas/Program.cs
+++ b/samples/Samples.MultipleSchemas/Program.cs
@@ -18,19 +18,19 @@ app.UseGraphQL<MultipleSchema.Cats.CatsSchema>("/cats/graphql");
 app.UseGraphQL<MultipleSchema.Dogs.DogsSchema>("/dogs/graphql");
 // configure Playground at "/cats/ui/playground" with relative link to api
 app.UseGraphQLPlayground(
+    "/cats/ui/playground",
     new GraphQL.Server.Ui.Playground.PlaygroundOptions
     {
         GraphQLEndPoint = "../graphql",
         SubscriptionsEndPoint = "../graphql",
-    },
-    "/cats/ui/playground");
+    });
 // configure Playground at "/dogs/ui/playground" with relative link to api
 app.UseGraphQLPlayground(
+    "/dogs/ui/playground",
     new GraphQL.Server.Ui.Playground.PlaygroundOptions
     {
         GraphQLEndPoint = "../graphql",
         SubscriptionsEndPoint = "../graphql",
-    },
-    "/dogs/ui/playground");
+    });
 app.MapRazorPages();
 await app.RunAsync();

--- a/samples/Samples.Net48/Startup.cs
+++ b/samples/Samples.Net48/Startup.cs
@@ -36,11 +36,11 @@ public class Startup
         app.UseGraphQL("/graphql");
         // configure the GraphiQL endpoint at "/ui/graphql"
         app.UseGraphQLGraphiQL(
+            "/ui/graphql",
             new Ui.GraphiQL.GraphiQLOptions
             {
                 GraphQLEndPoint = "/graphql",
                 SubscriptionsEndPoint = "/graphql",
-            },
-            "/ui/graphql");
+            });
     }
 }

--- a/src/Ui.Altair/Extensions/AltairApplicationBuilderExtensions.cs
+++ b/src/Ui.Altair/Extensions/AltairApplicationBuilderExtensions.cs
@@ -8,19 +8,12 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class AltairApplicationBuilderExtensions
 {
-    /// <summary> Adds middleware for Altair GraphQL UI using default options. </summary>
-    /// <param name="app"> <see cref="IApplicationBuilder"/> to configure an application's request pipeline. </param>
-    /// <param name="path">The path to the Altair GraphQL UI endpoint which defaults to '/ui/altair'</param>
-    /// <returns> The reference to provided <paramref name="app"/> instance. </returns>
-    public static IApplicationBuilder UseGraphQLAltair(this IApplicationBuilder app, string path = "/ui/altair")
-        => app.UseGraphQLAltair(new AltairOptions(), path);
-
     /// <summary> Adds middleware for Altair GraphQL UI using the specified options. </summary>
     /// <param name="app"> <see cref="IApplicationBuilder"/> to configure an application's request pipeline. </param>
     /// <param name="options"> Options to customize <see cref="AltairMiddleware"/>. If not set, then the default values will be used. </param>
     /// <param name="path">The path to the Altair GraphQL UI endpoint which defaults to '/ui/altair'</param>
     /// <returns> The reference to provided <paramref name="app"/> instance. </returns>
-    public static IApplicationBuilder UseGraphQLAltair(this IApplicationBuilder app, AltairOptions options, string path = "/ui/altair")
+    public static IApplicationBuilder UseGraphQLAltair(this IApplicationBuilder app, string path = "/ui/altair", AltairOptions? options = null)
     {
         return app.UseWhen(
             context => HttpMethods.IsGet(context.Request.Method) && !context.WebSockets.IsWebSocketRequest &&

--- a/src/Ui.Altair/Extensions/AltairEndpointRouteBuilderExtensions.cs
+++ b/src/Ui.Altair/Extensions/AltairEndpointRouteBuilderExtensions.cs
@@ -14,19 +14,10 @@ public static class AltairEndpointRouteBuilderExtensions
     /// Add the Altair middleware to the HTTP request pipeline
     /// </summary>
     /// <param name="endpoints">Defines a contract for a route builder in an application. A route builder specifies the routes for an application.</param>
-    /// <param name="pattern">The route pattern.</param>
-    /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
-    public static AltairEndpointConventionBuilder MapGraphQLAltair(this IEndpointRouteBuilder endpoints, string pattern = "ui/altair")
-        => endpoints.MapGraphQLAltair(new AltairOptions(), pattern);
-
-    /// <summary>
-    /// Add the Altair middleware to the HTTP request pipeline
-    /// </summary>
-    /// <param name="endpoints">Defines a contract for a route builder in an application. A route builder specifies the routes for an application.</param>
     /// <param name="options">Options to customize <see cref="AltairMiddleware"/>. If not set, then the default values will be used.</param>
     /// <param name="pattern">The route pattern.</param>
     /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
-    public static AltairEndpointConventionBuilder MapGraphQLAltair(this IEndpointRouteBuilder endpoints, AltairOptions options, string pattern = "ui/altair")
+    public static AltairEndpointConventionBuilder MapGraphQLAltair(this IEndpointRouteBuilder endpoints, string pattern = "ui/altair", AltairOptions? options = null)
     {
         if (endpoints == null)
             throw new ArgumentNullException(nameof(endpoints));

--- a/src/Ui.GraphiQL/Extensions/GraphiQLApplicationBuilderExtensions.cs
+++ b/src/Ui.GraphiQL/Extensions/GraphiQLApplicationBuilderExtensions.cs
@@ -8,19 +8,12 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class GraphiQLApplicationBuilderExtensions
 {
-    /// <summary> Adds middleware for GraphiQL using default options. </summary>
-    /// <param name="app"> <see cref="IApplicationBuilder"/> to configure an application's request pipeline. </param>
-    /// <param name="path">The path to the GraphiQL endpoint which defaults to '/ui/graphiql'</param>
-    /// <returns> The reference to provided <paramref name="app"/> instance. </returns>
-    public static IApplicationBuilder UseGraphQLGraphiQL(this IApplicationBuilder app, string path = "/ui/graphiql")
-        => app.UseGraphQLGraphiQL(new GraphiQLOptions(), path);
-
     /// <summary> Adds middleware for GraphiQL using the specified options. </summary>
     /// <param name="app"> <see cref="IApplicationBuilder"/> to configure an application's request pipeline. </param>
     /// <param name="options"> Options to customize <see cref="GraphiQLMiddleware"/>. If not set, then the default values will be used. </param>
     /// <param name="path">The path to the GraphiQL endpoint which defaults to '/ui/graphiql'</param>
     /// <returns> The reference to provided <paramref name="app"/> instance. </returns>
-    public static IApplicationBuilder UseGraphQLGraphiQL(this IApplicationBuilder app, GraphiQLOptions options, string path = "/ui/graphiql")
+    public static IApplicationBuilder UseGraphQLGraphiQL(this IApplicationBuilder app, string path = "/ui/graphiql", GraphiQLOptions? options = null)
     {
         return app.UseWhen(
             context => HttpMethods.IsGet(context.Request.Method) && !context.WebSockets.IsWebSocketRequest &&

--- a/src/Ui.GraphiQL/Extensions/GraphiQLEndpointRouteBuilderExtensions.cs
+++ b/src/Ui.GraphiQL/Extensions/GraphiQLEndpointRouteBuilderExtensions.cs
@@ -14,19 +14,10 @@ public static class GraphiQLEndpointRouteBuilderExtensions
     /// Add the GraphiQL middleware to the HTTP request pipeline
     /// </summary>
     /// <param name="endpoints">Defines a contract for a route builder in an application. A route builder specifies the routes for an application.</param>
-    /// <param name="pattern">The route pattern.</param>
-    /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
-    public static GraphiQLEndpointConventionBuilder MapGraphQLGraphiQL(this IEndpointRouteBuilder endpoints, string pattern = "ui/graphiql")
-        => endpoints.MapGraphQLGraphiQL(new GraphiQLOptions(), pattern);
-
-    /// <summary>
-    /// Add the GraphiQL middleware to the HTTP request pipeline
-    /// </summary>
-    /// <param name="endpoints">Defines a contract for a route builder in an application. A route builder specifies the routes for an application.</param>
     /// <param name="options">Options to customize <see cref="GraphiQLMiddleware"/>. If not set, then the default values will be used.</param>
     /// <param name="pattern">The route pattern.</param>
     /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
-    public static GraphiQLEndpointConventionBuilder MapGraphQLGraphiQL(this IEndpointRouteBuilder endpoints, GraphiQLOptions options, string pattern = "ui/graphiql")
+    public static GraphiQLEndpointConventionBuilder MapGraphQLGraphiQL(this IEndpointRouteBuilder endpoints, string pattern = "ui/graphiql", GraphiQLOptions? options = null)
     {
         if (endpoints == null)
             throw new ArgumentNullException(nameof(endpoints));

--- a/src/Ui.Playground/Extensions/PlaygroundApplicationBuilderExtensions.cs
+++ b/src/Ui.Playground/Extensions/PlaygroundApplicationBuilderExtensions.cs
@@ -8,19 +8,12 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class PlaygroundApplicationBuilderExtensions
 {
-    /// <summary> Adds middleware for GraphQL Playground using default options. </summary>
-    /// <param name="app"> <see cref="IApplicationBuilder"/> to configure an application's request pipeline. </param>
-    /// <param name="path">The path to the GraphQL Playground endpoint which defaults to '/ui/playground'</param>
-    /// <returns> The reference to provided <paramref name="app"/> instance. </returns>
-    public static IApplicationBuilder UseGraphQLPlayground(this IApplicationBuilder app, string path = "/ui/playground")
-        => app.UseGraphQLPlayground(new PlaygroundOptions(), path);
-
     /// <summary> Adds middleware for GraphQL Playground using the specified options. </summary>
     /// <param name="app"> <see cref="IApplicationBuilder"/> to configure an application's request pipeline. </param>
     /// <param name="options"> Options to customize <see cref="PlaygroundMiddleware"/>. If not set, then the default values will be used. </param>
     /// <param name="path">The path to the GraphQL Playground endpoint which defaults to '/ui/playground'</param>
     /// <returns> The reference to provided <paramref name="app"/> instance. </returns>
-    public static IApplicationBuilder UseGraphQLPlayground(this IApplicationBuilder app, PlaygroundOptions options, string path = "/ui/playground")
+    public static IApplicationBuilder UseGraphQLPlayground(this IApplicationBuilder app, string path = "/ui/playground", PlaygroundOptions? options = null)
     {
         return app.UseWhen(
             context => HttpMethods.IsGet(context.Request.Method) && !context.WebSockets.IsWebSocketRequest &&

--- a/src/Ui.Playground/Extensions/PlaygroundEndpointRouteBuilderExtensions.cs
+++ b/src/Ui.Playground/Extensions/PlaygroundEndpointRouteBuilderExtensions.cs
@@ -14,19 +14,10 @@ public static class PlaygroundEndpointRouteBuilderExtensions
     /// Add the Playground middleware to the HTTP request pipeline
     /// </summary>
     /// <param name="endpoints">Defines a contract for a route builder in an application. A route builder specifies the routes for an application.</param>
-    /// <param name="pattern">The route pattern.</param>
-    /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
-    public static PlaygroundEndpointConventionBuilder MapGraphQLPlayground(this IEndpointRouteBuilder endpoints, string pattern = "ui/playground")
-        => endpoints.MapGraphQLPlayground(new PlaygroundOptions(), pattern);
-
-    /// <summary>
-    /// Add the Playground middleware to the HTTP request pipeline
-    /// </summary>
-    /// <param name="endpoints">Defines a contract for a route builder in an application. A route builder specifies the routes for an application.</param>
     /// <param name="options">Options to customize <see cref="PlaygroundMiddleware"/>. If not set, then the default values will be used.</param>
     /// <param name="pattern">The route pattern.</param>
     /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
-    public static PlaygroundEndpointConventionBuilder MapGraphQLPlayground(this IEndpointRouteBuilder endpoints, PlaygroundOptions options, string pattern = "ui/playground")
+    public static PlaygroundEndpointConventionBuilder MapGraphQLPlayground(this IEndpointRouteBuilder endpoints, string pattern = "ui/playground", PlaygroundOptions? options = null)
     {
         if (endpoints == null)
             throw new ArgumentNullException(nameof(endpoints));

--- a/src/Ui.Voyager/Extensions/VoyagerApplicationBuilderExtensions.cs
+++ b/src/Ui.Voyager/Extensions/VoyagerApplicationBuilderExtensions.cs
@@ -8,19 +8,12 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class VoyagerApplicationBuilderExtensions
 {
-    /// <summary> Adds middleware for Voyager using default options. </summary>
-    /// <param name="app"> <see cref="IApplicationBuilder"/> to configure an application's request pipeline. </param>
-    /// <param name="path">The path to the Voyager endpoint which defaults to '/ui/voyager'</param>
-    /// <returns> The reference to provided <paramref name="app"/> instance. </returns>
-    public static IApplicationBuilder UseGraphQLVoyager(this IApplicationBuilder app, string path = "/ui/voyager")
-        => app.UseGraphQLVoyager(new VoyagerOptions(), path);
-
     /// <summary> Adds middleware for Voyager using the specified options. </summary>
     /// <param name="app"> <see cref="IApplicationBuilder"/> to configure an application's request pipeline. </param>
     /// <param name="options"> Options to customize <see cref="VoyagerMiddleware"/>. If not set, then the default values will be used. </param>
     /// <param name="path">The path to the Voyager endpoint which defaults to '/ui/voyager'</param>
     /// <returns> The reference to provided <paramref name="app"/> instance. </returns>
-    public static IApplicationBuilder UseGraphQLVoyager(this IApplicationBuilder app, VoyagerOptions options, string path = "/ui/voyager")
+    public static IApplicationBuilder UseGraphQLVoyager(this IApplicationBuilder app, string path = "/ui/voyager", VoyagerOptions? options = null)
     {
         return app.UseWhen(
             context => HttpMethods.IsGet(context.Request.Method) && !context.WebSockets.IsWebSocketRequest &&

--- a/src/Ui.Voyager/Extensions/VoyagerEndpointRouteBuilderExtensions.cs
+++ b/src/Ui.Voyager/Extensions/VoyagerEndpointRouteBuilderExtensions.cs
@@ -14,19 +14,10 @@ public static class VoyagerEndpointRouteBuilderExtensions
     /// Add the Voyager middleware to the HTTP request pipeline
     /// </summary>
     /// <param name="endpoints">Defines a contract for a route builder in an application. A route builder specifies the routes for an application.</param>
-    /// <param name="pattern">The route pattern.</param>
-    /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
-    public static VoyagerEndpointConventionBuilder MapGraphQLVoyager(this IEndpointRouteBuilder endpoints, string pattern = "ui/voyager")
-        => endpoints.MapGraphQLVoyager(new VoyagerOptions(), pattern);
-
-    /// <summary>
-    /// Add the Voyager middleware to the HTTP request pipeline
-    /// </summary>
-    /// <param name="endpoints">Defines a contract for a route builder in an application. A route builder specifies the routes for an application.</param>
     /// <param name="options">Options to customize <see cref="VoyagerMiddleware"/>. If not set, then the default values will be used.</param>
     /// <param name="pattern">The route pattern.</param>
     /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
-    public static VoyagerEndpointConventionBuilder MapGraphQLVoyager(this IEndpointRouteBuilder endpoints, VoyagerOptions options, string pattern = "ui/voyager")
+    public static VoyagerEndpointConventionBuilder MapGraphQLVoyager(this IEndpointRouteBuilder endpoints, string pattern = "ui/voyager", VoyagerOptions? options = null)
     {
         if (endpoints == null)
             throw new ArgumentNullException(nameof(endpoints));

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Altair.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Altair.approved.txt
@@ -19,8 +19,7 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class AltairApplicationBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLAltair(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/altair") { }
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLAltair(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, GraphQL.Server.Ui.Altair.AltairOptions options, string path = "/ui/altair") { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLAltair(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/altair", GraphQL.Server.Ui.Altair.AltairOptions? options = null) { }
     }
     public class AltairEndpointConventionBuilder : Microsoft.AspNetCore.Builder.IEndpointConventionBuilder
     {
@@ -28,7 +27,6 @@ namespace Microsoft.AspNetCore.Builder
     }
     public static class AltairEndpointRouteBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.AltairEndpointConventionBuilder MapGraphQLAltair(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "ui/altair") { }
-        public static Microsoft.AspNetCore.Builder.AltairEndpointConventionBuilder MapGraphQLAltair(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, GraphQL.Server.Ui.Altair.AltairOptions options, string pattern = "ui/altair") { }
+        public static Microsoft.AspNetCore.Builder.AltairEndpointConventionBuilder MapGraphQLAltair(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "ui/altair", GraphQL.Server.Ui.Altair.AltairOptions? options = null) { }
     }
 }

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -28,8 +28,7 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class GraphiQLApplicationBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLGraphiQL(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/graphiql") { }
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLGraphiQL(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, GraphQL.Server.Ui.GraphiQL.GraphiQLOptions options, string path = "/ui/graphiql") { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLGraphiQL(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/graphiql", GraphQL.Server.Ui.GraphiQL.GraphiQLOptions? options = null) { }
     }
     public class GraphiQLEndpointConventionBuilder : Microsoft.AspNetCore.Builder.IEndpointConventionBuilder
     {
@@ -37,7 +36,6 @@ namespace Microsoft.AspNetCore.Builder
     }
     public static class GraphiQLEndpointRouteBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.GraphiQLEndpointConventionBuilder MapGraphQLGraphiQL(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "ui/graphiql") { }
-        public static Microsoft.AspNetCore.Builder.GraphiQLEndpointConventionBuilder MapGraphQLGraphiQL(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, GraphQL.Server.Ui.GraphiQL.GraphiQLOptions options, string pattern = "ui/graphiql") { }
+        public static Microsoft.AspNetCore.Builder.GraphiQLEndpointConventionBuilder MapGraphQLGraphiQL(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "ui/graphiql", GraphQL.Server.Ui.GraphiQL.GraphiQLOptions? options = null) { }
     }
 }

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Playground.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Playground.approved.txt
@@ -53,8 +53,7 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class PlaygroundApplicationBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLPlayground(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/playground") { }
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLPlayground(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, GraphQL.Server.Ui.Playground.PlaygroundOptions options, string path = "/ui/playground") { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLPlayground(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/playground", GraphQL.Server.Ui.Playground.PlaygroundOptions? options = null) { }
     }
     public class PlaygroundEndpointConventionBuilder : Microsoft.AspNetCore.Builder.IEndpointConventionBuilder
     {
@@ -62,7 +61,6 @@ namespace Microsoft.AspNetCore.Builder
     }
     public static class PlaygroundEndpointRouteBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.PlaygroundEndpointConventionBuilder MapGraphQLPlayground(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "ui/playground") { }
-        public static Microsoft.AspNetCore.Builder.PlaygroundEndpointConventionBuilder MapGraphQLPlayground(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, GraphQL.Server.Ui.Playground.PlaygroundOptions options, string pattern = "ui/playground") { }
+        public static Microsoft.AspNetCore.Builder.PlaygroundEndpointConventionBuilder MapGraphQLPlayground(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "ui/playground", GraphQL.Server.Ui.Playground.PlaygroundOptions? options = null) { }
     }
 }

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Voyager.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Ui.Voyager.approved.txt
@@ -25,8 +25,7 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class VoyagerApplicationBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLVoyager(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/voyager") { }
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLVoyager(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, GraphQL.Server.Ui.Voyager.VoyagerOptions options, string path = "/ui/voyager") { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLVoyager(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/voyager", GraphQL.Server.Ui.Voyager.VoyagerOptions? options = null) { }
     }
     public class VoyagerEndpointConventionBuilder : Microsoft.AspNetCore.Builder.IEndpointConventionBuilder
     {
@@ -34,7 +33,6 @@ namespace Microsoft.AspNetCore.Builder
     }
     public static class VoyagerEndpointRouteBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.VoyagerEndpointConventionBuilder MapGraphQLVoyager(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "ui/voyager") { }
-        public static Microsoft.AspNetCore.Builder.VoyagerEndpointConventionBuilder MapGraphQLVoyager(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, GraphQL.Server.Ui.Voyager.VoyagerOptions options, string pattern = "ui/voyager") { }
+        public static Microsoft.AspNetCore.Builder.VoyagerEndpointConventionBuilder MapGraphQLVoyager(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "ui/voyager", GraphQL.Server.Ui.Voyager.VoyagerOptions? options = null) { }
     }
 }

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Altair.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Altair.approved.txt
@@ -19,7 +19,6 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class AltairApplicationBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLAltair(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/altair") { }
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLAltair(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, GraphQL.Server.Ui.Altair.AltairOptions options, string path = "/ui/altair") { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLAltair(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/altair", GraphQL.Server.Ui.Altair.AltairOptions? options = null) { }
     }
 }

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -28,7 +28,6 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class GraphiQLApplicationBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLGraphiQL(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/graphiql") { }
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLGraphiQL(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, GraphQL.Server.Ui.GraphiQL.GraphiQLOptions options, string path = "/ui/graphiql") { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLGraphiQL(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/graphiql", GraphQL.Server.Ui.GraphiQL.GraphiQLOptions? options = null) { }
     }
 }

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Playground.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Playground.approved.txt
@@ -53,7 +53,6 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class PlaygroundApplicationBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLPlayground(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/playground") { }
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLPlayground(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, GraphQL.Server.Ui.Playground.PlaygroundOptions options, string path = "/ui/playground") { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLPlayground(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/playground", GraphQL.Server.Ui.Playground.PlaygroundOptions? options = null) { }
     }
 }

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Voyager.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Voyager.approved.txt
@@ -25,7 +25,6 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class VoyagerApplicationBuilderExtensions
     {
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLVoyager(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/voyager") { }
-        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLVoyager(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, GraphQL.Server.Ui.Voyager.VoyagerOptions options, string path = "/ui/voyager") { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLVoyager(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/voyager", GraphQL.Server.Ui.Voyager.VoyagerOptions? options = null) { }
     }
 }


### PR DESCRIPTION
I think the UI middleware extension methods should require the path first and then the options, rather than the other way around.  I believe this just makes logical sense that you would define the endpoint address and then configure it.  Plus it matches the argument ordering of the `UseGraphQL` method (both now and previously).

Also I generally find that it works best when optional method arguments are additive to existing/required arguments, and this change fixes that issue as well.

This will require a note in the migration doc ( #854 ) if it is merged.

Some other options:
- Leave the old methods, deprecated
- Deprecate the path-only syntax leaving only the (options, path) syntax
- Change the options argument to a builder delegate (if we do this then I would deprecate the old ones rather than removing them)

Since we have a large number of changes going into v7, perhaps now is a good time to make this change.