### PR TITLE
Rename badge labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Nuget](https://img.shields.io/nuget/dt/GraphQL.Server.Transports.AspNetCore)](https://www.nuget.org/packages/GraphQL.Server.Transports.AspNetCore)
 [![Nuget](https://img.shields.io/nuget/v/GraphQL.Server.Transports.AspNetCore)](https://www.nuget.org/packages/GraphQL.Server.Transports.AspNetCore)
 [![GitHub Release Date](https://img.shields.io/github/release-date/graphql-dotnet/server?label=released)](https://github.com/graphql-dotnet/server/releases)
-[![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/graphql-dotnet/server/latest=new+commits)](https://github.com/graphql-dotnet/server/commits/master)
+[![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/graphql-dotnet/server/latest?label=new+commits)](https://github.com/graphql-dotnet/server/commits/master)
 [![GitHub contributors](https://img.shields.io/github/contributors/graphql-dotnet/server)](https://github.com/graphql-dotnet/server/graphs/contributors)
 ![Size](https://img.shields.io/github/repo-size/graphql-dotnet/server)
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![codecov](https://codecov.io/gh/graphql-dotnet/server/branch/master/graph/badge.svg?token=ZBcVYq7hz4)](https://codecov.io/gh/graphql-dotnet/server)
 [![Nuget](https://img.shields.io/nuget/dt/GraphQL.Server.Transports.AspNetCore)](https://www.nuget.org/packages/GraphQL.Server.Transports.AspNetCore)
 [![Nuget](https://img.shields.io/nuget/v/GraphQL.Server.Transports.AspNetCore)](https://www.nuget.org/packages/GraphQL.Server.Transports.AspNetCore)
-[![GitHub Release Date](https://img.shields.io/github/release-date/graphql-dotnet/server)](https://github.com/graphql-dotnet/server/releases)
-[![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/graphql-dotnet/server/latest)](https://github.com/graphql-dotnet/server/commits/master)
+[![GitHub Release Date](https://img.shields.io/github/release-date/graphql-dotnet/server?label=released)](https://github.com/graphql-dotnet/server/releases)
+[![GitHub commits since latest release (by date)](https://img.shields.io/github/commits-since/graphql-dotnet/server/latest=new+commits)](https://github.com/graphql-dotnet/server/commits/master)
 [![GitHub contributors](https://img.shields.io/github/contributors/graphql-dotnet/server)](https://github.com/graphql-dotnet/server/graphs/contributors)
 ![Size](https://img.shields.io/github/repo-size/graphql-dotnet/server)
 


### PR DESCRIPTION
Rename badge labels so they all fit on one line

Changed:
- "release date" to "released" (this badge comes immediately after the version number badge)
- "commits since 6.1.0" to "new commits" (this badge comes immediately after the the latter one)

I like changing "release date" to "released" but "new commits" is not as clear as before.  Might be better just to remove a badge