### PR TITLE
Add UseIgnoreDisconnections helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,13 +855,13 @@ As would be expected, subscription requests are only allowed over WebSocket chan
 ### Excessive `OperationCanceledException`s
 
 When hosting a WebSockets endpoint, it may be common for clients to simply disconnect rather
-than gracefully terminating the connection -- most specifically when the client is a web browser.
+than gracefully terminating the connection — most specifically when the client is a web browser.
 If you log exceptions, you may notice an `OperationCanceledException` logged any time this occurs.
 
-In some scenarios you may wish to log these exceptions -- for instance, when the GraphQL endpoint is
-used in server-to-server communications -- but if you wish to ignore these exceptions, simply call
+In some scenarios you may wish to log these exceptions — for instance, when the GraphQL endpoint is
+used in server-to-server communications — but if you wish to ignore these exceptions, simply call
 `app.UseIgnoreDisconnections();` immediately after any exception handling or logging configuration calls.
-This will consume any `OperationCanceledException`s when `HttpContext.RequestAborted` is signaled -- for
+This will consume any `OperationCanceledException`s when `HttpContext.RequestAborted` is signaled — for
 a WebSocket request or any other request.
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -852,6 +852,26 @@ are rejected over HTTP GET connections.  Derive from `GraphQLHttpMiddleware<T>` 
 
 As would be expected, subscription requests are only allowed over WebSocket channels.
 
+### Excessive `OperationCanceledException`s
+
+When hosting a WebSockets endpoint, it may be common for clients to simply disconnect rather
+than gracefully terminating the connection -- most specifically when the client is a web browser.
+If you log exceptions, you may notice an `OperationCanceledException` logged any time this occurs.
+
+In some scenarios you may wish to log these exceptions -- for instance, when the GraphQL endpoint is
+used in server-to-server communications -- but if you wish to ignore these exceptions, simply call
+`app.UseIgnoreDisconnections();` immediately after any exception handling or logging configuration calls.
+This will consume any `OperationCanceledException`s when `HttpContext.RequestAborted` is signaled -- for
+a WebSocket request or any other request.
+
+```csharp
+var app = builder.Build();
+app.UseDeveloperExceptionPage();
+app.UseIgnoreDisconnections();
+app.UseWebSockets();
+app.UseGraphQL();
+```
+
 ### File uploading/downloading
 
 A common question is how to upload or download files attached to GraphQL data.

--- a/tests/ApiApprovalTests/net50+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net50+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -416,6 +416,7 @@ namespace Microsoft.AspNetCore.Builder
             where TSchema : GraphQL.Types.ISchema { }
         public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQL<TMiddleware>(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, string path = "/graphql", params object[] args)
             where TMiddleware : GraphQL.Server.Transports.AspNetCore.GraphQLHttpMiddleware { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseIgnoreDisconnections(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder) { }
     }
     public static class GraphQLHttpEndpointRouteBuilderExtensions
     {

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -430,5 +430,6 @@ namespace Microsoft.AspNetCore.Builder
             where TSchema : GraphQL.Types.ISchema { }
         public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQL<TMiddleware>(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder, string path = "/graphql", params object[] args)
             where TMiddleware : GraphQL.Server.Transports.AspNetCore.GraphQLHttpMiddleware { }
+        public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseIgnoreDisconnections(this Microsoft.AspNetCore.Builder.IApplicationBuilder builder) { }
     }
 }

--- a/tests/Transports.AspNetCore.Tests/BuilderMethodTests.cs
+++ b/tests/Transports.AspNetCore.Tests/BuilderMethodTests.cs
@@ -103,7 +103,7 @@ public class BuilderMethodTests
     [Fact]
     public async Task UseIgnoreDisconnections_Fail()
     {
-        var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
         RequestDelegate func = next => throw new OperationCanceledException();
         var builderMock = new Mock<IApplicationBuilder>();
         builderMock.Setup(x => x.Use(It.IsAny<Func<RequestDelegate, RequestDelegate>>())).Returns<Func<RequestDelegate, RequestDelegate>>(

--- a/tests/Transports.AspNetCore.Tests/BuilderMethodTests.cs
+++ b/tests/Transports.AspNetCore.Tests/BuilderMethodTests.cs
@@ -88,6 +88,44 @@ public class BuilderMethodTests
         await VerifyAsync(url);
     }
 
+    [Fact]
+    public async Task Basic_WithUseIgnoreDisconnections()
+    {
+        _hostBuilder.Configure(app =>
+        {
+            app.UseIgnoreDisconnections();
+            app.UseWebSockets();
+            app.UseGraphQL();
+        });
+        await VerifyAsync();
+    }
+
+    [Fact]
+    public async Task UseIgnoreDisconnections_Fail()
+    {
+        var cts = new CancellationTokenSource();
+        RequestDelegate func = next => throw new OperationCanceledException();
+        var builderMock = new Mock<IApplicationBuilder>();
+        builderMock.Setup(x => x.Use(It.IsAny<Func<RequestDelegate, RequestDelegate>>())).Returns<Func<RequestDelegate, RequestDelegate>>(
+            d =>
+            {
+                func = d(func);
+                return builderMock.Object;
+            });
+        builderMock.Object.UseIgnoreDisconnections();
+        var context = new DefaultHttpContext()
+        {
+            RequestAborted = cts.Token,
+        };
+
+        // cts is not canceled here so OCE should pass through
+        await Should.ThrowAsync<OperationCanceledException>(() => func(context));
+
+        cts.Cancel();
+        // cts is canceled so OCE should be consumed
+        await func(context);
+    }
+
     [Theory]
     [InlineData("/graphql/")]
     [InlineData("/graphql/more")]


### PR DESCRIPTION
This PR adds a helper method to consume OCEs when the client disconnects unexpectedly, which is common when the client is a web browser with an open WebSocket connection to the server.  ASP.NET Core does not consume these OCEs by default, and since GraphQL over WebSockets can perform any query or mutation that a GET/POST can, it seems that there is no reason why an OCE should be consumed for a WebSocket connection and not for any other connection.  Futher, for server-to-server communications, it may be desired to log these exceptions.  As such, the default behavior has not been changed.  Note that graceful teardown of the WebSocket connection (per WebSocket spec) does not produce an OCE.

See added readme text:

> When hosting a WebSockets endpoint, it may be common for clients to simply disconnect rather than gracefully terminating the connection -- most specifically when the client is a web browser. If you log exceptions, you may notice an `OperationCanceledException` logged any time this occurs.
>
> In some scenarios you may wish to log these exceptions -- for instance, when the GraphQL endpoint is used in server-to-server communications -- but if you wish to ignore these exceptions, simply call `app.UseIgnoreDisconnections();` immediately after any exception handling or logging configuration calls. This will consume any `OperationCanceledException`s when `HttpContext.RequestAborted` is signaled -- for a WebSocket request or any other request.