### PR TITLE
Fix packing readme and analysis recommendations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
     <NoWarn>$(NoWarn);IDE0056;IDE0057</NoWarn> <!-- Index/Range operators -->
 
     <AssemblyName>GraphQL.Server.$(MSBuildProjectName)</AssemblyName>
@@ -34,11 +35,5 @@
     <SignAssembly>true</SignAssembly>
     <_FriendAssembliesPublicKey>PublicKey=0024000004800000940000000602000000240000525341310004000001000100352162dbf27be78fc45136884b8f324aa9f1dfc928c96c24704bf1df1a8779b2f26c760ed8321eca5b95ea6bd9bb60cd025b300f73bd1f4ae1ee6e281f85c527fa013ab5cb2c3fc7a1cbef7f9bf0c9014152e6a21f6e0ac6a371f8b45c6d7139c9119df9eeecf1cf59063545bb7c07437b1bc12be2c57d108d72d6c27176fbb8</_FriendAssembliesPublicKey>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <None Include="..\..\assets\logo.64x64.png" Pack="true" PackagePath="\" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,4 +36,10 @@
     <_FriendAssembliesPublicKey>PublicKey=0024000004800000940000000602000000240000525341310004000001000100352162dbf27be78fc45136884b8f324aa9f1dfc928c96c24704bf1df1a8779b2f26c760ed8321eca5b95ea6bd9bb60cd025b300f73bd1f4ae1ee6e281f85c527fa013ab5cb2c3fc7a1cbef7f9bf0c9014152e6a21f6e0ac6a371f8b45c6d7139c9119df9eeecf1cf59063545bb7c07437b1bc12be2c57d108d72d6c27176fbb8</_FriendAssembliesPublicKey>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="..\..\assets\logo.64x64.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,12 +25,6 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)graphql.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <None Include="..\..\assets\logo.64x64.png" Pack="true" PackagePath="\" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
     <InternalsVisibleTo Condition="'$(SignAssembly)' == 'true'" Include="$(AssemblyName).Tests, $(_FriendAssembliesPublicKey)"/>
     <InternalsVisibleTo Condition="'$(SignAssembly)' != 'true'" Include="$(AssemblyName).Tests"/>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,7 +4,6 @@
     <CoverletOutputFormat>opencover</CoverletOutputFormat>
     <CoverletOutput>$(MSBuildThisFileDirectory).coverage/$(AssemblyName)/</CoverletOutput>
     <Exclude>[GraphQL.Samples.Schemas.Chat]*,[GraphQL.Samples.Server]*</Exclude>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OutputType)' == 'Exe'">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,8 +4,13 @@
     <CoverletOutputFormat>opencover</CoverletOutputFormat>
     <CoverletOutput>$(MSBuildThisFileDirectory).coverage/$(AssemblyName)/</CoverletOutput>
     <Exclude>[GraphQL.Samples.Schemas.Chat]*,[GraphQL.Samples.Server]*</Exclude>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OutputType)' == 'Exe'">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(IsPackable)' != 'true'">
     <NoWarn>$(NoWarn);CS1591;IDE1006;IDE0053;CS1998</NoWarn>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);IDE0060</WarningsNotAsErrors>
@@ -19,6 +24,12 @@
   <PropertyGroup Condition="'$(SignAssembly)' == 'true'">
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)graphql.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="..\..\assets\logo.64x64.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
     <InternalsVisibleTo Condition="'$(SignAssembly)' == 'true'" Include="$(AssemblyName).Tests, $(_FriendAssembliesPublicKey)"/>

--- a/Tests.props
+++ b/Tests.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <SingleTestPlatform Condition="'$(SingleTestPlatform)' == ''">false</SingleTestPlatform>
     <NoWarn>$(NoWarn);IDE0017</NoWarn>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<configuration>
-  <disabledPackageSources>
-    <add key="GitHub" value="true" />
-    <add key="GitHub-Shane" value="true" />
-    <add key="ZboxGlobal" value="true" />
-  </disabledPackageSources>
-</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<configuration>
+  <disabledPackageSources>
+    <add key="GitHub" value="true" />
+    <add key="GitHub-Shane" value="true" />
+    <add key="ZboxGlobal" value="true" />
+  </disabledPackageSources>
+</configuration>

