### PR TITLE
Update response content type for `ExecutionResultActionResult`

### DIFF
--- a/src/Transports.AspNetCore/ExecutionResultActionResult.cs
+++ b/src/Transports.AspNetCore/ExecutionResultActionResult.cs
@@ -23,7 +23,7 @@ public sealed class ExecutionResultActionResult : IActionResult
     }
 
     /// <inheritdoc cref="HttpResponse.ContentType"/>
-    public string ContentType { get; set; } = GraphQLHttpMiddleware.CONTENTTYPE_GRAPHQLJSON;
+    public string ContentType { get; set; } = GraphQLHttpMiddleware.CONTENTTYPE_GRAPHQLRESPONSEJSON;
 
     /// <inheritdoc/>
     public async Task ExecuteResultAsync(ActionContext context)

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -57,8 +57,8 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     private const string MEDIATYPE_GRAPHQLJSON = "application/graphql+json"; // deprecated
     private const string MEDIATYPE_JSON = "application/json";
     private const string MEDIATYPE_GRAPHQL = "application/graphql";
-    internal const string CONTENTTYPE_JSON = "application/json; charset=utf-8";
-    internal const string CONTENTTYPE_GRAPHQLJSON = "application/graphql+json; charset=utf-8"; // deprecated
+    private const string CONTENTTYPE_JSON = "application/json; charset=utf-8";
+    private const string CONTENTTYPE_GRAPHQLJSON = "application/graphql+json; charset=utf-8"; // deprecated
     internal const string CONTENTTYPE_GRAPHQLRESPONSEJSON = "application/graphql-response+json; charset=utf-8";
 
     /// <summary>

--- a/tests/Transports.AspNetCore.Tests/ExecutionResultActionResultTests.cs
+++ b/tests/Transports.AspNetCore.Tests/ExecutionResultActionResultTests.cs
@@ -2,10 +2,11 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Tests;
 
-public class ExecutionResultActionResultTests
+public class ExecutionResultActionResultTests : IDisposable
 {
-    [Fact]
-    public async Task Basic()
+    private readonly TestServer _server;
+
+    public ExecutionResultActionResultTests()
     {
         var _hostBuilder = new WebHostBuilder();
         _hostBuilder.ConfigureServices(services =>
@@ -40,21 +41,49 @@ public class ExecutionResultActionResultTests
             });
 #endif
         });
-        var server = new TestServer(_hostBuilder);
+        _server = new TestServer(_hostBuilder);
+    }
 
-        var str = await server.ExecuteGet("/graphql?query={count}");
+    [Fact]
+    public async Task Basic()
+    {
+        var str = await _server.ExecuteGet("/graphql?query={count}");
         str.ShouldBe("{\"data\":{\"count\":0}}");
+    }
 
-        var str2 = await server.ExecuteGet("/graphql?query={}&resultCode=200");
+    [Fact]
+    public async Task ForcedResultCode()
+    {
+        var str2 = await _server.ExecuteGet("/graphql?query={}&resultCode=200");
         str2.ShouldBe(@"{""errors"":[{""message"":""Error parsing query: Expected Name, found }; for more information see http://spec.graphql.org/October2021/#Field"",""locations"":[{""line"":1,""column"":2}],""extensions"":{""code"":""SYNTAX_ERROR"",""codes"":[""SYNTAX_ERROR""]}}]}");
+    }
 
-        using var httpClient = server.CreateClient();
+    [Fact]
+    public async Task AltContentType()
+    {
+        using var httpClient = _server.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/graphql?query={count}&jsonType=true");
+        var response = await httpClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var contentType = response.Content.Headers.ContentType;
+        contentType.ShouldNotBeNull();
+        contentType.MediaType.ShouldBe("application/json");
+        var str3 = await response.Content.ReadAsStringAsync();
+        str3.ShouldBe("{\"data\":{\"count\":0}}");
+    }
+
+    [Fact]
+    public async Task ReturnsBadRequestForUnexecutedResults()
+    {
+        using var httpClient = _server.CreateClient();
         var request = new HttpRequestMessage(HttpMethod.Get, "/graphql?query={}");
         var response = await httpClient.SendAsync(request);
         response.StatusCode.ShouldBe(System.Net.HttpStatusCode.BadRequest);
         var str3 = await response.Content.ReadAsStringAsync();
         str3.ShouldBe(@"{""errors"":[{""message"":""Error parsing query: Expected Name, found }; for more information see http://spec.graphql.org/October2021/#Field"",""locations"":[{""line"":1,""column"":2}],""extensions"":{""code"":""SYNTAX_ERROR"",""codes"":[""SYNTAX_ERROR""]}}]}");
     }
