### PR TITLE
Catch additional exception types when a WebSocket connection is disconnected

### DIFF
--- a/src/Transports.AspNetCore/WebSockets/WebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/WebSocketConnection.cs
@@ -103,6 +103,10 @@ public class WebSocketConnection : IWebSocketConnection
                 {
                     result = await _webSocket.ReceiveAsync(bufferMemory, RequestAborted);
                 }
+                catch (OperationCanceledException) when (RequestAborted.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex) when (RequestAborted.IsCancellationRequested)
                 {
                     throw new OperationCanceledException(null, ex, RequestAborted);

--- a/src/Transports.AspNetCore/WebSockets/WebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/WebSocketConnection.cs
@@ -94,10 +94,19 @@ public class WebSocketConnection : IWebSocketConnection
                 // prep a Memory instance pointing to the free part of block
 #if NETSTANDARD2_0
                 var bufferMemory = new ArraySegment<byte>(buffer, bufferOffset, BUFFER_SIZE - bufferOffset);
+                WebSocketReceiveResult result;
 #else
                 var bufferMemory = new Memory<byte>(buffer, bufferOffset, BUFFER_SIZE - bufferOffset);
+                ValueWebSocketReceiveResult result;
 #endif
-                var result = await _webSocket.ReceiveAsync(bufferMemory, RequestAborted);
+                try
+                {
+                    result = await _webSocket.ReceiveAsync(bufferMemory, RequestAborted);
+                }
+                catch (Exception ex) when (RequestAborted.IsCancellationRequested)
+                {
+                    throw new OperationCanceledException(null, ex, RequestAborted);
+                }
                 bufferOffset += result.Count;
                 if (result.MessageType == WebSocketMessageType.Close)
                 {
@@ -167,9 +176,6 @@ public class WebSocketConnection : IWebSocketConnection
                     bufferOffset = 0;
                 }
             }
-        }
-        catch (WebSocketException) when (RequestAborted.IsCancellationRequested)
-        {
         }
         finally
         {

--- a/tests/Transports.AspNetCore.Tests/WebSockets/WebSocketConnectionTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/WebSocketConnectionTests.cs
@@ -493,7 +493,7 @@ public class WebSocketConnectionTests : IDisposable
     }
 
     [Fact]
-    public async Task ExecuteAsync_WebSocket_EatsWebSocketExceptions()
+    public async Task ExecuteAsync_WebSocket_WebSocketExceptions_Rethrows()
     {
         _mockConnection.CallBase = true;
         var mockReceiveStream = new Mock<IOperationMessageProcessor>(MockBehavior.Strict);
@@ -515,7 +515,7 @@ public class WebSocketConnectionTests : IDisposable
     }
 
     [Fact]
-    public async Task ExecuteAsync_WebSocket_EatsObjectDisposedExceptions()
+    public async Task ExecuteAsync_WebSocket_ObjectDisposedExceptions()
     {
         _mockConnection.CallBase = true;
         var mockReceiveStream = new Mock<IOperationMessageProcessor>(MockBehavior.Strict);

--- a/tests/Transports.AspNetCore.Tests/WebSockets/WebSocketConnectionTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/WebSocketConnectionTests.cs
@@ -511,7 +511,29 @@ public class WebSocketConnectionTests : IDisposable
                 throw new WebSocketException();
             })
             .Verifiable();
-        await _connection.ExecuteAsync(mockReceiveStream.Object);
+        await Should.ThrowAsync<OperationCanceledException>(() => _connection.ExecuteAsync(mockReceiveStream.Object));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WebSocket_EatsObjectDisposedExceptions()
+    {
+        _mockConnection.CallBase = true;
+        var mockReceiveStream = new Mock<IOperationMessageProcessor>(MockBehavior.Strict);
+        mockReceiveStream.Setup(x => x.InitializeConnectionAsync()).Returns(Task.CompletedTask).Verifiable();
+        mockReceiveStream.Setup(x => x.Dispose());
+#if NET48
+        _mockWebSocket.Setup(x => x.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), _token))
+            .Returns<ArraySegment<byte>, CancellationToken>((_, _) =>
+#else
+        _mockWebSocket.Setup(x => x.ReceiveAsync(It.IsAny<Memory<byte>>(), _token))
+            .Returns<Memory<byte>, CancellationToken>((_, _) =>
+#endif
+            {
+                _cts.Cancel();
+                throw new ObjectDisposedException("WebSocket");
+            })
+            .Verifiable();
+        await Should.ThrowAsync<OperationCanceledException>(() => _connection.ExecuteAsync(mockReceiveStream.Object));
     }
 
     [Fact]


### PR DESCRIPTION
ASP.NET Core can dispose a `WebSocket` instance internally, leading to a `ObjectDisposedException` when a client disconnects.

With this PR, exceptions are rethrown as `OperationCanceledException`s.