--- a/src/Authorization.AspNetCore/DefaultAuthorizationErrorMessageBuilder.cs
+++ b/src/Authorization.AspNetCore/DefaultAuthorizationErrorMessageBuilder.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Authorization.Infrastructure;
 
 namespace GraphQL.Server.Authorization.AspNetCore;
 
+/// <summary>
+/// Default error message builder implementation
+/// </summary>
 [Obsolete("This class will be removed in v8 as revealing authorization requirements may be a security risk; please use ErrorInfoProvider if you require detailed access-denied error messages.")]
 public class DefaultAuthorizationErrorMessageBuilder : IAuthorizationErrorMessageBuilder
 {
@@ -40,71 +43,71 @@ public class DefaultAuthorizationErrorMessageBuilder : IAuthorizationErrorMessag
     }
 
     /// <inheritdoc />
-    public virtual void AppendFailureHeader(StringBuilder error, OperationType? operationType)
+    public virtual void AppendFailureHeader(StringBuilder errorBuilder, OperationType? operationType)
     {
-        error
+        errorBuilder
             .Append("You are not authorized to run this ")
             .Append(GetOperationType(operationType))
             .Append('.');
     }
 
     /// <inheritdoc />
-    public virtual void AppendFailureLine(StringBuilder error, IAuthorizationRequirement authorizationRequirement)
+    public virtual void AppendFailureLine(StringBuilder errorBuilder, IAuthorizationRequirement authorizationRequirement)
     {
-        error.AppendLine();
+        errorBuilder.AppendLine();
 
         switch (authorizationRequirement)
         {
             case ClaimsAuthorizationRequirement claimsAuthorizationRequirement:
-                error.Append("Required claim '");
-                error.Append(claimsAuthorizationRequirement.ClaimType);
+                errorBuilder.Append("Required claim '");
+                errorBuilder.Append(claimsAuthorizationRequirement.ClaimType);
                 if (claimsAuthorizationRequirement.AllowedValues == null || !claimsAuthorizationRequirement.AllowedValues.Any())
                 {
-                    error.Append("' is not present.");
+                    errorBuilder.Append("' is not present.");
                 }
                 else
                 {
-                    error.Append("' with any value of '");
-                    error.Append(string.Join(", ", claimsAuthorizationRequirement.AllowedValues));
-                    error.Append("' is not present.");
+                    errorBuilder.Append("' with any value of '");
+                    errorBuilder.Append(string.Join(", ", claimsAuthorizationRequirement.AllowedValues));
+                    errorBuilder.Append("' is not present.");
                 }
                 break;
 
             case DenyAnonymousAuthorizationRequirement _:
-                error.Append("The current user must be authenticated.");
+                errorBuilder.Append("The current user must be authenticated.");
                 break;
 
             case NameAuthorizationRequirement nameAuthorizationRequirement:
-                error.Append("The current user name must match the name '");
-                error.Append(nameAuthorizationRequirement.RequiredName);
-                error.Append("'.");
+                errorBuilder.Append("The current user name must match the name '");
+                errorBuilder.Append(nameAuthorizationRequirement.RequiredName);
+                errorBuilder.Append("'.");
                 break;
 
             case OperationAuthorizationRequirement operationAuthorizationRequirement:
-                error.Append("Required operation '");
-                error.Append(operationAuthorizationRequirement.Name);
-                error.Append("' was not present.");
+                errorBuilder.Append("Required operation '");
+                errorBuilder.Append(operationAuthorizationRequirement.Name);
+                errorBuilder.Append("' was not present.");
                 break;
 
             case RolesAuthorizationRequirement rolesAuthorizationRequirement:
                 if (rolesAuthorizationRequirement.AllowedRoles == null || !rolesAuthorizationRequirement.AllowedRoles.Any())
                 {
                     // This should never happen.
-                    error.Append("Required roles are not present.");
+                    errorBuilder.Append("Required roles are not present.");
                 }
                 else
                 {
-                    error.Append("Required roles '");
-                    error.Append(string.Join(", ", rolesAuthorizationRequirement.AllowedRoles));
-                    error.Append("' are not present.");
+                    errorBuilder.Append("Required roles '");
+                    errorBuilder.Append(string.Join(", ", rolesAuthorizationRequirement.AllowedRoles));
+                    errorBuilder.Append("' are not present.");
                 }
                 break;
 
             case AssertionRequirement _:
             default:
-                error.Append("Requirement '");
-                error.Append(authorizationRequirement.GetType().Name);
-                error.Append("' was not satisfied.");
+                errorBuilder.Append("Requirement '");
+                errorBuilder.Append(authorizationRequirement.GetType().Name);
+                errorBuilder.Append("' was not satisfied.");
                 break;
         }
     }

