### PR TITLE
Add JWT bearer authentication sample

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,9 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
          dotnet-version: "6.0.102"
+         source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
+      env:
+         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/GraphQL.Server.sln
+++ b/GraphQL.Server.sln
@@ -108,6 +108,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Migration", "Migration", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Jwt", "samples\Samples.Jwt\Samples.Jwt.csproj", "{5A16B117-0FAD-4F91-A97C-E72B733B4E57}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Jwt.Tests", "tests\Samples.Jwt.Tests\Samples.Jwt.Tests.csproj", "{2B5A39E8-098F-458E-981C-BC9470CB94B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -238,6 +240,10 @@ Global
 		{5A16B117-0FAD-4F91-A97C-E72B733B4E57}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A16B117-0FAD-4F91-A97C-E72B733B4E57}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A16B117-0FAD-4F91-A97C-E72B733B4E57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B5A39E8-098F-458E-981C-BC9470CB94B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B5A39E8-098F-458E-981C-BC9470CB94B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B5A39E8-098F-458E-981C-BC9470CB94B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B5A39E8-098F-458E-981C-BC9470CB94B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -273,6 +279,7 @@ Global
 		{9AEB9941-618B-430A-A14C-37F39AFFC0C4} = {BBD07745-C962-4D2D-B302-6DA1BCC2FF43}
 		{FF0810A0-3372-40ED-B3E3-D703BEF0F118} = {AB155A1E-CB5E-465E-BC29-A1A4A5D9D2B0}
 		{5A16B117-0FAD-4F91-A97C-E72B733B4E57} = {5C07AFA3-12F2-40EA-807D-7A1EEF29012B}
+		{2B5A39E8-098F-458E-981C-BC9470CB94B0} = {BBD07745-C962-4D2D-B302-6DA1BCC2FF43}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3FC7FA59-E938-453C-8C4A-9D5635A9489A}

