### PR TITLE
Update samples and tests for .NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,10 @@ jobs:
           echo version=$version
           echo "version=$version" >> $GITHUB_ENV
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
           source-url: https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}
@@ -43,7 +42,7 @@ jobs:
       - name: Pack solution [Release]
         run: dotnet pack --no-restore --no-build -c Release -p:Version=$version -o out
       - name: Upload Nuget packages as workflow artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Nuget packages
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             2.1.x
@@ -49,6 +49,7 @@ jobs:
             5.0.x
             6.0.x
             7.0.x
+            8.0.x
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Tests.props
+++ b/Tests.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <SingleTestPlatform Condition="'$(SingleTestPlatform)' == ''">false</SingleTestPlatform>
-    <NoWarn>$(NoWarn);CS1591;CS1998;IDE0017;IDE0053;CA1707;CA1816;CA1822;CA1825;CA1835;CA1852;CA2201</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS1998;IDE0017;IDE0053;CA1707;CA1816;CA1822;CA1825;CA1835;CA1852;CA2201;CA1861</NoWarn>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -13,22 +13,25 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit" Version="2.6.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" Condition="'$(TargetFramework)' != 'netcoreapp2.1' AND '$(TargetFramework)' != 'netcoreapp3.1' AND '$(TargetFramework)' != 'net5.0'" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.*" Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.*" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.*" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.*" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.*" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.*" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.*" Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.*" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.*" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.*" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.*" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.*" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Samples.Authorization/Samples.Authorization.csproj
+++ b/samples/Samples.Authorization/Samples.Authorization.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.*">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/samples/Samples.Basic/Samples.Basic.csproj
+++ b/samples/Samples.Basic/Samples.Basic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Samples.Complex/Samples.Complex.csproj
+++ b/samples/Samples.Complex/Samples.Complex.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net7;net6;net5;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8;net6;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>GraphQL.Samples.Server</AssemblyName>
     <RootNamespace>GraphQL.Samples.Server</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/samples/Samples.Controller/Samples.Controller.csproj
+++ b/samples/Samples.Controller/Samples.Controller.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Samples.Cors/Samples.Cors.csproj
+++ b/samples/Samples.Cors/Samples.Cors.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Samples.EndpointRouting/Samples.EndpointRouting.csproj
+++ b/samples/Samples.EndpointRouting/Samples.EndpointRouting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Samples.Jwt/Samples.Jwt.csproj
+++ b/samples/Samples.Jwt/Samples.Jwt.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Samples.Jwt/Samples.Jwt.csproj
+++ b/samples/Samples.Jwt/Samples.Jwt.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Samples.MultipleSchemas/Samples.MultipleSchemas.csproj
+++ b/samples/Samples.MultipleSchemas/Samples.MultipleSchemas.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <WarningsNotAsErrors>CS8618</WarningsNotAsErrors>
   </PropertyGroup>
 

--- a/samples/Samples.Pages/Samples.Pages.csproj
+++ b/samples/Samples.Pages/Samples.Pages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
+++ b/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>Integration of GraphQL.NET validation subsystem into ASP.NET Core</Description>
     <PackageTags>GraphQL;authentication;authorization;validation</PackageTags>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Authorization.AspNetCore/AuthorizationVisitor.cs