--- a/src/Authorization.AspNetCore/DefaultAuthorizationErrorMessageBuilder.cs
+++ b/src/Authorization.AspNetCore/DefaultAuthorizationErrorMessageBuilder.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Authorization.Infrastructure;
 namespace GraphQL.Server.Authorization.AspNetCore;
 
 /// <summary>
-/// Default error message builder implementation
+/// Default error message builder implementation.
 /// </summary>
 [Obsolete("This class will be removed in v8 as revealing authorization requirements may be a security risk; please use ErrorInfoProvider if you require detailed access-denied error messages.")]
 public class DefaultAuthorizationErrorMessageBuilder : IAuthorizationErrorMessageBuilder

--- a/src/Authorization.AspNetCore/GraphQLBuilderAuthorizationExtensions.cs
+++ b/src/Authorization.AspNetCore/GraphQLBuilderAuthorizationExtensions.cs
@@ -8,6 +8,9 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace GraphQL.Server;
 
+/// <summary>
+/// Extension methods for <see cref="IGraphQLBuilder"/> interface.
+/// </summary>
 public static class GraphQLBuilderAuthorizationExtensions
 {
     /// <summary>

--- a/src/Authorization.AspNetCore/IAuthorizationErrorMessageBuilder.cs
+++ b/src/Authorization.AspNetCore/IAuthorizationErrorMessageBuilder.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace GraphQL.Server.Authorization.AspNetCore;
 
+/// <summary>
+/// Error message builder for authorization errors
+/// </summary>
 [Obsolete("This class will be removed in v8 as revealing authorization requirements may be a security risk; please use ErrorInfoProvider if you require detailed access-denied error messages.")]
 public interface IAuthorizationErrorMessageBuilder
 {
@@ -18,14 +21,14 @@ public interface IAuthorizationErrorMessageBuilder
     /// <summary>
     /// Appends the error message header to the provided <see cref="StringBuilder"/>.
     /// </summary>
-    /// <param name="error">The error message <see cref="StringBuilder"/>.</param>
+    /// <param name="errorBuilder">The error message <see cref="StringBuilder"/>.</param>
     /// <param name="operationType">The GraphQL operation type.</param>
-    void AppendFailureHeader(StringBuilder error, OperationType? operationType);
+    void AppendFailureHeader(StringBuilder errorBuilder, OperationType? operationType);
 
     /// <summary>
     /// Appends a description of the failed <paramref name="authorizationRequirement"/> to the supplied <see cref="StringBuilder"/>.
     /// </summary>
-    /// <param name="error">The <see cref="StringBuilder"/> which is used to compose the error message.</param>
+    /// <param name="errorBuilder">The <see cref="StringBuilder"/> which is used to compose the error message.</param>
     /// <param name="authorizationRequirement">The failed <see cref="IAuthorizationRequirement"/>.</param>
-    void AppendFailureLine(StringBuilder error, IAuthorizationRequirement authorizationRequirement);
+    void AppendFailureLine(StringBuilder errorBuilder, IAuthorizationRequirement authorizationRequirement);
 }

--- a/src/Authorization.AspNetCore/IAuthorizationErrorMessageBuilder.cs
+++ b/src/Authorization.AspNetCore/IAuthorizationErrorMessageBuilder.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 namespace GraphQL.Server.Authorization.AspNetCore;
 
 /// <summary>
-/// Error message builder for authorization errors
+/// Error message builder for authorization errors.
 /// </summary>
 [Obsolete("This class will be removed in v8 as revealing authorization requirements may be a security risk; please use ErrorInfoProvider if you require detailed access-denied error messages.")]
 public interface IAuthorizationErrorMessageBuilder

--- a/src/Ui.Playground/PlaygroundOptions.cs
+++ b/src/Ui.Playground/PlaygroundOptions.cs
@@ -43,10 +43,13 @@ public class PlaygroundOptions
 
     /* typed settings below are just wrappers for PlaygroundSettings dictionary */
 
+    /// <summary>
+    /// Cursor shape.
+    /// </summary>
     public EditorCursorShape EditorCursorShape
     {
         get => (EditorCursorShape)Enum.Parse(typeof(EditorCursorShape), (string)PlaygroundSettings["editor.cursorShape"], ignoreCase: true);
-        set => PlaygroundSettings["editor.cursorShape"] = value.ToString().ToLower();
+        set => PlaygroundSettings["editor.cursorShape"] = value.ToString().ToLowerInvariant();
     }
 
     /// <summary>
@@ -58,6 +61,9 @@ public class PlaygroundOptions
         set => PlaygroundSettings["editor.fontFamily"] = value;
     }
 