--- a/GraphQL.Server.sln
+++ b/GraphQL.Server.sln
@@ -106,6 +106,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Migration", "Migration", "{
 		docs\migration\migration7.md = docs\migration\migration7.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Jwt", "samples\Samples.Jwt\Samples.Jwt.csproj", "{5A16B117-0FAD-4F91-A97C-E72B733B4E57}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -232,6 +234,10 @@ Global
 		{9AEB9941-618B-430A-A14C-37F39AFFC0C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9AEB9941-618B-430A-A14C-37F39AFFC0C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9AEB9941-618B-430A-A14C-37F39AFFC0C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A16B117-0FAD-4F91-A97C-E72B733B4E57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A16B117-0FAD-4F91-A97C-E72B733B4E57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A16B117-0FAD-4F91-A97C-E72B733B4E57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A16B117-0FAD-4F91-A97C-E72B733B4E57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -266,6 +272,7 @@ Global
 		{BF4ED814-A21D-45F5-8F71-54148751AE81} = {BBD07745-C962-4D2D-B302-6DA1BCC2FF43}
 		{9AEB9941-618B-430A-A14C-37F39AFFC0C4} = {BBD07745-C962-4D2D-B302-6DA1BCC2FF43}
 		{FF0810A0-3372-40ED-B3E3-D703BEF0F118} = {AB155A1E-CB5E-465E-BC29-A1A4A5D9D2B0}
+		{5A16B117-0FAD-4F91-A97C-E72B733B4E57} = {5C07AFA3-12F2-40EA-807D-7A1EEF29012B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3FC7FA59-E938-453C-8C4A-9D5635A9489A}

--- a/README.md
+++ b/README.md
@@ -777,6 +777,7 @@ typical ASP.NET Core scenarios.
 | Controller      | .NET 6 Minimal           | MVC implementation; does not include WebSocket support |
 | Cors            | .NET 6 Minimal           | Demonstrates configuring a GraphQL endpoint to use a specified CORS policy |
 | EndpointRouting | .NET 6 Minimal           | Demonstrates configuring GraphQL through endpoint routing |
+| Jwt             | .NET 6 Minimal           | Demonstrates authenticating GraphQL requests with a JWT bearer token over HTTP POST and WebSocket connections |
 | MultipleSchemas | .NET 6 Minimal           | Demonstrates configuring multiple schemas within a single server |
 | Net48           | .NET Core 2.1 / .NET 4.8 | Demonstrates configuring GraphQL on .NET 4.8 / Core 2.1 |
 | Pages           | .NET 6 Minimal           | Demonstrates configuring GraphQL on top of a Razor Pages template |

--- a/samples/Samples.Jwt/Controllers/AuthController.cs
+++ b/samples/Samples.Jwt/Controllers/AuthController.cs
@@ -1,0 +1,29 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GraphQL.Server.Samples.Jwt.Controllers;
+
+public class AuthController : Controller
+{
+    // sample OAuth2-compatible authorization endpoint supporting the 'client credentials' flow
+    [HttpGet]
+    [HttpPost]
+    [Route("token")]
+    public IActionResult Token(string grant_type, string client_id, string client_secret)
+    {
+        // validate the provided client id and client secret
+        if (grant_type == "client_credentials" && client_id == "sampleClientId" && client_secret == "sampleSecret")
+        {
+            // provide a signed JWT token with an 'Administrator' role claim
+            var token = JwtHelper.CreateSignedToken(new Claim("role", "Administrator"));
+            return Json(new
+            {
+                access_token = token.Token,
+                expires_in = token.ExpiresIn.TotalSeconds,
+                token_type = "Bearer",
+            });
+        }
+
+        return Unauthorized();
+    }
+}

--- a/samples/Samples.Jwt/Controllers/OAuthController.cs
+++ b/samples/Samples.Jwt/Controllers/OAuthController.cs
@@ -15,7 +15,7 @@ public class OAuthController : Controller
         if (grant_type == "client_credentials" && client_id == "sampleClientId" && client_secret == "sampleSecret")
         {
             // provide a signed JWT token with an 'Administrator' role claim
-            var token = JwtHelper.CreateSignedToken(new Claim("role", "Administrator"));
+            var token = JwtHelper.Instance.CreateSignedToken(new Claim("role", "Administrator"));
             return Json(new
             {
                 access_token = token.Token,

--- a/samples/Samples.Jwt/Controllers/OAuthController.cs
+++ b/samples/Samples.Jwt/Controllers/OAuthController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GraphQL.Server.Samples.Jwt.Controllers;
 
-public class AuthController : Controller
+public class OAuthController : Controller
 {
     // sample OAuth2-compatible authorization endpoint supporting the 'client credentials' flow
     [HttpGet]

--- a/samples/Samples.Jwt/JwtHelper.cs
+++ b/samples/Samples.Jwt/JwtHelper.cs
@@ -5,6 +5,9 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace GraphQL.Server.Samples.Jwt;
 
+/// <summary>
+/// Provides a method to create a signed token, and provides token validation parameters to validate those tokens.
+/// </summary>
 public static class JwtHelper
 {
     private static readonly SecurityKey _securityKey;
@@ -50,8 +53,14 @@ public static class JwtHelper
             };
     }
 
+    /// <summary>
+    /// Returns the <see cref="TokenValidationParameters"/> used to authenticate JWT bearer tokens.
+    /// </summary>
     public static TokenValidationParameters TokenValidationParameters { get; }
 
+    /// <summary>
+    /// Creates a signed JWT token containing the specified <see cref="Claim"/>s.
+    /// </summary>
     public static (TimeSpan ExpiresIn, string Token) CreateSignedToken(params Claim[] claims)
     {
         var now = DateTime.UtcNow;

--- a/samples/Samples.Jwt/JwtHelper.cs
+++ b/samples/Samples.Jwt/JwtHelper.cs
@@ -89,7 +89,7 @@ public static class JwtHelper
     {
         // interpret the key as base64
         var keyBytes = Convert.FromBase64String(key);
-        // create a ECDsa key pair and import th key
+        // create a ECDsa key pair and import the key
         var ecdsa = ECDsa.Create();
         if (isPrivateKey)
             ecdsa.ImportECPrivateKey(keyBytes, out int _);

--- a/samples/Samples.Jwt/JwtHelper.cs
+++ b/samples/Samples.Jwt/JwtHelper.cs
@@ -75,7 +75,8 @@ public class JwtHelper
     {
         // hash the password and use that to create a symmetric key for signing the JWT tokens
         var passwordBytes = System.Text.Encoding.UTF8.GetBytes(password);
-        var keyBytes = SHA256.Create().ComputeHash(passwordBytes);
+        using var sha = SHA256.Create();
+        var keyBytes = sha.ComputeHash(passwordBytes);
         var securityKey = new SymmetricSecurityKey(keyBytes);
         // return the key
         return (securityKey, SecurityAlgorithms.HmacSha256);
@@ -92,7 +93,7 @@ public class JwtHelper
         // interpret the key as base64
         var keyBytes = Convert.FromBase64String(key);
         // create a ECDsa key pair and import the key
-        var ecdsa = ECDsa.Create();
+        using var ecdsa = ECDsa.Create();
         if (isPrivateKey)
             ecdsa.ImportECPrivateKey(keyBytes, out int _);
         else
@@ -107,7 +108,7 @@ public class JwtHelper
     /// </summary>
     public static (string PublicKey, string PrivateKey) CreateNewAsymmetricKeyPair()
     {
-        var ecdsa = ECDsa.Create();
+        using var ecdsa = ECDsa.Create();
         var privateKey = Convert.ToBase64String(ecdsa.ExportECPrivateKey());
         var publicKey = Convert.ToBase64String(ecdsa.ExportSubjectPublicKeyInfo());
         return (publicKey, privateKey);

--- a/samples/Samples.Jwt/JwtHelper.cs
+++ b/samples/Samples.Jwt/JwtHelper.cs
@@ -1,0 +1,80 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+
+namespace GraphQL.Server.Samples.Jwt;
+
+public static class JwtHelper
+{
+    private static readonly SecurityKey _securityKey;
+    private static readonly string _securityAlgorithm;
+    private static readonly SigningCredentials _signingCredentials;
+    private static readonly string _issuer = "http://localhost/Samples.Jwt";
+    private static readonly string _audience = "Samples.Jwt.Audience";
+    private static readonly TimeSpan _expiresIn = TimeSpan.FromMinutes(5);
+
+    static JwtHelper()
+    {
+        // create a new random password (typically the password would be defined in an application secret)
+        var password = Guid.NewGuid().ToString();
+        // hash the password and use that to create a symmetric key for signing the JWT tokens
+        var passwordBytes = System.Text.Encoding.UTF8.GetBytes(password);
+        var keyBytes = SHA256.Create().ComputeHash(passwordBytes);
+        _securityKey = new SymmetricSecurityKey(keyBytes);
+        // define the algorithm and credentials
+        _securityAlgorithm = SecurityAlgorithms.HmacSha256;
+        _signingCredentials = new(_securityKey, _securityAlgorithm);
+        // set the token validation parameters
+        TokenValidationParameters =
+            new TokenValidationParameters
+            {
+                // validate the issuer name on the token
+                ValidateIssuer = true,
+                ValidIssuer = _issuer,
+                // validate the audience name on the token
+                ValidateAudience = true,
+                ValidAudience = _audience,
+                // validate the 'not before' timestamp, if it exists
+                ValidateLifetime = true,
+                // ensure the token has not expired
+                RequireExpirationTime = true,
+                // allow up to 6 seconds of clock skew (aka add 6 seconds to the expiration time)
+                //   (because Azure might let the VM clock get 5 seconds off before forcing a re-sync to the host)
+                ClockSkew = TimeSpan.FromSeconds(6),
+                // ensure the digital signature exists and validate it
+                RequireSignedTokens = true,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKeys = new[] { _securityKey },
+                ValidAlgorithms = new[] { _securityAlgorithm },
+            };
+    }
+
+    public static TokenValidationParameters TokenValidationParameters { get; }
+
+    public static (TimeSpan ExpiresIn, string Token) CreateSignedToken(params Claim[] claims)
+    {
+        var now = DateTime.UtcNow;
+
+        // create the security token as follows:
+        var token = new JwtSecurityToken(
+            // issuer is an arbitary string, typically the name of the web server that issued the token
+            issuer: _issuer,
+            // audience is an arbitary string, typically representing valid recipients - typically 'Refresh' or 'Access' or a url for a subdomain
+            audience: _audience,
+            // include a list of claims
+            claims: claims,
+            // set the time this token becomes valid
+            notBefore: now,
+            // for access tokens, set a short timeout like 5 minutes, after which the access token will need to be refreshed
+            //   (the access token can be refreshed before or after the expiration, as refreshing it uses the refresh token)
+            // for refresh tokens, set a long timeout like 6 months, after which the refresh token will expire
+            expires: now.Add(_expiresIn),
+            // set the digital signature algorithm and key
+            signingCredentials: _signingCredentials
+        );
+
+        // return the token
+        return (_expiresIn, new JwtSecurityTokenHandler().WriteToken(token));
+    }
+}

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -37,7 +37,7 @@ public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
                 var token = authPayload.Authorization.Substring(7);
                 // parse the token in the same manner that the .NET AddJwtBearer() method does
                 var handler = new Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler();
-                var result = handler.ValidateToken(token, JwtHelper.TokenValidationParameters);
+                var result = handler.ValidateToken(token, JwtHelper.Instance.TokenValidationParameters);
                 if (result.IsValid)
                 {
                     // convert JWT tokens with "role" as the claim type (a JWT defined claim type) to the proper .NET claim type constant

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+using GraphQL.Server.Transports.AspNetCore.WebSockets;
+using GraphQL.Transport;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+namespace GraphQL.Server.Samples.Jwt;
+
+/// <summary>
+/// Authenticates WebSocket connections via the 'payload' of the initialization packet.
+/// This is necessary because WebSocket connections initiated from the browser cannot
+/// authenticate via HTTP headers.
+/// <br/><br/>
+/// This class is not used when authenticating over GET/POST.
+/// </summary>
+public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
+{
+    private readonly IGraphQLSerializer _graphQLSerializer;
+
+    public JwtWebSocketAuthenticationService(IGraphQLSerializer graphQLSerializer)
+    {
+        _graphQLSerializer = graphQLSerializer;
+    }
+
+    public Task AuthenticateAsync(IWebSocketConnection connection, string subProtocol, OperationMessage operationMessage)
+    {
+        try
+        {
+            // for connections authenticated via HTTP headers, no need to reauthenticate
+            if (connection.HttpContext.User.Identity?.IsAuthenticated ?? false)
+                return Task.CompletedTask;
+
+            // attempt to read the 'Authorization' key from the payload object and verify it contains "Bearer: XXXXXXXX"
+            var authPayload = _graphQLSerializer.ReadNode<AuthPayload>(operationMessage.Payload);
+            if (authPayload != null && authPayload.Authorization != null && authPayload.Authorization.StartsWith("Bearer ", StringComparison.Ordinal))
+            {
+                // pull the token from the value
+                var token = authPayload.Authorization.Substring(7);
+                // parse the token in the same manner that the .NET AddJwtBearer() method does
+                var handler = new Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler();
+                var result = handler.ValidateToken(token, JwtHelper.TokenValidationParameters);
+                if (result.IsValid)
+                {
+                    // convert JWT tokens with "role" as the claim type (a JWT defined claim type) to the proper .NET claim type constant
+                    // note this conversion automatically happens within the .NET AddJwtBearer() method when authenticating GET/POST requests
+                    var claims = result.ClaimsIdentity.Claims.Select(claim => claim.Type == "role" ? new Claim(result.ClaimsIdentity.RoleClaimType, claim.Value) : claim);
+                    var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, JwtBearerDefaults.AuthenticationScheme));
+
+                    // set the ClaimsPrincipal for the HttpContext; authentication will take place against this object
+                    connection.HttpContext.User = principal;
+                }
+            }
+        }
+        catch
+        {
+            // no errors during authentication should throw an exception
+            // specifically, attempting to validate an invalid JWT token will result in an exception, which should be ignored
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private class AuthPayload
+    {
+        public string? Authorization { get; set; }
+    }
+}

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -53,7 +53,7 @@ public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
         catch
         {
             // no errors during authentication should throw an exception
-            // specifically, attempting to validate an invalid JWT token will result in an exception, which should be ignored
+            // specifically, attempting to validate an invalid JWT token will result in an exception, which may be logged or simply ignored to not generate an inordinate amount of logs without purpose
         }
 
         return Task.CompletedTask;

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -40,7 +40,7 @@ public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
                 var result = handler.ValidateToken(token, JwtHelper.Instance.TokenValidationParameters);
                 if (result.IsValid)
                 {
-                    // convert JWT tokens with "role" as the claim type (a JWT defined claim type) to the proper .NET claim type constant
+                    // convert JWT tokens with "role" as the claim type (a JWT defined claim type) to the proper .NET claim type constant http://schemas.microsoft.com/ws/2008/06/identity/claims/role
                     // note this conversion automatically happens within the .NET AddJwtBearer() method when authenticating GET/POST requests
                     var claims = result.ClaimsIdentity.Claims.Select(claim => claim.Type == "role" ? new Claim(result.ClaimsIdentity.RoleClaimType, claim.Value) : claim);
                     var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, JwtBearerDefaults.AuthenticationScheme));

--- a/samples/Samples.Jwt/Pages/Index.cshtml
+++ b/samples/Samples.Jwt/Pages/Index.cshtml
@@ -1,0 +1,232 @@
+@page
+@using GraphQL.Server.Samples.Jwt
+@model IndexModel
+<!--
+ *  Copyright (c) 2021 GraphQL Contributors
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body {
+      height: 100%;
+      margin: 0;
+      width: 100%;
+      overflow: hidden;
+    }
+
+    #graphiql {
+      height: 100vh;
+    }
+  </style>
+
+  <!--
+    This GraphiQL example depends on Promise and fetch, which are available in
+    modern browsers, but can be "polyfilled" for older browsers.
+    GraphiQL itself depends on React DOM.
+    If you do not want to rely on a CDN, you can host these files locally or
+    include them directly in your favored resource bunder.
+  -->
+  <script
+    src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.3/fetch.min.js"
+    integrity="sha384-dcF7KoWRaRpjcNbVPUFgatYgAijf8DqW6NWuqLdfB5Sb4Cdbb8iHX7bHsl9YhpKa"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    src="https://unpkg.com/react@16.14.0/umd/react.production.min.js"
+    integrity="sha384-N7y5SSAooNlIfb9H750GR82ufkn1JXJFaCjg8pmt+OZuKcZoTvTGfog4d4taG/cF"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    src="https://unpkg.com/react-dom@16.14.0/umd/react-dom.production.min.js"
+    integrity="sha384-j7WmMv3OO6n8pZRATOsaMVEdZcHpoaTBIika/l92YM2AkEex72QunlTQlgmu+pI8"
+    crossorigin="anonymous"
+  ></script>
+
+  <!--
+    These two files can be found in the npm module, however you may wish to
+    copy them directly into your environment, or perhaps include them in your
+    favored resource bundler.
+   -->
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/graphiql@1.5.1/graphiql.min.css"
+    integrity="sha384-1YHEU+Xy8hlKYAZ26WTz+JQEPMM6i/Mx5m8umMkSZChlzSYmq7RqyCyRbGqrILVZ"
+    crossorigin="anonymous"
+  />
+  <script
+    src="https://unpkg.com/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"
+    integrity="sha384-TqI6gT2PjmSrnEOTvGHLad1U4Vm5VoyzMmcKK0C/PLCWTnwPyXhCJY6NYhC/tp19"
+    crossorigin="anonymous"
+  ></script>
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.css"
+    integrity="sha384-GBqwox+q8UtVEyBLBKloN5QDlBDsQnuoSUfMeJH1ZtDiCrrk103D7Bg/WjIvl4ya"
+    crossorigin="anonymous"
+  />
+  <script
+    src="https://unpkg.com/subscriptions-transport-ws@0.8.3/browser/client.js"
+    crossorigin="anonymous"
+  ></script>
+  <script
+    src="https://unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"
+    integrity="sha384-ArTEHLNWIe9TuoDpFEtD/NeztNdWn3SdmWwMiAuZaSJeOaYypEGzeQoBxuPO+ORM"
+    crossorigin="anonymous"
+  ></script>
+
+</head>
+<body>
+  <div id="graphiql">Loading...</div>
+  <script
+    src="https://unpkg.com/graphiql@1.5.1/graphiql.min.js"
+    integrity="sha384-ktvW/i3KUd0D3ub91RkvHlJmf5wWqq7/VSBpCtpRrItml9btmAZH0x8c7fEXcr3e"
+    crossorigin="anonymous"
+  ></script>
+  <script>
+
+    /**
+     * This GraphiQL example illustrates how to use some of GraphiQL's props
+     * in order to enable reading and updating the URL parameters, making
+     * link sharing of queries a little bit easier.
+     *
+     * This is only one example of this kind of feature, GraphiQL exposes
+     * various React params to enable interesting integrations.
+     */
+
+    // Parse the search string to get url parameters.
+    var search = window.location.search;
+    var parameters = {};
+    search.substr(1).split('&').forEach(function (entry) {
+      var eq = entry.indexOf('=');
+      if (eq >= 0) {
+        parameters[decodeURIComponent(entry.slice(0, eq))] =
+          decodeURIComponent(entry.slice(eq + 1));
+      }
+    });
+
+    // if variables was provided, try to format it.
+    if (parameters.variables) {
+      try {
+        parameters.variables =
+          JSON.stringify(JSON.parse(parameters.variables), null, 2);
+      } catch (e) {
+        // Do nothing, we want to display the invalid JSON as a string, rather
+        // than present an error.
+      }
+    }
+
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
+
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
+
+    function onEditOperationName(newOperationName) {
+      parameters.operationName = newOperationName;
+      updateURL();
+    }
+
+    function updateURL() {
+      var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+        return Boolean(parameters[key]);
+      }).map(function (key) {
+        return encodeURIComponent(key) + '=' +
+          encodeURIComponent(parameters[key]);
+      }).join('&');
+      history.replaceState(null, null, newSearch);
+    }
+
+    // For simplicity, a new authorization token is obtained for every call.
+    // Normally this would be cached until the token expires and then refreshed
+    function getAuthToken() {
+      return fetch('/token', {
+        method: 'post',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: 'grant_type=client_credentials&client_id=sampleClientId&client_secret=sampleSecret'
+      }).then(function(authResponse) {
+        if (authResponse.status != 200)
+          return Promise.reject();
+        return authResponse.json();
+      })
+    }
+
+    // Defines a GraphQL fetcher using the fetch API. You're not required to
+    // use fetch, and could instead implement graphQLFetcher however you like,
+    // as long as it returns a Promise or Observable.
+    function graphQLFetcher(graphQLParams, fetcherOpts = { headers: {} }) {
+      // This example expects a GraphQL server at the path /graphql.
+      // Change this to point wherever you host your GraphQL server.
+      return getAuthToken().then(function(authData) {
+        let headers = Object.assign({ 'Authorization': authData.token_type + ' ' + authData.access_token }, fetcherOpts.headers);
+        headers = Object.assign(@Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Headers)), headers)
+        return fetch('@Model.GraphQLEndPoint', {
+          method: 'post',
+          headers: headers,
+          body: JSON.stringify(graphQLParams),
+          credentials: 'include',
+        })
+      }).then(function (response) {
+        return response.text();
+      }).then(function (responseBody) {
+        try {
+          return JSON.parse(responseBody);
+        } catch (error) {
+          return responseBody;
+        }
+      });
+    }
+
+    // Enable Subscriptions via WebSocket
+    // since 0.8.2 doesn't support a promise to create the auth token, we are just creating it once ahead of time here
+    // (0.9.0+ isn't compatible without more changes)
+    let subscriptionsClient = null;
+    getAuthToken().then(function (authData) {
+      subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
+        (window.location.protocol === "http:" ? "ws://" : "wss://") + window.location.host + "@Model.SubscriptionsEndPoint",
+        {
+          reconnect: true,
+          connectionParams: { 'Authorization': authData.token_type + ' ' + authData.access_token }
+        });
+    });
+    function subscriptionsFetcher(graphQLParams, fetcherOpts = { headers: {} }) {
+      console.log('init subscriptions fetcher');
+      return window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, function (_graphQLParams) {
+        return graphQLFetcher(_graphQLParams, fetcherOpts);
+      })(graphQLParams);
+    }
+
+    // Render <GraphiQL /> into the body.
+    // See the README in the top level of this module to learn more about
+    // how you can customize GraphiQL by providing different values or
+    // additional child elements.
+    ReactDOM.render(
+      React.createElement(@Model.GraphiQLElement, {
+        fetcher: subscriptionsFetcher,
+        query: parameters.query,
+        variables: parameters.variables,
+        operationName: parameters.operationName,
+        onEditQuery: onEditQuery,
+        onEditVariables: onEditVariables,
+        onEditOperationName: onEditOperationName,
+        headerEditorEnabled: @Model.HeaderEditorEnabled.ToString().ToLower(),
+      }),
+      document.getElementById('graphiql'),
+    );
+  </script>
+</body>
+</html>

--- a/samples/Samples.Jwt/Pages/Index.cshtml.cs
+++ b/samples/Samples.Jwt/Pages/Index.cshtml.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GraphQL.Server.Samples.Jwt;
+
+public class IndexModel : PageModel
+{
+    private readonly ILogger<IndexModel> _logger;
+
+    public IndexModel(ILogger<IndexModel> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OnGet()
+    {
+
+    }
+
+    public string GraphQLEndPoint => "/graphql";
+
+    public string SubscriptionsEndPoint => "/graphql";
+
+    public IDictionary<string, object?> Headers { get; } = new Dictionary<string, object?> {
+            { "Accept", "application/json" },
+            { "Content-Type", "application/json" },
+        };
+
+    public string GraphiQLElement => "GraphiQLWithExtensions.GraphiQLWithExtensions";
+
+    public bool HeaderEditorEnabled => true;
+}

--- a/samples/Samples.Jwt/Program.cs
+++ b/samples/Samples.Jwt/Program.cs
@@ -6,6 +6,7 @@ using Chat = GraphQL.Samples.Schemas.Chat;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
+builder.Services.AddControllers();
 builder.Services.AddSingleton<Chat.IChat, Chat.Chat>();
 builder.Services.AddGraphQL(b => b
     .AddAutoSchema<Chat.Query>(s => s
@@ -14,36 +15,44 @@ builder.Services.AddGraphQL(b => b
     .AddSystemTextJson()
     // support authorization policies within the schema (although none are set in this sample)
     .AddAuthorizationRule()
-    // support WebSocket authentication via the payload of the initialization packet
+    // support WebSocket authentication via the payload of the initialization message
     .AddWebSocketAuthentication<JwtWebSocketAuthenticationService>());
 
-// provide authentication for GET/POST requests via the 'Authorization' HTTP header;
+// configure authentication for GET/POST requests via the 'Authorization' HTTP header;
 // will authenticate WebSocket requests as well, but browsers cannot set the
 // 'Authorization' HTTP header for WebSocket requests
 builder.Services.AddAuthentication(
     opts =>
     {
         opts.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
-        // configure custom authorization policies here
+        // configure custom authorization policies here, if any
     })
     .AddJwtBearer(opts => opts.TokenValidationParameters = JwtHelper.TokenValidationParameters);
 
 var app = builder.Build();
 app.UseDeveloperExceptionPage();
+// enable WebSocket support within the ASP.NET Core framework
 app.UseWebSockets();
 // use ASP.Net Core authentication (again, for GET/POST requests mainly)
 app.UseAuthentication();
 // configure the graphql endpoint at "/graphql" for administrators only
 app.UseGraphQL("/graphql", opts =>
 {
-    // set a transport-level authorization policy; connections are refused if this policy is not met
-    // this means that anonymous access to the introspection query is not available
+    // here we are setting a transport-level authorization policy allowing only authenticated users
+    // that carry the "Administrator" role to connect; connections are refused if this policy is not met
+
+    // because of this rule, anonymous access to perform introspection queries is not available
+
+    // remove this authorization policy if you wish to allow anonymous access to your schema and set
+    // authorization policies on individual graphs and fields
+
     opts.AuthorizedRoles.Add("Administrator");
 });
+// enable ASP.Net Core routing for razor pages and MVC controllers
 app.UseRouting();
 // enable Pages for the GraphiQL demonstration endpoint at /
 app.MapRazorPages();
-// the OAuth2 authorization endpoint will be at /token
+// enable MVC controllers for the OAuth2 authorization endpoint at /token
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller}/{action}");

--- a/samples/Samples.Jwt/Program.cs
+++ b/samples/Samples.Jwt/Program.cs
@@ -55,7 +55,7 @@ app.UseGraphQL("/graphql", opts =>
 
     opts.AuthorizedRoles.Add("Administrator");
 });
-// enable ASP.Net Core routing for razor pages and MVC controllers
+// enable ASP.NET Core routing for razor pages and MVC controllers
 app.UseRouting();
 // enable Pages for the GraphiQL demonstration endpoint at /
 app.MapRazorPages();

--- a/samples/Samples.Jwt/Program.cs
+++ b/samples/Samples.Jwt/Program.cs
@@ -1,0 +1,34 @@
+using GraphQL;
+using GraphQL.Server.Samples.Jwt;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Chat = GraphQL.Samples.Schemas.Chat;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddSingleton<Chat.IChat, Chat.Chat>();
+builder.Services.AddGraphQL(b => b
+    .AddAutoSchema<Chat.Query>(s => s
+        .WithMutation<Chat.Mutation>()
+        .WithSubscription<Chat.Subscription>())
+    .AddAuthorizationRule()
+    .AddWebSocketAuthentication<JwtWebSocketAuthenticationService>()
+    .AddSystemTextJson());
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(opts => opts.TokenValidationParameters = JwtHelper.TokenValidationParameters);
+
+var app = builder.Build();
+app.UseDeveloperExceptionPage();
+app.UseWebSockets();
+app.UseAuthentication();
+// configure the graphql endpoint at "/graphql" for administrators only
+app.UseGraphQL("/graphql", opts => opts.AuthorizedRoles.Add("Administrator"));
+app.UseRouting();
+app.MapRazorPages();
+// the authorization endpoint will be at /token
+app.MapControllerRoute(
+    name: "default",
+    pattern: "{controller}/{action}");
+
+await app.RunAsync();

--- a/samples/Samples.Jwt/Program.cs
+++ b/samples/Samples.Jwt/Program.cs
@@ -18,6 +18,13 @@ builder.Services.AddGraphQL(b => b
     // support WebSocket authentication via the payload of the initialization message
     .AddWebSocketAuthentication<JwtWebSocketAuthenticationService>());
 
+// initialize the JwtHelper.Instance property for use throughout the application
+// use a symmetric security key with a random password
+JwtHelper.Instance = new(Guid.NewGuid().ToString(), SecurityKeyType.SymmetricSecurityKey);
+// or: use an asymmetric security key with a new random key pair (typically would be pulled from application secrets)
+//var (_, privateKey) = JwtHelper.CreateNewAsymmetricKeyPair();
+//JwtHelper.Instance = new(privateKey, JwtKeyType.PrivateKey);
+
 // configure authentication for GET/POST requests via the 'Authorization' HTTP header;
 // will authenticate WebSocket requests as well, but browsers cannot set the
 // 'Authorization' HTTP header for WebSocket requests
@@ -27,7 +34,7 @@ builder.Services.AddAuthentication(
         opts.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
         // configure custom authorization policies here, if any
     })
-    .AddJwtBearer(opts => opts.TokenValidationParameters = JwtHelper.TokenValidationParameters);
+    .AddJwtBearer(opts => opts.TokenValidationParameters = JwtHelper.Instance.TokenValidationParameters);
 
 var app = builder.Build();
 app.UseDeveloperExceptionPage();

--- a/samples/Samples.Jwt/Program.cs
+++ b/samples/Samples.Jwt/Program.cs
@@ -40,7 +40,7 @@ var app = builder.Build();
 app.UseDeveloperExceptionPage();
 // enable WebSocket support within the ASP.NET Core framework
 app.UseWebSockets();
-// use ASP.Net Core authentication (again, for GET/POST requests mainly)
+// use ASP.NET Core authentication (again, for GET/POST requests mainly)
 app.UseAuthentication();
 // configure the graphql endpoint at "/graphql" for administrators only
 app.UseGraphQL("/graphql", opts =>

--- a/samples/Samples.Jwt/Properties/launchSettings.json
+++ b/samples/Samples.Jwt/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:51526/",
+      "sslPort": 44334
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Typical": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/samples/Samples.Jwt/Samples.Jwt.csproj
+++ b/samples/Samples.Jwt/Samples.Jwt.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Transports.AspNetCore\Transports.AspNetCore.csproj" />
+    <ProjectReference Include="..\Samples.Schemas.Chat\Samples.Schemas.Chat.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Samples.Jwt/SecurityKeyType.cs
+++ b/samples/Samples.Jwt/SecurityKeyType.cs
@@ -1,0 +1,22 @@
+namespace GraphQL.Server.Samples.Jwt;
+
+/// <summary>
+/// Indicates the type of security
+/// </summary>
+public enum SecurityKeyType
+{
+    /// <summary>
+    /// Represents a SHA256 symmetric security key, capable of creating and validating JWT tokens.
+    /// </summary>
+    SymmetricSecurityKey,
+
+    /// <summary>
+    /// Represents the public key of a ECDsa asymmetric security key, only capable of validating JWT tokens.
+    /// </summary>
+    PublicKey,
+
+    /// <summary>
+    /// Represents the private key of a ECDsa asymmetric security key, capable of creating and validating JWT tokens.
+    /// </summary>
+    PrivateKey,
+}

--- a/tests/Samples.Jwt.Tests/EndToEndTests.cs
+++ b/tests/Samples.Jwt.Tests/EndToEndTests.cs
@@ -59,10 +59,17 @@ public class EndToEndTests : IDisposable
     }
 
     [Fact]
-    public async Task GraphQLWebSocket_Authorized()
+    public async Task GraphQLWebSocket_Authorized_HttpHeader()
     {
         var token = await GetJwtToken();
-        await _testServer.VerifyGraphQLWebSocketsAsync(jwtToken: token);
+        await _testServer.VerifyGraphQLWebSocketsAsync(authHeaderJwtToken: token);
+    }
+
+    [Fact]
+    public async Task GraphQLWebSocket_Authorized_WebSocketPayload()
+    {
+        var token = await GetJwtToken();
+        await _testServer.VerifyGraphQLWebSocketsAsync(payloadJwtToken: token);
     }
 
     [Fact]

--- a/tests/Samples.Jwt.Tests/EndToEndTests.cs
+++ b/tests/Samples.Jwt.Tests/EndToEndTests.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Text.Json;
+using GraphQL.Transport;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Samples.Tests;
+
+namespace Samples.Jwt.Tests;
+
+public class EndToEndTests : IDisposable
+{
+    private readonly WebApplicationFactory<Program> _applicationFactory;
+    private readonly TestServer _testServer;
+    private readonly HttpClient _testClient;
+    private const string ACCESS_DENIED_RESPONSE = @"{""errors"":[{""message"":""Access denied for schema."",""extensions"":{""code"":""ACCESS_DENIED"",""codes"":[""ACCESS_DENIED""]}}]}";
+
+    public EndToEndTests()
+    {
+        _applicationFactory = new WebApplicationFactory<Program>();
+        _testServer = _applicationFactory.Server;
+        _testClient = _testServer.CreateClient();
+    }
+
+    public void Dispose()
+    {
+        _testClient.Dispose();
+        _testServer.Dispose();
+        _applicationFactory.Dispose();
+    }
+
+    [Fact]
+    public Task GraphiQL()
+        => _testServer.VerifyGraphiQLAsync();
+
+    [Fact]
+    public async Task GraphQLGet_Authorized()
+    {
+        var token = await GetJwtToken();
+        await _testServer.VerifyGraphQLGetAsync(jwtToken: token);
+    }
+
+    [Fact]
+    public async Task GraphQLGet_Unauthorized()
+    {
+        await _testServer.VerifyGraphQLGetAsync(expected: ACCESS_DENIED_RESPONSE, statusCode: HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GraphQLPost_Authorized()
+    {
+        var token = await GetJwtToken();
+        await _testServer.VerifyGraphQLPostAsync(jwtToken: token);
+    }
+
+    [Fact]
+    public async Task GraphQLPost_Unauthorized()
+    {
+        await _testServer.VerifyGraphQLPostAsync(expected: ACCESS_DENIED_RESPONSE, statusCode: HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GraphQLWebSocket_Authorized()
+    {
+        var token = await GetJwtToken();
+        await _testServer.VerifyGraphQLWebSocketsAsync(jwtToken: token);
+    }
+
+    [Fact]
+    public async Task GraphQLWebSocket_Unauthorized()
+    {
+        var webSocketClient = _testServer.CreateWebSocketClient();
+        webSocketClient.ConfigureRequest = request =>
+        {
+            request.Headers["Sec-WebSocket-Protocol"] = "graphql-transport-ws";
+        };
+        webSocketClient.SubProtocols.Add("graphql-transport-ws");
+        using var webSocket = await webSocketClient.ConnectAsync(new Uri(_testServer.BaseAddress, "/graphql"), default);
+
+        // send CONNECTION_INIT
+        await webSocket.SendMessageAsync(new OperationMessage
+        {
+            Type = "connection_init",
+        });
+
+        // wait for connection rejection
+        await webSocket.ReceiveCloseMessageAsync();
+    }
+
+    [Fact]
+    public Task OAuth2_Get()
+        => GetJwtToken();
+
+    [Fact]
+    public async Task OAuth2_Post_UrlEncoded()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/token");
+        var content = new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+        {
+            new("grant_type", "client_credentials"),
+            new("client_id", "sampleClientId"),
+            new("client_secret", "sampleSecret"),
+        });
+        request.Content = content;
+        using var response = await _testClient.SendAsync(request);
+        await ProcessOAuthResponseAsync(response);
+    }
+
+    [Fact]
+    public async Task OAuth2_Post_MultipartFormData()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/token");
+        var content = new MultipartFormDataContent()
+        {
+            { new StringContent("client_credentials"), "grant_type" },
+            { new StringContent("sampleClientId"), "client_id" },
+            { new StringContent("sampleSecret"), "client_secret" },
+        };
+        request.Content = content;
+        using var response = await _testClient.SendAsync(request);
+        await ProcessOAuthResponseAsync(response);
+    }
+
+    private async Task<string> GetJwtToken()
+    {
+        using var response = await _testClient.GetAsync("/token?grant_type=client_credentials&client_id=sampleClientId&client_secret=sampleSecret");
+        return await ProcessOAuthResponseAsync(response);
+    }
+
+    private async Task<string> ProcessOAuthResponseAsync(HttpResponseMessage response)
+    {
+        response.EnsureSuccessStatusCode();
+        var str = await response.Content.ReadAsStringAsync();
+        var authResponse = JsonSerializer.Deserialize<OAuthResponse>(str);
+        authResponse.ShouldNotBeNull();
+        authResponse.access_token.ShouldNotBeNull();
+        authResponse.expires_in.ShouldBe(300); // 300 seconds / 5 minutes
+        authResponse.token_type.ShouldBe("Bearer");
+        return authResponse.access_token;
+    }
+
+    private class OAuthResponse
+    {
+        public string? token_type { get; set; }
+        public string? access_token { get; set; }
+        public int? expires_in { get; set; }
+    }
+}

--- a/tests/Samples.Jwt.Tests/EndToEndTests.cs
+++ b/tests/Samples.Jwt.Tests/EndToEndTests.cs
@@ -100,7 +100,7 @@ public class EndToEndTests : IDisposable
     [Fact]
     public async Task OAuth2_Post_UrlEncoded()
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, "/token");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/token");
         var content = new FormUrlEncodedContent(new KeyValuePair<string, string>[]
         {
             new("grant_type", "client_credentials"),
@@ -115,7 +115,7 @@ public class EndToEndTests : IDisposable
     [Fact]
     public async Task OAuth2_Post_MultipartFormData()
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, "/token");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/token");
         var content = new MultipartFormDataContent()
         {
             { new StringContent("client_credentials"), "grant_type" },

--- a/tests/Samples.Jwt.Tests/Samples.Jwt.Tests.csproj
+++ b/tests/Samples.Jwt.Tests/Samples.Jwt.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../Tests.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net6</TargetFramework>
+    <Description>End to end tests for the Samples.Pages project</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\Samples.Jwt\Samples.Jwt.csproj" />
+    <ProjectReference Include="..\Samples.Tests\Samples.Tests.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Samples.Jwt.Tests/Samples.Jwt.Tests.csproj
+++ b/tests/Samples.Jwt.Tests/Samples.Jwt.Tests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
-    <Description>End to end tests for the Samples.Pages project</Description>
+    <Description>End to end tests for the Samples.Jwt project</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Samples.Tests/ServerTests.cs
+++ b/tests/Samples.Tests/ServerTests.cs
@@ -17,21 +17,21 @@ public class ServerTests<TProgram> where TProgram : class
         await webApp.Server.VerifyGraphiQLAsync(url);
     }
 
-    public async Task VerifyGraphQLGetAsync(string url = "/graphql", string query = "{count}", string expected = @"{""data"":{""count"":0}}", HttpStatusCode statusCode = HttpStatusCode.OK)
+    public async Task VerifyGraphQLGetAsync(string url = "/graphql", string query = "{count}", string expected = @"{""data"":{""count"":0}}", HttpStatusCode statusCode = HttpStatusCode.OK, string? jwtToken = null)
     {
         using var webApp = new WebApplicationFactory<TProgram>();
-        await webApp.Server.VerifyGraphQLGetAsync(url, query, expected, statusCode);
+        await webApp.Server.VerifyGraphQLGetAsync(url, query, expected, statusCode, jwtToken);
     }
 
-    public async Task VerifyGraphQLPostAsync(string url = "/graphql", string query = "{count}", string expected = @"{""data"":{""count"":0}}", HttpStatusCode statusCode = HttpStatusCode.OK)
+    public async Task VerifyGraphQLPostAsync(string url = "/graphql", string query = "{count}", string expected = @"{""data"":{""count"":0}}", HttpStatusCode statusCode = HttpStatusCode.OK, string? jwtToken = null)
     {
         using var webApp = new WebApplicationFactory<TProgram>();
-        await webApp.Server.VerifyGraphQLPostAsync(url, query, expected, statusCode);
+        await webApp.Server.VerifyGraphQLPostAsync(url, query, expected, statusCode, jwtToken);
     }
 
-    public async Task VerifyGraphQLWebSocketsAsync(string url = "/graphql", string query = "{count}", string expected = @"{""data"":{""count"":0}}", bool success = true)
+    public async Task VerifyGraphQLWebSocketsAsync(string url = "/graphql", string query = "{count}", string expected = @"{""data"":{""count"":0}}", bool success = true, string? jwtToken = null)
     {
         using var webApp = new WebApplicationFactory<TProgram>();
-        await webApp.Server.VerifyGraphQLWebSocketsAsync(url, query, expected, success);
+        await webApp.Server.VerifyGraphQLWebSocketsAsync(url, query, expected, success, jwtToken);
     }
 }

--- a/tests/Samples.Tests/TestServerExtensions.cs
+++ b/tests/Samples.Tests/TestServerExtensions.cs
@@ -26,27 +26,52 @@ public static class TestServerExtensions
         ret.ShouldContain("graphiql", Case.Insensitive);
     }
 
-    public static async Task VerifyGraphQLGetAsync(this TestServer server, string url = "/graphql", string query = "{count}", string expected = @"{""data"":{""count"":0}}", HttpStatusCode statusCode = HttpStatusCode.OK)
+    public static async Task VerifyGraphQLGetAsync(
+        this TestServer server,
+        string url = "/graphql",
+        string query = "{count}",
+        string expected = @"{""data"":{""count"":0}}",
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        string? jwtToken = null)
     {
         using var client = server.CreateClient();
-        using var response = await client.GetAsync(url + "?query=" + Uri.EscapeDataString(query));
+        var request = new HttpRequestMessage(HttpMethod.Get, url + "?query=" + Uri.EscapeDataString(query));
+        if (jwtToken != null)
+            request.Headers.Authorization = new("Bearer", jwtToken);
+        using var response = await client.SendAsync(request);
         response.StatusCode.ShouldBe(statusCode);
         var ret = await response.Content.ReadAsStringAsync();
         ret.ShouldBe(expected);
     }
 
-    public static async Task VerifyGraphQLPostAsync(this TestServer server, string url = "/graphql", string query = "{count}", string expected = @"{""data"":{""count"":0}}", HttpStatusCode statusCode = HttpStatusCode.OK)
+    public static async Task VerifyGraphQLPostAsync(
+        this TestServer server,
+        string url = "/graphql",
+        string query = "{count}",
+        string expected = @"{""data"":{""count"":0}}",
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        string? jwtToken = null)
     {
         using var client = server.CreateClient();
-        var request = System.Text.Json.JsonSerializer.Serialize(new { query });
-        var content = new StringContent(request, System.Text.Encoding.UTF8, "application/graphql+json");
-        using var response = await client.PostAsync(url, content);
+        var body = System.Text.Json.JsonSerializer.Serialize(new { query });
+        var content = new StringContent(body, System.Text.Encoding.UTF8, "application/graphql+json");
+        var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Content = content;
+        if (jwtToken != null)
+            request.Headers.Authorization = new("Bearer", jwtToken);
+        using var response = await client.SendAsync(request);
         response.StatusCode.ShouldBe(statusCode);
         var ret = await response.Content.ReadAsStringAsync();
         ret.ShouldBe(expected);
     }
 
-    public static async Task VerifyGraphQLWebSocketsAsync(this TestServer server, string url = "/graphql", string query = "{count}", string expected = @"{""data"":{""count"":0}}", bool success = true)
+    public static async Task VerifyGraphQLWebSocketsAsync(
+        this TestServer server,
+        string url = "/graphql",
+        string query = "{count}",
+        string expected = @"{""data"":{""count"":0}}",
+        bool success = true,
+        string? jwtToken = null)
     {
         var webSocketClient = server.CreateWebSocketClient();
         webSocketClient.ConfigureRequest = request =>
@@ -59,7 +84,8 @@ public static class TestServerExtensions
         // send CONNECTION_INIT
         await webSocket.SendMessageAsync(new OperationMessage
         {
-            Type = "connection_init"
+            Type = "connection_init",
+            Payload = jwtToken == null ? null : new { Authorization = "Bearer " + jwtToken },
         });
 
         // wait for CONNECTION_ACK

--- a/tests/Samples.Tests/TestServerExtensions.cs
+++ b/tests/Samples.Tests/TestServerExtensions.cs
@@ -35,7 +35,7 @@ public static class TestServerExtensions
         string? jwtToken = null)
     {
         using var client = server.CreateClient();
-        var request = new HttpRequestMessage(HttpMethod.Get, url + "?query=" + Uri.EscapeDataString(query));
+        using var request = new HttpRequestMessage(HttpMethod.Get, url + "?query=" + Uri.EscapeDataString(query));
         if (jwtToken != null)
             request.Headers.Authorization = new("Bearer", jwtToken);
         using var response = await client.SendAsync(request);
@@ -55,7 +55,7 @@ public static class TestServerExtensions
         using var client = server.CreateClient();
         var body = System.Text.Json.JsonSerializer.Serialize(new { query });
         var content = new StringContent(body, System.Text.Encoding.UTF8, "application/graphql+json");
-        var request = new HttpRequestMessage(HttpMethod.Post, url);
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
         request.Content = content;
         if (jwtToken != null)
             request.Headers.Authorization = new("Bearer", jwtToken);

--- a/tests/Samples.Tests/TestServerExtensions.cs
+++ b/tests/Samples.Tests/TestServerExtensions.cs
@@ -71,12 +71,15 @@ public static class TestServerExtensions
         string query = "{count}",
         string expected = @"{""data"":{""count"":0}}",
         bool success = true,
-        string? jwtToken = null)
+        string? authHeaderJwtToken = null,
+        string? payloadJwtToken = null)
     {
         var webSocketClient = server.CreateWebSocketClient();
         webSocketClient.ConfigureRequest = request =>
         {
             request.Headers["Sec-WebSocket-Protocol"] = "graphql-transport-ws";
+            if (authHeaderJwtToken != null)
+                request.Headers["Authorization"] = "Bearer " + authHeaderJwtToken;
         };
         webSocketClient.SubProtocols.Add("graphql-transport-ws");
         using var webSocket = await webSocketClient.ConnectAsync(new Uri(server.BaseAddress, url), default);
@@ -85,7 +88,7 @@ public static class TestServerExtensions
         await webSocket.SendMessageAsync(new OperationMessage
         {
             Type = "connection_init",
-            Payload = jwtToken == null ? null : new { Authorization = "Bearer " + jwtToken },
+            Payload = payloadJwtToken == null ? null : new { Authorization = "Bearer " + payloadJwtToken },
         });
 
         // wait for CONNECTION_ACK

--- a/tests/Samples.Tests/WebSocketExtensions.cs
+++ b/tests/Samples.Tests/WebSocketExtensions.cs
@@ -48,15 +48,12 @@ public static class WebSocketExtensions
 
     public static async Task ReceiveCloseMessageAsync(this WebSocket socket)
     {
-        using var cts = new CancellationTokenSource();
-        cts.CancelAfter(5000);
-        var mem = new MemoryStream();
+        using var cts = new CancellationTokenSource(5000);
+        var drainBuffer = new byte[1024];
         ValueWebSocketReceiveResult response;
         do
         {
-            var buffer = new byte[1024];
-            response = await socket.ReceiveAsync(new MemoryBytes(buffer), cts.Token);
-            mem.Write(buffer, 0, response.Count);
+            response = await socket.ReceiveAsync(new MemoryBytes(drainBuffer), cts.Token);
         } while (!response.EndOfMessage);
         response.MessageType.ShouldBe(WebSocketMessageType.Close);
     }

--- a/tests/Samples.Tests/WebSocketExtensions.cs
+++ b/tests/Samples.Tests/WebSocketExtensions.cs
@@ -45,4 +45,19 @@ public static class WebSocketExtensions
             message.Payload = ((JsonElement)message.Payload).GetRawText();
         return message;
     }