+++ b/src/Authorization.AspNetCore/AuthorizationVisitor.cs
@@ -8,7 +8,7 @@ namespace GraphQL.Server.Authorization.AspNetCore;
 public partial class AuthorizationValidationRule
 {
     /// <inheritdoc/>
-    [Obsolete("This class has been replaced by GraphQL.Server.Transports.AspNetCore.AuthorizationValidationRule.AuthorizationVisitor and will be removed in v8.")]
+    [Obsolete("This class has been replaced by GraphQL.Server.Transports.AspNetCore.AuthorizationVisitor and will be removed in v8.")]
     public class AuthorizationVisitor : Transports.AspNetCore.AuthorizationVisitor
     {
         private readonly IAuthorizationErrorMessageBuilder _messageBuilder;

--- a/tests/ApiApprovalTests/ApiApprovalTests.csproj
+++ b/tests/ApiApprovalTests/ApiApprovalTests.csproj
@@ -2,11 +2,11 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
+    <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ApiApprovalTests/net50+netcoreapp31/GraphQL.Server.Authorization.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net50+netcoreapp31/GraphQL.Server.Authorization.AspNetCore.approved.txt
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
         protected virtual void AddValidationError(GraphQLParser.AST.ASTNode? node, GraphQL.Validation.ValidationContext context, GraphQLParser.AST.OperationType? operationType, Microsoft.AspNetCore.Authorization.AuthorizationResult result) { }
         public System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> ValidateAsync(GraphQL.Validation.ValidationContext context) { }
         [System.Obsolete("This class has been replaced by GraphQL.Server.Transports.AspNetCore.Authorizatio" +
-            "nValidationRule.AuthorizationVisitor and will be removed in v8.")]
+            "nVisitor and will be removed in v8.")]
         public class AuthorizationVisitor : GraphQL.Server.Transports.AspNetCore.AuthorizationVisitor
         {
             public AuthorizationVisitor(GraphQL.Validation.ValidationContext context, System.Security.Claims.ClaimsPrincipal claimsPrincipal, Microsoft.AspNetCore.Authorization.IAuthorizationService authorizationService, GraphQL.Server.Authorization.AspNetCore.IAuthorizationErrorMessageBuilder authorizationErrorMessageBuilder, GraphQL.Server.Authorization.AspNetCore.AuthorizationValidationRule authorizationValidationRule) { }

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Authorization.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Authorization.AspNetCore.approved.txt
@@ -16,7 +16,7 @@ namespace GraphQL.Server.Authorization.AspNetCore
         protected virtual void AddValidationError(GraphQLParser.AST.ASTNode? node, GraphQL.Validation.ValidationContext context, GraphQLParser.AST.OperationType? operationType, Microsoft.AspNetCore.Authorization.AuthorizationResult result) { }
         public System.Threading.Tasks.ValueTask<GraphQL.Validation.INodeVisitor?> ValidateAsync(GraphQL.Validation.ValidationContext context) { }
         [System.Obsolete("This class has been replaced by GraphQL.Server.Transports.AspNetCore.Authorizatio" +
-            "nValidationRule.AuthorizationVisitor and will be removed in v8.")]
+            "nVisitor and will be removed in v8.")]
         public class AuthorizationVisitor : GraphQL.Server.Transports.AspNetCore.AuthorizationVisitor
         {
             public AuthorizationVisitor(GraphQL.Validation.ValidationContext context, System.Security.Claims.ClaimsPrincipal claimsPrincipal, Microsoft.AspNetCore.Authorization.IAuthorizationService authorizationService, GraphQL.Server.Authorization.AspNetCore.IAuthorizationErrorMessageBuilder authorizationErrorMessageBuilder, GraphQL.Server.Authorization.AspNetCore.AuthorizationValidationRule authorizationValidationRule) { }

--- a/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
+++ b/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\..\src\Authorization.AspNetCore\Authorization.AspNetCore.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.*" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.*" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.*" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.*" Condition="'$(TargetFramework)' == 'net5.0'" />

--- a/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
+++ b/tests/Authorization.AspNetCore.Tests/Authorization.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>

--- a/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
+++ b/tests/Authorization.AspNetCore.Tests/AuthorizationValidationRuleTests.cs
@@ -313,7 +313,7 @@ public class AuthorizationValidationRuleTests : ValidationTestBase
         });
     }
 
