### PR TITLE
[WIP] Introduce IOperationMessageListener

### DIFF
--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -680,6 +680,7 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     protected virtual IOperationMessageProcessor CreateMessageProcessor(IWebSocketConnection webSocketConnection, string subProtocol)
     {
         var authService = webSocketConnection.HttpContext.RequestServices.GetService<IWebSocketAuthenticationService>();
+        var listeners = webSocketConnection.HttpContext.RequestServices.GetServices<IOperationMessageListener>();
 
         if (subProtocol == WebSockets.GraphQLWs.SubscriptionServer.SubProtocol)
         {
@@ -691,7 +692,8 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
                 _serializer,
                 _serviceScopeFactory,
                 this,
-                authService);
+                authService,
+                listeners);
         }
         else if (subProtocol == WebSockets.SubscriptionsTransportWs.SubscriptionServer.SubProtocol)
         {
@@ -703,7 +705,8 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
                 _serializer,
                 _serviceScopeFactory,
                 this,
-                authService);
+                authService,
+                listeners);
         }
 
         throw new ArgumentOutOfRangeException(nameof(subProtocol));

--- a/src/Transports.AspNetCore/IOperationMessageListener.cs
+++ b/src/Transports.AspNetCore/IOperationMessageListener.cs
@@ -1,0 +1,12 @@
+namespace GraphQL.Server.Transports.AspNetCore;
+
+/// <summary>
+/// Allows to hook up into <see cref="BaseSubscriptionServer.OnMessageReceivedAsync(OperationMessage)"/>.
+/// </summary>
+public interface IOperationMessageListener
+{
+    /// <summary>
+    /// This method is called at the very beginning of <see cref="BaseSubscriptionServer.OnMessageReceivedAsync(OperationMessage)"/>
+    /// </summary>
+    ValueTask ListenAsync(BaseSubscriptionServer subscriptionServer, OperationMessage message);
+}

--- a/src/Transports.AspNetCore/WebSockets/SubscriptionsTransportWs/SubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/SubscriptionsTransportWs/SubscriptionServer.cs
@@ -4,6 +4,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.SubscriptionsTransport
 public class SubscriptionServer : BaseSubscriptionServer
 {
     private readonly IWebSocketAuthenticationService? _authenticationService;
+    private readonly IOperationMessageListener[]? _listeners;
 
     /// <summary>
     /// The WebSocket sub-protocol used for this protocol.
@@ -51,6 +52,7 @@ public class SubscriptionServer : BaseSubscriptionServer
     /// <param name="serviceScopeFactory">A <see cref="IServiceScopeFactory"/> to create service scopes for execution of GraphQL requests.</param>
     /// <param name="userContextBuilder">The user context builder used during connection initialization.</param>
     /// <param name="authenticationService">An optional service to authenticate connections.</param>
+    /// <param name="listeners">An optional collection of message listeners.</param>
     public SubscriptionServer(
         IWebSocketConnection connection,
         GraphQLWebSocketOptions options,
@@ -59,7 +61,8 @@ public class SubscriptionServer : BaseSubscriptionServer
         IGraphQLSerializer serializer,
         IServiceScopeFactory serviceScopeFactory,
         IUserContextBuilder userContextBuilder,
-        IWebSocketAuthenticationService? authenticationService = null)
+        IWebSocketAuthenticationService? authenticationService = null,
+        IEnumerable<IOperationMessageListener>? listeners = null)
         : base(connection, options, authorizationOptions)
     {
         DocumentExecuter = executer ?? throw new ArgumentNullException(nameof(executer));
@@ -67,11 +70,16 @@ public class SubscriptionServer : BaseSubscriptionServer
         UserContextBuilder = userContextBuilder ?? throw new ArgumentNullException(nameof(userContextBuilder));
         Serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         _authenticationService = authenticationService;
+        _listeners = listeners?.ToArray();
     }
 
     /// <inheritdoc/>
     public override async Task OnMessageReceivedAsync(OperationMessage message)
     {
+        if (_listeners != null)
+            foreach (var listener in _listeners)
+                await listener.ListenAsync(this, message);
+
         if (message.Type == MessageType.GQL_CONNECTION_TERMINATE)
         {
             await OnCloseConnectionAsync();
@@ -174,10 +182,9 @@ public class SubscriptionServer : BaseSubscriptionServer
     /// <inheritdoc/>
     protected override async Task<ExecutionResult> ExecuteRequestAsync(OperationMessage message)
     {
-        var request = Serializer.ReadNode<GraphQLRequest>(message.Payload);
 #pragma warning disable CA2208 // Instantiate argument exceptions correctly
-        if (request == null)
-            throw new ArgumentNullException(nameof(message) + "." + nameof(OperationMessage.Payload));
+        var request = Serializer.ReadNode<GraphQLRequest>(message.Payload)
+            ?? throw new ArgumentNullException(nameof(message) + "." + nameof(OperationMessage.Payload));
 #pragma warning restore CA2208 // Instantiate argument exceptions correctly
         var scope = ServiceScopeFactory.CreateScope();
         try

--- a/tests/ApiApprovalTests/net50+net60+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net50+net60+netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -147,6 +147,10 @@ namespace GraphQL.Server.Transports.AspNetCore
         string? AuthorizedPolicy { get; }
         System.Collections.Generic.IEnumerable<string> AuthorizedRoles { get; }
     }
+    public interface IOperationMessageListener
+    {
+        System.Threading.Tasks.ValueTask ListenAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.BaseSubscriptionServer subscriptionServer, GraphQL.Transport.OperationMessage message);
+    }
     public interface IUserContextBuilder
     {
         System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>?> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context, object? payload);
@@ -312,7 +316,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs
     }
     public class SubscriptionServer : GraphQL.Server.Transports.AspNetCore.WebSockets.BaseSubscriptionServer
     {
-        public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
+        public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.AspNetCore.IOperationMessageListener>? listeners = null) { }
         protected GraphQL.IDocumentExecuter DocumentExecuter { get; }
         protected GraphQL.IGraphQLSerializer Serializer { get; }
         protected Microsoft.Extensions.DependencyInjection.IServiceScopeFactory ServiceScopeFactory { get; }
