### PR TITLE
Change default response content type to match draft spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,14 +458,14 @@ follows:
 builder.Services.AddResponseCompression(options =>
 {
     options.EnableForHttps = true; // may lead to CRIME and BREACH attacks
-    options.MimeTypes = new[] { "application/json", "application/graphql+json" };
+    options.MimeTypes = new[] { "application/json", "application/graphql-response+json" };
 })
 
 // place this first/early in the pipeline
 app.UseResponseCompression();
 ```
 
-In order to compress GraphQL responses, the `application/graphql+json` content type must be
+In order to compress GraphQL responses, the `application/graphql-response+json` content type must be
 added to the `MimeTypes` option.  You may choose to enable other content types as well.
 
 Please note that enabling response compression over HTTPS can lead to CRIME and BREACH
@@ -661,7 +661,7 @@ A list of methods are as follows:
 | `HandleWebSocketSubProtocolNotSupportedAsync` | Writes a '400 Invalid WebSocket sub-protocol.' message to the output. |
 
 Below is a sample of custom middleware to change the response content type to `application/json`,
-rather than the default of `application/graphql+json`:
+rather than the default of `application/graphql-response+json`:
 
 ```csharp
 class MyMiddleware<TSchema> : GraphQLHttpMiddleware<TSchema>

--- a/docs/migration/migration7.md
+++ b/docs/migration/migration7.md
@@ -1,4 +1,4 @@
-# Migrating from v6 to v7
+# Migrating from v6 to v7.1
 
 ## Major changes and new features
 
@@ -6,7 +6,7 @@
 
 - Configuration simplified to a single line of code
 - Single middleware to support GET, POST and WebSocket connections (configurable)
-- Media type of 'application/graphql+json' is accepted and returned as recommended by the draft spec (configurable via virtual method)
+- Media type of 'application/graphql-response+json' is accepted and returned as recommended by the draft spec (configurable via virtual method)
 - Batched requests will execute in parallel within separate service scopes (configurable)
 - Authorization rules can be set on endpoints, regardless of schema configuration
 - Mutation requests are disallowed over GET connections, as required by the spec

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -54,7 +54,7 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     private const string MEDIATYPE_GRAPHQLJSON = "application/graphql+json";
     private const string MEDIATYPE_JSON = "application/json";
     private const string MEDIATYPE_GRAPHQL = "application/graphql";
-    internal const string CONTENTTYPE_GRAPHQLJSON = "application/graphql+json; charset=utf-8";
+    internal const string CONTENTTYPE_GRAPHQLJSON = "application/graphql-response+json; charset=utf-8";
 
     /// <summary>
     /// Initializes a new instance.

--- a/tests/Samples.Tests/TestServerExtensions.cs
+++ b/tests/Samples.Tests/TestServerExtensions.cs
@@ -54,7 +54,7 @@ public static class TestServerExtensions
     {
         using var client = server.CreateClient();
         var body = System.Text.Json.JsonSerializer.Serialize(new { query });
-        var content = new StringContent(body, System.Text.Encoding.UTF8, "application/graphql+json");
+        var content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
         using var request = new HttpRequestMessage(HttpMethod.Post, url);
         request.Content = content;
         if (jwtToken != null)

--- a/tests/Transports.AspNetCore.Tests/ShouldlyExtensions.cs
+++ b/tests/Transports.AspNetCore.Tests/ShouldlyExtensions.cs
@@ -13,7 +13,7 @@ internal static class ShouldlyExtensions
     public static async Task ShouldBeAsync(this HttpResponseMessage message, HttpStatusCode httpStatusCode, string expectedResponse)
     {
         message.StatusCode.ShouldBe(httpStatusCode);
-        message.Content.Headers.ContentType?.MediaType.ShouldBe("application/graphql+json");
+        message.Content.Headers.ContentType?.MediaType.ShouldBe("application/graphql-response+json");
         message.Content.Headers.ContentType?.CharSet.ShouldBe("utf-8");
         var actualResponse = await message.Content.ReadAsStringAsync();
         actualResponse.ShouldBe(expectedResponse);

--- a/tests/Transports.AspNetCore.Tests/TestServerExtensions.cs
+++ b/tests/Transports.AspNetCore.Tests/TestServerExtensions.cs
@@ -15,7 +15,7 @@ internal static class TestServerExtensions
     {
         var client = server.CreateClient();
         var data = System.Text.Json.JsonSerializer.Serialize(new { query = query, variables = variables });
-        var content = new StringContent(data, Encoding.UTF8, "application/graphql+json");
+        var content = new StringContent(data, Encoding.UTF8, "application/json");
         using var response = await client.PostAsync(url, content);
         response.EnsureSuccessStatusCode();
         var str = await response.Content.ReadAsStringAsync();

--- a/tests/Transports.AspNetCore.Tests/TestServerExtensions.cs
+++ b/tests/Transports.AspNetCore.Tests/TestServerExtensions.cs
@@ -15,7 +15,7 @@ internal static class TestServerExtensions
     {
         var client = server.CreateClient();
         var data = System.Text.Json.JsonSerializer.Serialize(new { query = query, variables = variables });
-        var content = new StringContent(data, Encoding.UTF8, "application/json");
+        using var content = new StringContent(data, Encoding.UTF8, "application/json");
         using var response = await client.PostAsync(url, content);
         response.EnsureSuccessStatusCode();
         var str = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
Closes #916 

- Changes default response type from `application/graphql+json` to `application/graphql-response+json`
- Changes tests to use content type of `application/json` for requests