-    private static ISchema BasicSchema<T>()
+    private static Schema BasicSchema<T>()
     {
         string defs = """
             type Query {
@@ -347,7 +347,7 @@ public class AuthorizationValidationRuleTests : ValidationTestBase
         public string Post { get; set; } = "";
     }
 
-    private ISchema NestedSchema()
+    private Schema NestedSchema()
     {
         string defs = """
             type Query {
@@ -398,7 +398,7 @@ public class AuthorizationValidationRuleTests : ValidationTestBase
         public string Name { get; set; }
     }
 
-    private ISchema TypedSchema()
+    private Schema TypedSchema()
     {
         var query = new ObjectGraphType();
 

--- a/tests/Authorization.AspNetCore.Tests/ValidationTestBase.cs
+++ b/tests/Authorization.AspNetCore.Tests/ValidationTestBase.cs
@@ -29,14 +29,14 @@ public class ValidationTestBase : IDisposable
         config.Rules.Add(Rule);
         configure(config);
 
-        config.Rules.Any().ShouldBeTrue("Must provide at least one rule to validate against.");
+        config.Rules.ShouldNotBeEmpty("Must provide at least one rule to validate against.");
 
         config.Schema.Initialize();
 
         var result = Validate(config);
 
         string message = "";
-        if (result.Errors?.Any() == true)
+        if (result.Errors?.Count > 0)
         {
             message = string.Join(", ", result.Errors.Select(x => x.Message));
         }
@@ -51,7 +51,7 @@ public class ValidationTestBase : IDisposable
         config.User = CreatePrincipal();
         configure(config);
 
-        config.Rules.Any().ShouldBeTrue("Must provide at least one rule to validate against.");
+        config.Rules.ShouldNotBeEmpty("Must provide at least one rule to validate against.");
 
         config.Schema.Initialize();
 

--- a/tests/Samples.Authorization.Tests/Samples.Authorization.Tests.csproj
+++ b/tests/Samples.Authorization.Tests/Samples.Authorization.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>End to end tests for the Samples.Authorization project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.AzureFunctions.Tests/EndToEndTests.cs
+++ b/tests/Samples.AzureFunctions.Tests/EndToEndTests.cs
@@ -17,7 +17,7 @@ public class EndToEndTests
         {
             request.Method = "GET";
             request.QueryString = new QueryString("?query={count}");
-        }, GraphQL.RunGraphQL).ConfigureAwait(false);
+        }, GraphQL.RunGraphQL);
 
         statusCode.ShouldBe(200);
         contentType.ShouldBe("application/graphql-response+json; charset=utf-8");
@@ -32,7 +32,7 @@ public class EndToEndTests
             request.Method = "POST";
             request.ContentType = "application/json";
             request.Body = new MemoryStream(Encoding.UTF8.GetBytes("""{"query":"{count}"}"""));
-        }, GraphQL.RunGraphQL).ConfigureAwait(false);
+        }, GraphQL.RunGraphQL);
 
         statusCode.ShouldBe(200);
         contentType.ShouldBe("application/graphql-response+json; charset=utf-8");
@@ -45,7 +45,7 @@ public class EndToEndTests
         var (statusCode, contentType, body) = await ExecuteRequest(request =>
         {
             request.Method = "GET";
-        }, GraphQL.RunPlayground).ConfigureAwait(false);
+        }, GraphQL.RunPlayground);
 
         statusCode.ShouldBe(200);
         contentType.ShouldBe("text/html");

--- a/tests/Samples.Basic.Tests/Samples.Basic.Tests.csproj
+++ b/tests/Samples.Basic.Tests/Samples.Basic.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>End to end tests for the Samples.Basic project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.Complex.Tests/Samples.Complex.Tests.csproj
+++ b/tests/Samples.Complex.Tests/Samples.Complex.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
     <Description>End to end tests for Samples.Server project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.Complex.Tests/Serializer.cs
+++ b/tests/Samples.Complex.Tests/Serializer.cs
@@ -15,11 +15,9 @@ internal static class Serializer
     internal static string ToJson(GraphQLRequest[] requests)
         => ToJson(Array.ConvertAll(requests, r => r.ToDictionary()));
 
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new() { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull };
     public static string ToJson(object obj)