+    /// <summary>
+    /// Editor font size.
+    /// </summary>
     public int EditorFontSize
     {
         get => (int)PlaygroundSettings["editor.fontSize"];
@@ -73,30 +79,45 @@ public class PlaygroundOptions
         set => PlaygroundSettings["editor.reuseHeaders"] = value;
     }
 
+    /// <summary>
+    /// Editor theme.
+    /// </summary>
     public EditorTheme EditorTheme
     {
         get => (EditorTheme)Enum.Parse(typeof(EditorTheme), (string)PlaygroundSettings["editor.theme"], ignoreCase: true);
-        set => PlaygroundSettings["editor.theme"] = value.ToString().ToLower();
+        set => PlaygroundSettings["editor.theme"] = value.ToString().ToLowerInvariant();
     }
 
+    /// <summary>
+    /// Enable beta updates.
+    /// </summary>
     public bool BetaUpdates
     {
         get => (bool)PlaygroundSettings["general.betaUpdates"];
         set => PlaygroundSettings["general.betaUpdates"] = value;
     }
 
+    /// <summary>
+    /// Print width setting.
+    /// </summary>
     public int PrettierPrintWidth
     {
         get => (int)PlaygroundSettings["prettier.printWidth"];
         set => PlaygroundSettings["prettier.printWidth"] = value;
     }
 
+    /// <summary>
+    /// Tab width setting.
+    /// </summary>
     public int PrettierTabWidth
     {
         get => (int)PlaygroundSettings["prettier.tabWidth"];
         set => PlaygroundSettings["prettier.tabWidth"] = value;
     }
 
+    /// <summary>
+    /// Use tabs.
+    /// </summary>
     public bool PrettierUseTabs
     {
         get => (bool)PlaygroundSettings["prettier.useTabs"];
@@ -155,12 +176,18 @@ public class PlaygroundOptions
         set => PlaygroundSettings["schema.polling.interval"] = value;
     }
 
+    /// <summary>
+    /// Disable comments.
+    /// </summary>
     public bool SchemaDisableComments
     {
         get => (bool)PlaygroundSettings["schema.disableComments"];
         set => PlaygroundSettings["schema.disableComments"] = value;
     }
 
+    /// <summary>
+    /// Hide tracing data in responses.
+    /// </summary>
     public bool HideTracingResponse
     {
         get => (bool)PlaygroundSettings["tracing.hideTracingResponse"];
@@ -168,15 +195,36 @@ public class PlaygroundOptions
     }
 }
 
+/// <summary>
+/// Available cursor shapes.
+/// </summary>
 public enum EditorCursorShape
 {
+    /// <summary>
+    /// Line.
+    /// </summary>
     Line,
+    /// <summary>
+    /// Block.
+    /// </summary>
     Block,
+    /// <summary>
+    /// Underline.
+    /// </summary>
     Underline
 }
 
+/// <summary>
+/// Available editor themes.
+/// </summary>
 public enum EditorTheme
 {
+    /// <summary>
+    /// Dark theme.
+    /// </summary>
     Dark,
+    /// <summary>
+    /// Light theme.
+    /// </summary>
     Light
 }

