### PR TITLE
Bump GraphQL.NET to fix invalid execution context

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>7.2.0-preview</VersionPrefix>
+    <VersionPrefix>7.3.0-preview</VersionPrefix>
     <NextVersion>8.0.0</NextVersion>
     <LangVersion>latest</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -32,7 +32,7 @@
     <RootNamespace>GraphQL.Server.$(MSBuildProjectName)</RootNamespace>
     <PackageId>GraphQL.Server.$(MSBuildProjectName)</PackageId>
 
-    <GraphQLVersion>7.1.1</GraphQLVersion>
+    <GraphQLVersion>7.3.0</GraphQLVersion>
 
     <SignAssembly>true</SignAssembly>
     <_FriendAssembliesPublicKey>PublicKey=0024000004800000940000000602000000240000525341310004000001000100352162dbf27be78fc45136884b8f324aa9f1dfc928c96c24704bf1df1a8779b2f26c760ed8321eca5b95ea6bd9bb60cd025b300f73bd1f4ae1ee6e281f85c527fa013ab5cb2c3fc7a1cbef7f9bf0c9014152e6a21f6e0ac6a371f8b45c6d7139c9119df9eeecf1cf59063545bb7c07437b1bc12be2c57d108d72d6c27176fbb8</_FriendAssembliesPublicKey>