-        => JsonSerializer.Serialize(obj, new JsonSerializerOptions
-        {
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-        });
+        => JsonSerializer.Serialize(obj, _jsonSerializerOptions);
 
     internal static FormUrlEncodedContent ToFormUrlEncodedContent(GraphQLRequest request)
     {

--- a/tests/Samples.Controller.Tests/Samples.Controller.Tests.csproj
+++ b/tests/Samples.Controller.Tests/Samples.Controller.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>End to end tests for the Samples.Controller project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.Cors.Tests/Samples.Cors.Tests.csproj
+++ b/tests/Samples.Cors.Tests/Samples.Cors.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>End to end tests for the Samples.Cors project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.EndpointRouting.Tests/Samples.EndpointRouting.Tests.csproj
+++ b/tests/Samples.EndpointRouting.Tests/Samples.EndpointRouting.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>End to end tests for the Samples.EndpointRouting project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.Jwt.Tests/Samples.Jwt.Tests.csproj
+++ b/tests/Samples.Jwt.Tests/Samples.Jwt.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>End to end tests for the Samples.Jwt project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.MultipleSchemas.Tests/Samples.MultipleSchemas.Tests.csproj
+++ b/tests/Samples.MultipleSchemas.Tests/Samples.MultipleSchemas.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>End to end tests for the Samples.MultipleSchemas project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.Pages.Tests/Samples.Pages.Tests.csproj
+++ b/tests/Samples.Pages.Tests/Samples.Pages.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>End to end tests for the Samples.Pages project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.Tests/Samples.Tests.csproj
+++ b/tests/Samples.Tests/Samples.Tests.csproj
@@ -2,11 +2,11 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>net7.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netcoreapp2.1</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">
-    <TargetFrameworks>net7.0;netcoreapp2.1;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netcoreapp2.1;net48</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup>

--- a/tests/Samples.Tests/WebSocketExtensions.cs
+++ b/tests/Samples.Tests/WebSocketExtensions.cs
@@ -1,7 +1,6 @@
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
-using GraphQL;
 using GraphQL.SystemTextJson;
 using GraphQL.Transport;
 #if NET48
@@ -15,7 +14,7 @@ namespace Samples.Tests;
 
 public static class WebSocketExtensions
 {
-    private static readonly IGraphQLTextSerializer _serializer = new GraphQLSerializer();
+    private static readonly GraphQLSerializer _serializer = new();
 
     public static Task SendMessageAsync(this WebSocket socket, OperationMessage message)
         => SendStringAsync(socket, _serializer.Serialize(message));

--- a/tests/Transports.AspNetCore.Tests/AuthorizationTests.cs
+++ b/tests/Transports.AspNetCore.Tests/AuthorizationTests.cs
@@ -591,7 +591,7 @@ public class AuthorizationTests : IDisposable
     }
 
     [Fact]
-    public void NullIdentity()
+    public async Task NullIdentity()
     {
         var mockAuthorizationService = new Mock<IAuthorizationService>(MockBehavior.Strict);
         var mockServices = new Mock<IServiceProvider>(MockBehavior.Strict);
@@ -600,7 +600,7 @@ public class AuthorizationTests : IDisposable
         var validator = new DocumentValidator();
         _schema.Authorize();
 
-        var (result, _) = validator.ValidateAsync(new ValidationOptions
+        var (result, _) = await validator.ValidateAsync(new ValidationOptions
         {
             Document = document,
             Extensions = Inputs.Empty,
@@ -611,7 +611,7 @@ public class AuthorizationTests : IDisposable
             Variables = Inputs.Empty,
             RequestServices = mockServices.Object,
             User = new ClaimsPrincipal(),
-        }).GetAwaiter().GetResult(); // there is no async code being tested
+        });
 
         result.Errors.ShouldHaveSingleItem().ShouldBeOfType<AccessDeniedError>().Message.ShouldBe("Access denied for schema.");
     }
@@ -681,7 +681,7 @@ public class AuthorizationTests : IDisposable
     [InlineData("{ parent { child(invalid: true) } }", null, true)]
     [InlineData("query { ...frag1 }", null, true)]
     [InlineData("query { ...frag1 } fragment frag1 on QueryType { ...frag1 }", null, true)]
-    public void TestDefective(string query, string variables, bool expectedIsValid)
+    public void TestDefective(string query, string? variables, bool expectedIsValid)
     {
         _query.AddField(new FieldType { Name = "test", Type = typeof(StringGraphType) }).Authorize();
 

--- a/tests/Transports.AspNetCore.Tests/ChatTests.cs
+++ b/tests/Transports.AspNetCore.Tests/ChatTests.cs
@@ -12,7 +12,7 @@ public class ChatTests : IDisposable
         _app = new(ConfigureBuilder());
     }
 
