### PR TITLE
Add GraphQLHttpMiddlewareOptions.ValidationErrorsReturnHeader

### DIFF
--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -301,7 +301,7 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
             {
                 statusCode = HttpStatusCode.BadRequest;
                 if (!string.IsNullOrEmpty(_options.ValidationErrorsReturnHeader))
-                    context.Response.Headers.Add(_options.ValidationErrorsReturnHeader, Microsoft.Extensions.Primitives.StringValues.Empty);
+                    context.Response.Headers.Add(_options.ValidationErrorsReturnHeader, "true");
             }
         }
         await WriteJsonResponseAsync(context, statusCode, result);

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -298,7 +298,11 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
             if (result.Errors?.Any(e => e is HttpMethodValidationError) == true)
                 statusCode = HttpStatusCode.MethodNotAllowed;
             else if (_options.ValidationErrorsReturnBadRequest)
+            {
                 statusCode = HttpStatusCode.BadRequest;
+                if (!string.IsNullOrEmpty(_options.ValidationErrorsReturnHeader))
+                    context.Response.Headers.Add(_options.ValidationErrorsReturnHeader, Microsoft.Extensions.Primitives.StringValues.Empty);
+            }
         }
         await WriteJsonResponseAsync(context, statusCode, result);
     }

--- a/src/Transports.AspNetCore/GraphQLHttpMiddlewareOptions.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddlewareOptions.cs
@@ -58,7 +58,7 @@ public class GraphQLHttpMiddlewareOptions : IAuthorizationOptions
     /// <br/><br/>
     /// Does not apply to batched or WebSocket requests.
     /// </summary>
-    public string ValidationErrorsReturnHeader { get; set; } = "graphql-validation";
+    public string ValidationErrorsReturnHeader { get; set; } = "X-GraphQL-Validation-Error";
 
     /// <summary>
     /// Enables parsing the query string on POST requests.

--- a/src/Transports.AspNetCore/GraphQLHttpMiddlewareOptions.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddlewareOptions.cs
@@ -50,6 +50,17 @@ public class GraphQLHttpMiddlewareOptions : IAuthorizationOptions
     public bool ValidationErrorsReturnBadRequest { get; set; } = true;
 
     /// <summary>
+    /// When set and <see cref="ValidationErrorsReturnBadRequest"/> enabled,
+    /// GraphQL requests with validation errors have the specified header.
+    /// This helps to understand what the response body should be deserialized
+    /// in and whether it is necessary at all.
+    /// GraphQL requests with execution errors are unaffected.
+    /// <br/><br/>
+    /// Does not apply to batched or WebSocket requests.
+    /// </summary>
+    public string ValidationErrorsReturnHeader { get; set; } = "graphql-validation";
+
+    /// <summary>
     /// Enables parsing the query string on POST requests.
     /// If enabled, the query string properties override those in the body of the request.
     /// </summary>

--- a/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -110,6 +110,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         public bool ReadQueryStringOnPost { get; set; }
         public bool ReadVariablesFromQueryString { get; set; }
         public bool ValidationErrorsReturnBadRequest { get; set; }
+        public string ValidationErrorsReturnHeader { get; set; }
         public GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions WebSockets { get; set; }
     }
     public class GraphQLHttpMiddleware<TSchema> : GraphQL.Server.Transports.AspNetCore.GraphQLHttpMiddleware

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -117,6 +117,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         public bool ReadQueryStringOnPost { get; set; }
         public bool ReadVariablesFromQueryString { get; set; }
         public bool ValidationErrorsReturnBadRequest { get; set; }
+        public string ValidationErrorsReturnHeader { get; set; }
         public GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions WebSockets { get; set; }
     }
     public class GraphQLHttpMiddleware<TSchema> : GraphQL.Server.Transports.AspNetCore.GraphQLHttpMiddleware


### PR DESCRIPTION
It helps when migrating to v7 to distinguish 400 from graphql validation layer and 400 from something else. In the first case caller **can** try to deserialize response body into "normal" graphql response.