### PR TITLE
Respect the configured serializer in Ui.Playground

### DIFF
--- a/src/Ui.Playground/PlaygroundMiddleware.cs
+++ b/src/Ui.Playground/PlaygroundMiddleware.cs
@@ -39,7 +39,7 @@ public class PlaygroundMiddleware
         httpContext.Response.ContentType = "text/html";
         httpContext.Response.StatusCode = 200;
 
-        _pageModel ??= new PlaygroundPageModel(_options);
+        _pageModel ??= new PlaygroundPageModel(_options, httpContext.RequestServices);
 
         byte[] data = Encoding.UTF8.GetBytes(_pageModel.Render());
         return httpContext.Response.Body.WriteAsync(data, 0, data.Length);

--- a/src/Ui.Playground/Ui.Playground.csproj
+++ b/src/Ui.Playground/Ui.Playground.csproj
@@ -10,6 +10,10 @@
     <EmbeddedResource Include="Internal\playground.cshtml" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="GraphQL" Version="$(GraphQLVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>


### PR DESCRIPTION
This should allow using AOT with Ui.Playground, but adds an extra dependency to `GraphQL`.