-    private IWebHostBuilder ConfigureBuilder()
+    private WebHostBuilder ConfigureBuilder()
     {
         var hostBuilder = new WebHostBuilder();
         hostBuilder.ConfigureServices(services =>

--- a/tests/Transports.AspNetCore.Tests/Middleware/AuthorizationTests.cs
+++ b/tests/Transports.AspNetCore.Tests/Middleware/AuthorizationTests.cs
@@ -29,6 +29,7 @@ public class AuthorizationTests : IDisposable
                 .AddAutoSchema<Chat.Query>()
                 .AddErrorInfoProvider(new CustomErrorInfoProvider(this))
                 .AddSystemTextJson());
+            services.AddRouting();
             services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddJwtBearer(options =>
                 {

--- a/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
+++ b/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
@@ -2,15 +2,15 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">
-    <TargetFrameworks>net48;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net48;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$(SingleTestPlatform)' == 'true'">
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Transports.AspNetCore.Tests/WebSocketExtensions.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSocketExtensions.cs
@@ -11,7 +11,7 @@ namespace Tests;
 
 public static class WebSocketExtensions
 {
-    private static readonly IGraphQLTextSerializer _serializer = new GraphQLSerializer();
+    private static readonly GraphQLSerializer _serializer = new GraphQLSerializer();
 
     public static Task SendMessageAsync(this WebSocket socket, OperationMessage message)
         => SendStringAsync(socket, _serializer.Serialize(message));

--- a/tests/Transports.AspNetCore.Tests/WebSockets/NewSubscriptionServerTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/NewSubscriptionServerTests.cs
@@ -232,7 +232,7 @@ public class NewSubscriptionServerTests : IDisposable
     [InlineData("abc")]
     [InlineData("")]
     [InlineData(null)]
-    public async Task OnSubscribe(string id)
+    public async Task OnSubscribe(string? id)
     {
         var message = new OperationMessage() { Id = id };
         _mockServer.Protected().Setup<Task>("OnSubscribeAsync", message).CallBase().Verifiable();
@@ -248,7 +248,7 @@ public class NewSubscriptionServerTests : IDisposable
     [InlineData("abc")]
     [InlineData("")]
     [InlineData(null)]
-    public async Task OnComplete(string id)
+    public async Task OnComplete(string? id)
     {
         var message = new OperationMessage() { Id = id };
         _mockServer.Protected().Setup<Task>("OnCompleteAsync", message).CallBase().Verifiable();

--- a/tests/Transports.AspNetCore.Tests/WebSockets/OldSubscriptionServerTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/OldSubscriptionServerTests.cs
@@ -190,7 +190,7 @@ public class OldSubscriptionServerTests : IDisposable
     [InlineData("abc")]
     [InlineData("")]
     [InlineData(null)]
-    public async Task OnStart(string id)
+    public async Task OnStart(string? id)
     {
         var message = new OperationMessage() { Id = id };
         _mockServer.Protected().Setup<Task>("OnStartAsync", message).CallBase().Verifiable();
@@ -206,7 +206,7 @@ public class OldSubscriptionServerTests : IDisposable
     [InlineData("abc")]
     [InlineData("")]
     [InlineData(null)]
-    public async Task OnStop(string id)
+    public async Task OnStop(string? id)
     {
         var message = new OperationMessage() { Id = id };
         _mockServer.Protected().Setup<Task>("OnStopAsync", message).CallBase().Verifiable();


### PR DESCRIPTION
- Sample and test projects now target .NET 8
- Test project dependencies are updated to work with .NET 8
- Minor code changes to tests to fix new .NET 8 SDK analyzer violations
- Patch for https://github.com/dotnet/aspnetcore/issues/53332 within a test
- Fixed existing obsolete description.
- Update CI workflows to install/use the .NET 8 SDK
- No changes at all to main library.