### PR TITLE
Misc updates for the JWT sample application

### DIFF
--- a/samples/Samples.Jwt/Controllers/OAuthController.cs
+++ b/samples/Samples.Jwt/Controllers/OAuthController.cs
@@ -5,6 +5,13 @@ namespace GraphQL.Server.Samples.Jwt.Controllers;
 
 public class OAuthController : Controller
 {
+    private readonly JwtHelper _jwtHelper;
+
+    public OAuthController(JwtHelper jwtHelper)
+    {
+        _jwtHelper = jwtHelper;
+    }
+
     // sample OAuth2-compatible authorization endpoint supporting the 'client credentials' flow
     [HttpGet]
     [HttpPost]
@@ -15,7 +22,7 @@ public class OAuthController : Controller
         if (grant_type == "client_credentials" && client_id == "sampleClientId" && client_secret == "sampleSecret")
         {
             // provide a signed JWT token with an 'Administrator' role claim
-            var token = JwtHelper.Instance.CreateSignedToken(new Claim("role", "Administrator"));
+            var token = _jwtHelper.CreateSignedToken(new Claim("role", "Administrator"));
             return Json(new
             {
                 access_token = token.Token,

--- a/samples/Samples.Jwt/JwtHelper.cs
+++ b/samples/Samples.Jwt/JwtHelper.cs
@@ -10,11 +10,6 @@ namespace GraphQL.Server.Samples.Jwt;
 /// </summary>
 public class JwtHelper
 {
-    /// <summary>
-    /// The shared instance for the application.
-    /// </summary>
-    public static JwtHelper Instance { get; set; } = null!;
-
     private readonly SecurityKey _securityKey;
     private readonly string _securityAlgorithm;
     private readonly SigningCredentials _signingCredentials;
@@ -155,20 +150,25 @@ public class JwtHelper
 
         // create the security token as follows:
         var token = new JwtSecurityToken(
-            // issuer is an arbitrary string, typically the name of the web server that issued the token
-            issuer: _issuer,
-            // audience is an arbitrary string, typically representing valid recipients - typically 'Refresh' or 'Access' or a url for a subdomain
-            audience: _audience,
-            // include a list of claims
-            claims: claims,
-            // set the time this token becomes valid
-            notBefore: now,
-            // for access tokens, set a short timeout like 5 minutes, after which the access token will need to be refreshed
-            //   (the access token can be refreshed before or after the expiration, as refreshing it uses the refresh token)
-            // for refresh tokens, set a long timeout like 6 months, after which the refresh token will expire
-            expires: now.Add(_expiresIn),
             // set the digital signature algorithm and key
-            signingCredentials: _signingCredentials
+            new JwtHeader(_signingCredentials),
+            // set the payload
+            new JwtPayload(
+                // issuer is an arbitrary string, typically the name of the web server that issued the token
+                issuer: _issuer,
+                // audience is an arbitrary string, typically representing valid recipients - typically 'Refresh' or 'Access' or a url for a subdomain
+                audience: _audience,
+                // include a list of claims
+                claims: claims,
+                // set the time this token becomes valid
+                notBefore: now,
+                // set the issued-at time
+                issuedAt: now,
+                // for access tokens, set a short timeout like 5 minutes, after which the access token will need to be refreshed
+                //   (the access token can be refreshed before or after the expiration, as refreshing it uses the refresh token)
+                // for refresh tokens, set a long timeout like 6 months, after which the refresh token will expire
+                expires: now.Add(_expiresIn)
+            )
         );
 
         // return the token

--- a/samples/Samples.Jwt/JwtHelper.cs
+++ b/samples/Samples.Jwt/JwtHelper.cs
@@ -74,7 +74,7 @@ public class JwtHelper
     }
 
     /// <summary>
-    /// Creates a symmetric security key based on a password
+    /// Creates a 256-bit symmetric security key based on a password
     /// </summary>
     private static (SecurityKey SecurityKey, string SecurityAlgorithm) CreateSymmetricSecurityKey(string password)
     {
@@ -114,7 +114,7 @@ public class JwtHelper
     }
 
     /// <summary>
-    /// Creates an asymmetric ECDsa security key pair.
+    /// Creates an asymmetric ECDsa 256-bit security key pair.
     /// </summary>
     public static (string PublicKey, string PrivateKey) CreateNewAsymmetricKeyPair()
     {

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -50,8 +50,9 @@ public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
             {
                 // pull the token from the value
                 var token = authPayload.Authorization.Substring(7);
-                // parse the token in the same manner that the .NET AddJwtBearer() method does
-                // note that JwtSecurityTokenHandler maps the 'name' and 'role' claims to the 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name' and 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role' claims
+                // parse the token in the same manner that the .NET AddJwtBearer() method does:
+                // JwtSecurityTokenHandler maps the 'name' and 'role' claims to the 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name'
+                // and 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role' claims;
                 // this mapping is not performed by Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler
                 var handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
                 var tokenValidationParameters = _jwtBearerOptionsMonitor.Get(JwtBearerDefaults.AuthenticationScheme).TokenValidationParameters;

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -21,7 +21,7 @@ namespace GraphQL.Server.Samples.Jwt;
 /// </item>
 /// <item>
 /// The expected format of the payload is <c>{"Authorization":"Bearer TOKEN"}</c> where TOKEN is the JSON Web Token (JWT),
-/// mirroring the format of a HTTP header.
+/// mirroring the format of the 'Authorization' HTTP header.
 /// </item>
 /// </list>
 /// </summary>

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Samples.Jwt;
 /// <item>This class is not used when authenticating over GET/POST.</item>
 /// <item>
 /// This class pulls the <see cref="TokenValidationParameters"/> instance from the instance of
-/// <see cref="IOptions{TOptions}">IOptions</see>&lt;<see cref="JwtBearerOptions"/>&gt; registered
+/// <see cref="IOptionsMonitor{TOptions}">IOptionsMonitor</see>&lt;<see cref="JwtBearerOptions"/>&gt; registered
 /// by ASP.NET Core during the call to <see cref="JwtBearerExtensions.AddJwtBearer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder, Action{JwtBearerOptions})">AddJwtBearer</see>.
 /// </item>
 /// <item>

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -1,7 +1,8 @@
-using System.Security.Claims;
 using GraphQL.Server.Transports.AspNetCore.WebSockets;
 using GraphQL.Transport;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 
 namespace GraphQL.Server.Samples.Jwt;
 
@@ -10,15 +11,28 @@ namespace GraphQL.Server.Samples.Jwt;
 /// This is necessary because WebSocket connections initiated from the browser cannot
 /// authenticate via HTTP headers.
 /// <br/><br/>
-/// This class is not used when authenticating over GET/POST.
+/// Notes:
+/// <list type="bullet">
+/// <item>This class is not used when authenticating over GET/POST.</item>
+/// <item>
+/// This class pulls the <see cref="TokenValidationParameters"/> instance from the instance of
+/// <see cref="IOptions{TOptions}">IOptions</see>&lt;<see cref="JwtBearerOptions"/>&gt; registered
+/// by ASP.NET Core during the call to <see cref="JwtBearerExtensions.AddJwtBearer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder, Action{JwtBearerOptions})">AddJwtBearer</see>.
+/// </item>
+/// <item>
+/// The expected format of the payload is <c>{"authorization":"Bearer TOKEN"}</c> where TOKEN is the JSON Web Token (JWT).
+/// </item>
+/// </list>
 /// </summary>
 public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
 {
     private readonly IGraphQLSerializer _graphQLSerializer;
+    private readonly IOptionsMonitor<JwtBearerOptions> _jwtBearerOptionsMonitor;
 
-    public JwtWebSocketAuthenticationService(IGraphQLSerializer graphQLSerializer)
+    public JwtWebSocketAuthenticationService(IGraphQLSerializer graphQLSerializer, IOptionsMonitor<JwtBearerOptions> jwtBearerOptionsMonitor)
     {
         _graphQLSerializer = graphQLSerializer;
+        _jwtBearerOptionsMonitor = jwtBearerOptionsMonitor;
     }
 
     public Task AuthenticateAsync(IWebSocketConnection connection, string subProtocol, OperationMessage operationMessage)
@@ -29,25 +43,20 @@ public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
             if (connection.HttpContext.User.Identity?.IsAuthenticated ?? false)
                 return Task.CompletedTask;
 
-            // attempt to read the 'Authorization' key from the payload object and verify it contains "Bearer: XXXXXXXX"
+            // attempt to read the 'Authorization' key from the payload object and verify it contains "Bearer XXXXXXXX"
             var authPayload = _graphQLSerializer.ReadNode<AuthPayload>(operationMessage.Payload);
             if (authPayload != null && authPayload.Authorization != null && authPayload.Authorization.StartsWith("Bearer ", StringComparison.Ordinal))
             {
                 // pull the token from the value
                 var token = authPayload.Authorization.Substring(7);
                 // parse the token in the same manner that the .NET AddJwtBearer() method does
-                var handler = new Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler();
-                var result = handler.ValidateToken(token, JwtHelper.Instance.TokenValidationParameters);
-                if (result.IsValid)
-                {
-                    // convert JWT tokens with "role" as the claim type (a JWT defined claim type) to the proper .NET claim type constant http://schemas.microsoft.com/ws/2008/06/identity/claims/role
-                    // note this conversion automatically happens within the .NET AddJwtBearer() method when authenticating GET/POST requests
-                    var claims = result.ClaimsIdentity.Claims.Select(claim => claim.Type == "role" ? new Claim(result.ClaimsIdentity.RoleClaimType, claim.Value) : claim);
-                    var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, JwtBearerDefaults.AuthenticationScheme));
-
-                    // set the ClaimsPrincipal for the HttpContext; authentication will take place against this object
-                    connection.HttpContext.User = principal;
-                }
+                // note that JwtSecurityTokenHandler maps the 'name' and 'role' claims to the 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name' and 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role' claims
+                // this mapping is not performed by Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler
+                var handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
+                var tokenValidationParameters = _jwtBearerOptionsMonitor.Get(JwtBearerDefaults.AuthenticationScheme).TokenValidationParameters;
+                var principal = handler.ValidateToken(token, tokenValidationParameters, out var securityToken);
+                // set the ClaimsPrincipal for the HttpContext; authentication will take place against this object
+                connection.HttpContext.User = principal;
             }
         }
         catch

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -20,7 +20,8 @@ namespace GraphQL.Server.Samples.Jwt;
 /// by ASP.NET Core during the call to <see cref="JwtBearerExtensions.AddJwtBearer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder, Action{JwtBearerOptions})">AddJwtBearer</see>.
 /// </item>
 /// <item>
-/// The expected format of the payload is <c>{"authorization":"Bearer TOKEN"}</c> where TOKEN is the JSON Web Token (JWT).
+/// The expected format of the payload is <c>{"Authorization":"Bearer TOKEN"}</c> where TOKEN is the JSON Web Token (JWT),
+/// mirroring the format of a HTTP header.
 /// </item>
 /// </list>
 /// </summary>

--- a/samples/Samples.Jwt/Program.cs
+++ b/samples/Samples.Jwt/Program.cs
@@ -24,11 +24,14 @@ builder.Services.AddGraphQL(b => b
 // ===   TO USE A PASSWORD WITH A HIGH ENTROPY, SUCH AS A PAIR OF RANDOM 128-BIT GUIDS   ===
 //var password = Guid.NewGuid().ToString() + Guid.NewGuid().ToString(); // 244-bit entropy
 var password = JwtHelper.CreateNewSymmetricKey(); // 256-bit entropy
-JwtHelper.Instance = new(password, SecurityKeyType.SymmetricSecurityKey);
+var jwtHelper = new JwtHelper(password, SecurityKeyType.SymmetricSecurityKey);
 
 // or: use an asymmetric security key with a new random key pair (typically would be pulled from application secrets)
 //var (_, privateKey) = JwtHelper.CreateNewAsymmetricKeyPair();
-//JwtHelper.Instance = new(privateKey, SecurityKeyType.PrivateKey);
+//var jwtHelper = new JwtHelper(privateKey, SecurityKeyType.PrivateKey);
+
+// register JwtHelper as a singleton so it can be used by OAuthController
+builder.Services.AddSingleton(jwtHelper);
 
 // configure authentication for GET/POST requests via the 'Authorization' HTTP header;
 // will authenticate WebSocket requests as well, but browsers cannot set the
@@ -39,7 +42,7 @@ builder.Services.AddAuthentication(
         opts.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
         // configure custom authorization policies here, if any
     })
-    .AddJwtBearer(opts => opts.TokenValidationParameters = JwtHelper.Instance.TokenValidationParameters);
+    .AddJwtBearer(opts => opts.TokenValidationParameters = jwtHelper.TokenValidationParameters);
 
 var app = builder.Build();
 app.UseDeveloperExceptionPage();

--- a/samples/Samples.Jwt/Samples.Jwt.csproj
+++ b/samples/Samples.Jwt/Samples.Jwt.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Pull `TokenValidationParameters` from the call to `AddJwtBearer` so that the reference to the static property `JwtHelper.Instance` is not necessary
- Eliminate the static property `JwtHelper.Instance`
- Reconfigure `Program.cs` to use a local variable instead of a static property
- Reconfigure `OAuthController` to pull `JwtHelper` from DI
- Add the 'iat' claim to generated tokens (required for Open ID Connect)
- Bump Microsoft.AspNetCore.Authentication.JwtBearer since the project is a .NET 7 sample