+
+    public static async Task ReceiveCloseMessageAsync(this WebSocket socket)
+    {
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(5000);
+        var mem = new MemoryStream();
+        ValueWebSocketReceiveResult response;
+        do
+        {
+            var buffer = new byte[1024];
+            response = await socket.ReceiveAsync(new MemoryBytes(buffer), cts.Token);
+            mem.Write(buffer, 0, response.Count);
+        } while (!response.EndOfMessage);
+        response.MessageType.ShouldBe(WebSocketMessageType.Close);
+    }
 }

--- a/tests/Transports.AspNetCore.Tests/Middleware/WebSocketTests.cs
+++ b/tests/Transports.AspNetCore.Tests/Middleware/WebSocketTests.cs
@@ -6,10 +6,8 @@ public class WebSocketTests : IDisposable
 
     private void Configure(Action<GraphQLHttpMiddlewareOptions>? configureOptions = null, Action<IServiceCollection>? configureServices = null)
     {
-        if (configureOptions == null)
-            configureOptions = _ => { };
-        if (configureServices == null)
-            configureServices = _ => { };
+        configureOptions ??= _ => { };
+        configureServices ??= _ => { };
 
         var hostBuilder = new WebHostBuilder();
         hostBuilder.ConfigureServices(services =>


### PR DESCRIPTION
Due to the number of questions we answer regarding JWT bearer authentication, I thought it best to write a proper sample.

The sample confines token generation and validation to a `JwtHelper` class.  An `OAuthController` class simulates an extremely basic OAuth2-compliant endpoint.  The sample also demonstrates authenticated subscription support from a browser, which is a real pain to get working properly without a working sample.

The sample uses a symmetric security key, but also includes some code demonstrating how to use asymmetric key pairs.