--- a/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Authorization.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Authorization.AspNetCore.approved.txt
@@ -31,8 +31,8 @@ namespace GraphQL.Server.Authorization.AspNetCore
     public class DefaultAuthorizationErrorMessageBuilder : GraphQL.Server.Authorization.AspNetCore.IAuthorizationErrorMessageBuilder
     {
         public DefaultAuthorizationErrorMessageBuilder() { }
-        public virtual void AppendFailureHeader(System.Text.StringBuilder error, GraphQLParser.AST.OperationType? operationType) { }
-        public virtual void AppendFailureLine(System.Text.StringBuilder error, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement authorizationRequirement) { }
+        public virtual void AppendFailureHeader(System.Text.StringBuilder errorBuilder, GraphQLParser.AST.OperationType? operationType) { }
+        public virtual void AppendFailureLine(System.Text.StringBuilder errorBuilder, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement authorizationRequirement) { }
         public virtual string GenerateMessage(GraphQLParser.AST.OperationType? operationType, Microsoft.AspNetCore.Authorization.AuthorizationResult result) { }
     }
     [System.Obsolete("This class will be removed in v8; please override GraphQLHttpMiddleware.HandleAut" +
@@ -47,8 +47,8 @@ namespace GraphQL.Server.Authorization.AspNetCore
         "ed error messages.")]
     public interface IAuthorizationErrorMessageBuilder
     {
-        void AppendFailureHeader(System.Text.StringBuilder error, GraphQLParser.AST.OperationType? operationType);
-        void AppendFailureLine(System.Text.StringBuilder error, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement authorizationRequirement);
+        void AppendFailureHeader(System.Text.StringBuilder errorBuilder, GraphQLParser.AST.OperationType? operationType);
+        void AppendFailureLine(System.Text.StringBuilder errorBuilder, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement authorizationRequirement);
         string GenerateMessage(GraphQLParser.AST.OperationType? operationType, Microsoft.AspNetCore.Authorization.AuthorizationResult result);
     }
     [System.Obsolete("This class will be removed in v8; please override GraphQLHttpMiddleware.HandleAut" +

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Authorization.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Authorization.AspNetCore.approved.txt
@@ -31,8 +31,8 @@ namespace GraphQL.Server.Authorization.AspNetCore
     public class DefaultAuthorizationErrorMessageBuilder : GraphQL.Server.Authorization.AspNetCore.IAuthorizationErrorMessageBuilder
     {
         public DefaultAuthorizationErrorMessageBuilder() { }
-        public virtual void AppendFailureHeader(System.Text.StringBuilder error, GraphQLParser.AST.OperationType? operationType) { }
-        public virtual void AppendFailureLine(System.Text.StringBuilder error, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement authorizationRequirement) { }
+        public virtual void AppendFailureHeader(System.Text.StringBuilder errorBuilder, GraphQLParser.AST.OperationType? operationType) { }
+        public virtual void AppendFailureLine(System.Text.StringBuilder errorBuilder, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement authorizationRequirement) { }
         public virtual string GenerateMessage(GraphQLParser.AST.OperationType? operationType, Microsoft.AspNetCore.Authorization.AuthorizationResult result) { }
     }
     [System.Obsolete("This class will be removed in v8; please override GraphQLHttpMiddleware.HandleAut" +
@@ -47,8 +47,8 @@ namespace GraphQL.Server.Authorization.AspNetCore
         "ed error messages.")]
     public interface IAuthorizationErrorMessageBuilder
     {
-        void AppendFailureHeader(System.Text.StringBuilder error, GraphQLParser.AST.OperationType? operationType);
-        void AppendFailureLine(System.Text.StringBuilder error, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement authorizationRequirement);
+        void AppendFailureHeader(System.Text.StringBuilder errorBuilder, GraphQLParser.AST.OperationType? operationType);
+        void AppendFailureLine(System.Text.StringBuilder errorBuilder, Microsoft.AspNetCore.Authorization.IAuthorizationRequirement authorizationRequirement);
         string GenerateMessage(GraphQLParser.AST.OperationType? operationType, Microsoft.AspNetCore.Authorization.AuthorizationResult result);
     }
     [System.Obsolete("This class will be removed in v8; please override GraphQLHttpMiddleware.HandleAut" +


### PR DESCRIPTION
On NuGet.org, the readme file is not appearing.  This is because the PackageReadmeFile did not get set while building.  This is because the condition `IsPackable == true` does not work if `IsPackable` is not explicitly set, even though when it is not set, it is implied to be true for the purposes of packing and within ItemGroups.  This also caused the analysis to be disabled.

The analysis mode revealed that some xml comments on some old code was missing.

I ran the pack locally and examined the output to be sure it built correctly this time.

It is not critical to release 7.0.1, as there are no breaking changes and the 7.0.0 code should work just fine.  Nevertheless, we can release 7.0.1 if you think we should @sungam3r , before everyone downloads it.  Or, we could wait a week or two to see if there are any other issues that need to be addressed.