--- a/tests/Transports.AspNetCore.Tests/WebSockets/AsyncContextTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/AsyncContextTests.cs
@@ -1,0 +1,160 @@
+using System.Reactive.Subjects;
+
+namespace Tests.WebSockets;
+
+public class AsyncContextTests
+{
+    /*
+     * This demonstrates that because the GraphQL execution of subscription events
+     * occurs within the ExecutionContext of the sender of the subscription event,
+     * using IHttpContextAccessor and other ExecutionContext-bound services within
+     * the subscription event execution will not work as expected.
+     * 
+     * Even worse, this means that IHttpContextAccessor.HttpContext may return the
+     * HttpContext of the sender of the event, rather than the one that initiated the
+     * subscription, which can be unanticipated and very hard to diagnose.
+     *
+     * This would ideally be fixed in a future version of GraphQL.NET, probably by
+     * capturing the ExecutionContext upon subscription and restoring it for data events.
+     *
+     * Note that this issue has nothing to do with DI service scope, as DI service scope
+     * is not used by AsyncLocal or HttpContextAccessor.
+     *
+     * Note that since the IResolveFieldContext.User and UserContext properties do not
+     * rely on AsyncLocal or IHttpContextAccessor for propagation, their use (and in turn,
+     * the provided authorization rule) are unaffected by this issue.
+     *
+     */
+    [Fact]
+    public async Task DemonstrateNoAsyncContextWithinSubscriptionResolvers()
+    {
+        using var replaySubject = new ReplaySubject<Class1>();
+
+        using var server = new TestServer(new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(replaySubject);
+                services.AddHttpContextAccessor();
+                services.AddSingleton<Class1Type>();
+                services.AddGraphQL(b => b
+                    .AddAutoSchema<Query>(o => o.WithSubscription<Subscription>())
+                    .AddSystemTextJson()
+                    .AddErrorInfoProvider(o => o.ExposeExceptionDetails = true)
+                    .ConfigureSchema(s =>
+                    {
+                        s.RegisterTypeMapping<Class1, Class1Type>();
+                    })
+                    .AddScopedSubscriptionExecutionStrategy()
+                );
+            })
+            .Configure(app =>
+            {
+                app.UseWebSockets();
+                app.UseGraphQL();
+            })
+        );
+
+        // create websocket connection
+        var webSocketClient = server.CreateWebSocketClient();
+        webSocketClient.ConfigureRequest = request =>
+        {
+            request.Headers["Sec-WebSocket-Protocol"] = "graphql-transport-ws";
+        };
+        webSocketClient.SubProtocols.Add("graphql-transport-ws");
+        using var webSocket = await webSocketClient.ConnectAsync(new Uri(server.BaseAddress, "graphql"), default);
+
+        // send CONNECTION_INIT
+        await webSocket.SendMessageAsync(new OperationMessage
+        {
+            Type = "connection_init"
+        });
+
+        // wait for CONNECTION_ACK
+        var message = await webSocket.ReceiveMessageAsync();
+        message.Type.ShouldBe("connection_ack");
+
+        // subscribe
+        await webSocket.SendMessageAsync(new OperationMessage
+        {
+            Type = "subscribe",
+            Id = "123",
+            Payload = new GraphQLRequest
+            {
+                Query = "subscription { events { hasHttpContext } }",
+            },
+        });
+
+        // It is necessary to allow time for the asynchronous websocket handler code
+        // to execute prior to the independent call to AddMessageInternal below.
+        // Since the websocket call does not return a response when the subscription
+        // has completed being set up, there is no response we can await to determine
+        // when to call AddMessageInternal; so for the purposes of testing, we make
+        // an additional call here.
+
+        // wait for the message to be handled by the server;
+        // just send a ping and wait for the pong
+        await webSocket.SendMessageAsync(new OperationMessage
+        {
+            Type = "ping",
+        });
+        message = await webSocket.ReceiveMessageAsync();
+        message.Type.ShouldBe("pong");
+
+        // verify the subscription has connected (should be connected because of the ping)
+        replaySubject.HasObservers.ShouldBeTrue();
+
+        // post a new message
+        replaySubject.OnNext(new Class1());
+
+        // wait for a new message sent over this websocket
+        message = await webSocket.ReceiveMessageAsync();
+        message.Type.ShouldBe("next");
+        message.Payload.ShouldBe("""{"data":{"events":{"hasHttpContext":false}}}"""); // ideally this should be 'true'
+
+        // unsubscribe
+        await webSocket.SendMessageAsync(new OperationMessage
+        {
+            Type = "complete",
+            Id = "123",
+        });
+
+        // close websocket
+        await webSocket.CloseOutputAsync(System.Net.WebSockets.WebSocketCloseStatus.NormalClosure, null, default);
+
+        // wait for websocket closure
+        (await webSocket.ReceiveCloseAsync()).ShouldBe(System.Net.WebSockets.WebSocketCloseStatus.NormalClosure);
+    }
+
+    public class Query
+    {
+        public static string Hero => throw new NotImplementedException();
+    }
+
+    public class Subscription
+    {
+        public static IObservable<Class1> Events([FromServices] IHttpContextAccessor accessor, [FromServices] ReplaySubject<Class1> replaySubject)
+        {
+            var context = accessor.HttpContext;
+            context.ShouldNotBeNull(); // we can see that the http context is passed to the initial subscription resolver correctly
+            return replaySubject;
+        }
+    }
+
+    public class Class1Type : ObjectGraphType<Class1>
+    {
+        public Class1Type()
+        {
+            Field<bool>("HasHttpContext")
+                .Resolve(context =>
+                {
+                    var accessor = context.RequestServices.ShouldNotBeNull().GetRequiredService<IHttpContextAccessor>();
+                    // here we can see that the http context is not accessible by field resolvers within a subscription data event
+                    return accessor.HttpContext != null; // currently returns false; ideally would return true
+                });
+        }
+    }
+
+    public class Class1
+    {
+    }
+}

--- a/tests/Transports.AspNetCore.Tests/WebSockets/AsyncContextTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/AsyncContextTests.cs
@@ -33,6 +33,9 @@ public class AsyncContextTests
         using var server = new TestServer(new WebHostBuilder()
             .ConfigureServices(services =>
             {
+#if !NETCOREAPP3_1_OR_GREATER
+                services.AddHostApplicationLifetime();
+#endif
                 services.AddSingleton(replaySubject);
                 services.AddHttpContextAccessor();
                 services.AddSingleton<Class1Type>();


### PR DESCRIPTION
This demonstrates a problem in GraphQL.NET, where the `ExecutionContext` of the sender of a data event is carried through to field resolvers' executions for individually connected clients.

This can pose a security risk if someone were to assume that `IHttpContextAccessor.HttpContext` with a subscription field resolver returns the context of the connected client (as it would for any other field resolvers), whereas in fact it will contain anything but that -- either `null` or the http context of the client which initiated the data event.

This was fixed within in GraphQL.NET 7.3.0.  This PR bumps the minimum version of GraphQL.NET to match.