### PR TITLE
Allow the configuration of the response content type via options

### DIFF
--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -454,7 +454,7 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     /// <see cref="WriteJsonResponseAsync{TResult}(HttpContext, HttpStatusCode, TResult)"/>.
     /// </summary>
     protected virtual string SelectResponseContentType(HttpContext context)
-        => CONTENTTYPE_GRAPHQLJSON;
+        => _options.ResponseContentType;
 
     /// <summary>
     /// Writes the specified object (usually a GraphQL response represented as an instance of <see cref="ExecutionResult"/>) as JSON to the HTTP response stream.

--- a/src/Transports.AspNetCore/GraphQLHttpMiddlewareOptions.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddlewareOptions.cs
@@ -93,4 +93,9 @@ public class GraphQLHttpMiddlewareOptions : IAuthorizationOptions
     /// Returns an options class for WebSocket connections.
     /// </summary>
     public GraphQLWebSocketOptions WebSockets { get; set; } = new();
+
+    /// <summary>
+    /// The Content-Type to use for GraphQL responses
+    /// </summary>
+    public string ResponseContentType { get; set; } = GraphQLHttpMiddleware.CONTENTTYPE_GRAPHQLJSON;
 }

--- a/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net5+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -109,6 +109,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         public bool ReadExtensionsFromQueryString { get; set; }
         public bool ReadQueryStringOnPost { get; set; }
         public bool ReadVariablesFromQueryString { get; set; }
+        public string ResponseContentType { get; set; }
         public bool ValidationErrorsReturnBadRequest { get; set; }
         public GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions WebSockets { get; set; }
     }

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -116,6 +116,7 @@ namespace GraphQL.Server.Transports.AspNetCore
         public bool ReadExtensionsFromQueryString { get; set; }
         public bool ReadQueryStringOnPost { get; set; }
         public bool ReadVariablesFromQueryString { get; set; }
+        public string ResponseContentType { get; set; }
         public bool ValidationErrorsReturnBadRequest { get; set; }
         public GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions WebSockets { get; set; }
     }


### PR DESCRIPTION
This allows users to override the default response content type without
having to implement their own middleware.