+
+    public void Dispose() => _server.Dispose();
 }
 
 [Route("/")]
@@ -69,7 +98,7 @@ public class TestController : Controller
 
     [HttpGet]
     [Route("graphql")]
-    public async Task<IActionResult> Test(string query, int? resultCode = null)
+    public async Task<IActionResult> Test(string query, int? resultCode = null, bool jsonType = false)
     {
         var result = await _documentExecuter.ExecuteAsync(new()
         {
@@ -77,9 +106,16 @@ public class TestController : Controller
             RequestServices = HttpContext.RequestServices,
             CancellationToken = HttpContext.RequestAborted,
         });
+
+        ExecutionResultActionResult result2;
         if (resultCode == null)
-            return new ExecutionResultActionResult(result);
+            result2 = new ExecutionResultActionResult(result);
         else
-            return new ExecutionResultActionResult(result, (System.Net.HttpStatusCode)resultCode.Value);
+            result2 = new ExecutionResultActionResult(result, (System.Net.HttpStatusCode)resultCode.Value);
+
+        if (jsonType)
+            result2.ContentType = "application/json";
+
+        return result2;
     }
 }

--- a/tests/Transports.AspNetCore.Tests/ExecutionResultActionResultTests.cs
+++ b/tests/Transports.AspNetCore.Tests/ExecutionResultActionResultTests.cs
@@ -62,7 +62,7 @@ public class ExecutionResultActionResultTests : IDisposable
     public async Task AltContentType()
     {
         using var httpClient = _server.CreateClient();
-        var request = new HttpRequestMessage(HttpMethod.Get, "/graphql?query={count}&jsonType=true");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/graphql?query={count}&jsonType=true");
         var response = await httpClient.SendAsync(request);
         response.EnsureSuccessStatusCode();
         var contentType = response.Content.Headers.ContentType;

--- a/tests/Transports.AspNetCore.Tests/TestServerExtensions.cs
+++ b/tests/Transports.AspNetCore.Tests/TestServerExtensions.cs
@@ -7,6 +7,10 @@ internal static class TestServerExtensions
         var client = server.CreateClient();
         using var response = await client.GetAsync(url);
         response.EnsureSuccessStatusCode();
+        var contentType = response.Content.Headers.ContentType;
+        contentType.ShouldNotBeNull();
+        contentType.MediaType.ShouldBe("application/graphql-response+json");
+        contentType.CharSet.ShouldBe("utf-8");
         var str = await response.Content.ReadAsStringAsync();
         return str;
     }
@@ -18,6 +22,10 @@ internal static class TestServerExtensions
         using var content = new StringContent(data, Encoding.UTF8, "application/json");
         using var response = await client.PostAsync(url, content);
         response.EnsureSuccessStatusCode();
+        var contentType = response.Content.Headers.ContentType;
+        contentType.ShouldNotBeNull();
+        contentType.MediaType.ShouldBe("application/graphql-response+json");
+        contentType.CharSet.ShouldBe("utf-8");
         var str = await response.Content.ReadAsStringAsync();
         return str;
     }


### PR DESCRIPTION
I missed this in 7.1.  We should probably release 7.1.1 with this fix.

Perhaps in a future version we can add a `SelectResponseContentType` protected method and re-use the logic from the middleware.  Since the `ContentType` property should be renamed `DefaultContentType`, we should probably do so in 8.0.  Not too worried about it, as it is unlikely this class will see much use.