@@ -350,7 +354,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.SubscriptionsTransport
     }
     public class SubscriptionServer : GraphQL.Server.Transports.AspNetCore.WebSockets.BaseSubscriptionServer
     {
-        public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
+        public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.AspNetCore.IOperationMessageListener>? listeners = null) { }
         protected GraphQL.IDocumentExecuter DocumentExecuter { get; }
         protected GraphQL.IGraphQLSerializer Serializer { get; }
         protected Microsoft.Extensions.DependencyInjection.IServiceScopeFactory ServiceScopeFactory { get; }

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -165,6 +165,10 @@ namespace GraphQL.Server.Transports.AspNetCore
     {
         System.Threading.CancellationToken ApplicationStopping { get; }
     }
+    public interface IOperationMessageListener
+    {
+        System.Threading.Tasks.ValueTask ListenAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.BaseSubscriptionServer subscriptionServer, GraphQL.Transport.OperationMessage message);
+    }
     public interface IUserContextBuilder
     {
         System.Threading.Tasks.ValueTask<System.Collections.Generic.IDictionary<string, object?>?> BuildUserContextAsync(Microsoft.AspNetCore.Http.HttpContext context, object? payload);
@@ -330,7 +334,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs
     }
     public class SubscriptionServer : GraphQL.Server.Transports.AspNetCore.WebSockets.BaseSubscriptionServer
     {
-        public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
+        public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.AspNetCore.IOperationMessageListener>? listeners = null) { }
         protected GraphQL.IDocumentExecuter DocumentExecuter { get; }
         protected GraphQL.IGraphQLSerializer Serializer { get; }
         protected Microsoft.Extensions.DependencyInjection.IServiceScopeFactory ServiceScopeFactory { get; }
@@ -368,7 +372,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.SubscriptionsTransport
     }
     public class SubscriptionServer : GraphQL.Server.Transports.AspNetCore.WebSockets.BaseSubscriptionServer
     {
-        public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
+        public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null, System.Collections.Generic.IEnumerable<GraphQL.Server.Transports.AspNetCore.IOperationMessageListener>? listeners = null) { }
         protected GraphQL.IDocumentExecuter DocumentExecuter { get; }
         protected GraphQL.IGraphQLSerializer Serializer { get; }
         protected Microsoft.Extensions.DependencyInjection.IServiceScopeFactory ServiceScopeFactory { get; }


### PR DESCRIPTION
There was [`IOperationMessageListener`](https://github.com/graphql-dotnet/server/blob/v6/src/Transports.Subscriptions.Abstractions/IOperationMessageListener.cs) in v6 and some our code uses it. Now I need to migrate that code to the-latest-and-greatest v7. My main goal is to achieve the "old behavior" without inheriting from `GraphQLHttpMiddleware` on our side since it creates complexity (combinations) with our other code that inherits from `GraphQLHttpMiddleware` in other way. So I looked throught the code and tried to find the way to hook up into message execution in the most soft way.