### PR TITLE
Web socket authentication example constructor now matches class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ class MyAuthService : IWebSocketAuthenticationService
 {
     private readonly IGraphQLSerializer _serializer;
 
-    public MyWSAuthService(IGraphQLSerializer serializer)
+    public MyAuthService(IGraphQLSerializer serializer)
     {
         _serializer = serializer;
     }


### PR DESCRIPTION
The documentation [example](https://github.com/graphql-dotnet/server#authentication-for-websocket-requests) for web socket authentication, has a constructor name that does not match the class name.

This fix changes the constructor name from `MyWSAuthService` to `MyAuthService`, so constructor name and class name matches.