### PR TITLE
Add CSRF protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,31 @@ app.UseEndpoints(endpoints =>
 await app.RunAsync();
 ```
 
+In order to ensure that all requests trigger CORS preflight requests, by default the server
+will reject requests that do not meet one of the following criteria:
+
+- The request is a POST request that includes a Content-Type header that is not
+  `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`.
+- The request includes a non-empty `GraphQL-Require-Preflight` header.
+
+To disable this behavior, set the `CsrfProtectionEnabled` option to `false` in the `GraphQLServerOptions`.
+
+```csharp
+app.UseGraphQL("/graphql", config =>
+{
+    config.CsrfProtectionEnabled = false;
+});
+```
+
+You may also change the allowed headers by modifying the `CsrfProtectionHeaders` option.
+
+```csharp
+app.UseGraphQL("/graphql", config =>
+{
+    config.CsrfProtectionHeaders = ["MyCustomHeader"];
+});
+```
+
 ### Response compression
 
 ASP.NET Core supports response compression independently of GraphQL, with brotli and gzip
@@ -660,6 +685,8 @@ methods allowing for different options for each configured endpoint.
 | `AuthorizationRequired`            | Requires `HttpContext.User` to represent an authenticated user. | False |
 | `AuthorizedPolicy`                 | If set, requires `HttpContext.User` to pass authorization of the specified policy. | |
 | `AuthorizedRoles`                  | If set, requires `HttpContext.User` to be a member of any one of a list of roles. | |
+| `CsrfProtectionEnabled`            | Enables cross-site request forgery (CSRF) protection for both GET and POST requests. | True |
+| `CsrfProtectionHeaders`            | Sets the headers used for CSRF protection when necessary. | `GraphQL-Require-Preflight` |
 | `DefaultResponseContentType`       | Sets the default response content type used within responses. | `application/graphql-response+json; charset=utf-8` |
 | `EnableBatchedRequests`            | Enables handling of batched GraphQL requests for POST requests when formatted as JSON. | True |
 | `ExecuteBatchedRequestsInParallel` | Enables parallel execution of batched GraphQL requests. | True |

--- a/docs/migration/migration8.md
+++ b/docs/migration/migration8.md
@@ -4,6 +4,8 @@
 
 - When using `FormFileGraphType` with type-first schemas, you may specify the allowed media
   types for the file by using the new `[MediaType]` attribute on the argument or input object field.
+- Cross-site request forgery (CSRF) protection has been added for both GET and POST requests,
+  enabled by default.
 
 ## Breaking changes
 
@@ -11,6 +13,11 @@
   GraphQL.NET library.  Please see the GraphQL.NET v8 migration document for more information.
 - The obsolete (v6 and prior) authorization validation rule has been removed.  See the v7 migration
   document for more information on how to migrate to the v7/v8 authorization validation rule.
+- Cross-site request forgery (CSRF) protection has been enabled for all requests by default.
+  This will require that the `GraphQL-Require-Preflight` header be sent with all GET requests and
+  all form-POST requests.  To disable this feature, set the `CsrfProtectionEnabled` property on the
+  `GraphQLMiddlewareOptions` class to `false`.  You may also configure the headers list by modifying
+  the `CsrfProtectionHeaders` property on the same class.  See the readme for more details.
 
 ## Other changes
 

--- a/src/Transports.AspNetCore/Errors/CsrfProtectionError.cs
+++ b/src/Transports.AspNetCore/Errors/CsrfProtectionError.cs
@@ -1,0 +1,16 @@
+namespace GraphQL.Server.Transports.AspNetCore.Errors;
+
+/// <summary>
+/// Represents an error indicating that the JSON provided could not be parsed.
+/// </summary>
+public class CsrfProtectionError : RequestError
+{
+    /// <inheritdoc cref="CsrfProtectionError"/>
+    public CsrfProtectionError(IEnumerable<string> headersRequired) : base($"This request requires a non-empty header from the following list: {FormatHeaders(headersRequired)}.") { }
+
+    /// <inheritdoc cref="CsrfProtectionError"/>
+    public CsrfProtectionError(IEnumerable<string> headersRequired, Exception innerException) : base($"This request requires a non-empty header from the following list: {FormatHeaders(headersRequired)}. {innerException.Message}") { }
+
+    private static string FormatHeaders(IEnumerable<string> headersRequired)
+        => string.Join(", ", headersRequired.Select(x => $"'{x}'"));
+}

--- a/src/Transports.AspNetCore/Errors/CsrfProtectionError.cs
+++ b/src/Transports.AspNetCore/Errors/CsrfProtectionError.cs
@@ -1,7 +1,7 @@
 namespace GraphQL.Server.Transports.AspNetCore.Errors;
 
 /// <summary>
-/// Represents an error indicating that the JSON provided could not be parsed.
+/// Represents an error indicating that the request may not have triggered a CORS preflight request.
 /// </summary>
 public class CsrfProtectionError : RequestError
 {

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -497,7 +497,7 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
         if (!_options.CsrfProtectionEnabled)
             return false;
         if (context.Request.Headers.TryGetValue("Content-Type", out var contentType) && contentType.Count > 0
-            && (contentType[0] == "text/plain" || contentType[0] == "application/x-www-form-urlencoded" || contentType[0] == "multipart/form-data"))
+            && !(contentType[0] == "text/plain" || contentType[0] == "application/x-www-form-urlencoded" || contentType[0] == "multipart/form-data"))
             return false;
         foreach (var header in _options.CsrfProtectionHeaders)
         {

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -496,9 +496,17 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     {
         if (!_options.CsrfProtectionEnabled)
             return false;
-        if (context.Request.Headers.TryGetValue("Content-Type", out var contentType) && contentType.Count > 0
-            && !(contentType[0] == "text/plain" || contentType[0] == "application/x-www-form-urlencoded" || contentType[0] == "multipart/form-data"))
-            return false;
+        if (context.Request.Headers.TryGetValue("Content-Type", out var contentTypes) && contentTypes.Count > 0 && contentTypes[0] != null)
+        {
+            var contentType = contentTypes[0]!;
+            if (contentType.IndexOf(';') > 0)
+            {
+                contentType = contentType.Substring(0, contentType.IndexOf(';'));
+            }
+            contentType = contentType.Trim().ToLowerInvariant();
+            if (!(contentType == "text/plain" || contentType == "application/x-www-form-urlencoded" || contentType == "multipart/form-data"))
+                return false;
+        }
         foreach (var header in _options.CsrfProtectionHeaders)
         {
             if (context.Request.Headers.TryGetValue(header, out var values) && values.Count > 0 && values[0]?.Length > 0)

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -142,6 +142,10 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
             return;
         }
 
+        // Perform CSRF protection if necessary
+        if (await HandleCsrfProtectionAsync(context, next))
+            return;
+
         // Authenticate request if necessary
         if (await HandleAuthorizeAsync(context, next))
             return;
@@ -484,7 +488,28 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     }
 
     /// <summary>
-    /// Perform authentication, if required, and return <see langword="true"/> if the
+    /// Performs CSRF protection, if required, and returns <see langword="true"/> if the
+    /// request was handled (typically by returning an error message).  If <see langword="false"/>
+    /// is returned, the request is processed normally.
+    /// </summary>
+    protected virtual async ValueTask<bool> HandleCsrfProtectionAsync(HttpContext context, RequestDelegate next)
+    {
+        if (!_options.CsrfProtectionEnabled)
+            return false;
+        if (context.Request.Headers.TryGetValue("Content-Type", out var contentType) && contentType.Count > 0
+            && (contentType[0] == "text/plain" || contentType[0] == "application/x-www-form-urlencoded" || contentType[0] == "multipart/form-data"))
+            return false;
+        foreach (var header in _options.CsrfProtectionHeaders)
+        {
+            if (context.Request.Headers.TryGetValue(header, out var values) && values.Count > 0 && values[0]?.Length > 0)
+                return false;
+        }
+        await HandleCsrfProtectionErrorAsync(context, next);
+        return true;
+    }
+
+    /// <summary>
+    /// Perform authentication, if required, and returns <see langword="true"/> if the
     /// request was handled (typically by returning an error message).  If <see langword="false"/>
     /// is returned, the request is processed normally.
     /// </summary>
@@ -1034,21 +1059,29 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     /// </summary>
     protected virtual async ValueTask<bool> HandleDeserializationErrorAsync(HttpContext context, RequestDelegate next, Exception exception)
     {
-        await WriteErrorResponseAsync(context, HttpStatusCode.BadRequest, new JsonInvalidError(exception));
+        await WriteErrorResponseAsync(context, new JsonInvalidError(exception));
         return true;
+    }
+
+    /// <summary>
+    /// Writes a '.' message to the output.
+    /// </summary>
+    protected virtual async Task HandleCsrfProtectionErrorAsync(HttpContext context, RequestDelegate next)
+    {
+        await WriteErrorResponseAsync(context, new CsrfProtectionError(_options.CsrfProtectionHeaders));
     }
 
     /// <summary>
     /// Writes a '400 Batched requests are not supported.' message to the output.
     /// </summary>
     protected virtual Task HandleBatchedRequestsNotSupportedAsync(HttpContext context, RequestDelegate next)
-        => WriteErrorResponseAsync(context, HttpStatusCode.BadRequest, new BatchedRequestsNotSupportedError());
+        => WriteErrorResponseAsync(context, new BatchedRequestsNotSupportedError());
 
     /// <summary>
     /// Writes a '400 Invalid requested WebSocket sub-protocol(s).' message to the output.
     /// </summary>
     protected virtual Task HandleWebSocketSubProtocolNotSupportedAsync(HttpContext context, RequestDelegate next)
-        => WriteErrorResponseAsync(context, HttpStatusCode.BadRequest, new WebSocketSubProtocolNotSupportedError(context.WebSockets.WebSocketRequestedProtocols));
+        => WriteErrorResponseAsync(context, new WebSocketSubProtocolNotSupportedError(context.WebSockets.WebSocketRequestedProtocols));
 
     /// <summary>
     /// Writes a '415 Invalid Content-Type header: could not be parsed.' message to the output.
@@ -1078,6 +1111,12 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
         //return WriteErrorResponseAsync(context, $"Invalid HTTP method.{(Options.HandleGet || Options.HandlePost ? $" Only {(Options.HandleGet && Options.HandlePost ? "GET and POST are" : Options.HandleGet ? "GET is" : "POST is")} supported." : "")}", HttpStatusCode.MethodNotAllowed);
         return next(context);
     }
+
+    /// <summary>
+    /// Writes the specified error as a JSON-formatted GraphQL response.
+    /// </summary>
+    protected virtual Task WriteErrorResponseAsync(HttpContext context, ExecutionError executionError)
+        => WriteErrorResponseAsync(context, executionError is IHasPreferredStatusCode withCode ? withCode.PreferredStatusCode : HttpStatusCode.BadRequest, executionError);
 
     /// <summary>
     /// Writes the specified error message as a JSON-formatted GraphQL response, with the specified HTTP status code.

--- a/src/Transports.AspNetCore/GraphQLHttpMiddlewareOptions.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddlewareOptions.cs
@@ -71,6 +71,22 @@ public class GraphQLHttpMiddlewareOptions : IAuthorizationOptions
     public bool ReadFormOnPost { get; set; } = true; // TODO: change to false for v9
 
     /// <summary>
+    /// Enables cross-site request forgery (CSRF) protection for both GET and POST requests.
+    /// Requires a non-empty header from the <see cref="CsrfProtectionHeaders"/> list to be
+    /// present, or a POST request with a Content-Type header that is not <c>text/plain</c>,
+    /// <c>application/x-www-form-urlencoded</c>, or <c>multipart/form-data</c>.
+    /// </summary>
+    public bool CsrfProtectionEnabled { get; set; } = true;
+
+    /// <summary>
+    /// When <see cref="CsrfProtectionEnabled"/> is enabled, requests require a non-empty
+    /// header from this list or a POST request with a Content-Type header that is not
+    /// <c>text/plain</c>, <c>application/x-www-form-urlencoded</c>, or <c>multipart/form-data</c>.
+    /// Defaults to <c>GraphQL-Require-Preflight</c>.
+    /// </summary>
+    public List<string> CsrfProtectionHeaders { get; set; } = ["GraphQL-Require-Preflight"]; // see https://github.com/graphql/graphql-over-http/pull/303
+
+    /// <summary>
     /// Enables reading variables from the query string.
     /// Variables are interpreted as JSON and deserialized before being
     /// provided to the <see cref="IDocumentExecuter"/>.

--- a/tests/ApiApprovalTests/net50+net60+net80/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net50+net60+net80/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -99,6 +99,8 @@ namespace GraphQL.Server.Transports.AspNetCore
         protected virtual System.Threading.Tasks.Task HandleBatchRequestAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?> gqlRequests) { }
         protected virtual System.Threading.Tasks.Task HandleBatchedRequestsNotSupportedAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleContentTypeCouldNotBeParsedErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
+        protected virtual System.Threading.Tasks.ValueTask<bool> HandleCsrfProtectionAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
+        protected virtual System.Threading.Tasks.Task HandleCsrfProtectionErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.ValueTask<bool> HandleDeserializationErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, System.Exception exception) { }
         protected virtual System.Threading.Tasks.Task HandleInvalidContentTypeErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleInvalidHttpMethodErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
@@ -115,6 +117,7 @@ namespace GraphQL.Server.Transports.AspNetCore
                 "BatchRequest"})]
         protected virtual System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Transport.GraphQLRequest?, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?>?>?> ReadPostContentAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding) { }
         protected virtual string SelectResponseContentType(Microsoft.AspNetCore.Http.HttpContext context) { }
+        protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, string errorMessage) { }
         protected virtual System.Threading.Tasks.Task WriteJsonResponseAsync<TResult>(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, TResult result) { }
@@ -126,6 +129,8 @@ namespace GraphQL.Server.Transports.AspNetCore
         public bool AuthorizationRequired { get; set; }
         public string? AuthorizedPolicy { get; set; }
         public System.Collections.Generic.List<string> AuthorizedRoles { get; set; }
+        public bool CsrfProtectionEnabled { get; set; }
+        public System.Collections.Generic.List<string> CsrfProtectionHeaders { get; set; }
         public Microsoft.Net.Http.Headers.MediaTypeHeaderValue DefaultResponseContentType { get; set; }
         public bool EnableBatchedRequests { get; set; }
         public bool ExecuteBatchedRequestsInParallel { get; set; }
@@ -192,6 +197,11 @@ namespace GraphQL.Server.Transports.AspNetCore.Errors
     public class BatchedRequestsNotSupportedError : GraphQL.Execution.RequestError
     {
         public BatchedRequestsNotSupportedError() { }
+    }
+    public class CsrfProtectionError : GraphQL.Execution.RequestError
+    {
+        public CsrfProtectionError(System.Collections.Generic.IEnumerable<string> headersRequired) { }
+        public CsrfProtectionError(System.Collections.Generic.IEnumerable<string> headersRequired, System.Exception innerException) { }
     }
     public class FileCountExceededError : GraphQL.Execution.RequestError, GraphQL.Server.Transports.AspNetCore.Errors.IHasPreferredStatusCode
     {

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -106,6 +106,8 @@ namespace GraphQL.Server.Transports.AspNetCore
         protected virtual System.Threading.Tasks.Task HandleBatchRequestAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?> gqlRequests) { }
         protected virtual System.Threading.Tasks.Task HandleBatchedRequestsNotSupportedAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleContentTypeCouldNotBeParsedErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
+        protected virtual System.Threading.Tasks.ValueTask<bool> HandleCsrfProtectionAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
+        protected virtual System.Threading.Tasks.Task HandleCsrfProtectionErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.ValueTask<bool> HandleDeserializationErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, System.Exception exception) { }
         protected virtual System.Threading.Tasks.Task HandleInvalidContentTypeErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleInvalidHttpMethodErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
@@ -122,6 +124,7 @@ namespace GraphQL.Server.Transports.AspNetCore
                 "BatchRequest"})]
         protected virtual System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Transport.GraphQLRequest?, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?>?>?> ReadPostContentAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding) { }
         protected virtual string SelectResponseContentType(Microsoft.AspNetCore.Http.HttpContext context) { }
+        protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, string errorMessage) { }
         protected virtual System.Threading.Tasks.Task WriteJsonResponseAsync<TResult>(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, TResult result) { }
@@ -133,6 +136,8 @@ namespace GraphQL.Server.Transports.AspNetCore
         public bool AuthorizationRequired { get; set; }
         public string? AuthorizedPolicy { get; set; }
         public System.Collections.Generic.List<string> AuthorizedRoles { get; set; }
+        public bool CsrfProtectionEnabled { get; set; }
+        public System.Collections.Generic.List<string> CsrfProtectionHeaders { get; set; }
         public Microsoft.Net.Http.Headers.MediaTypeHeaderValue DefaultResponseContentType { get; set; }
         public bool EnableBatchedRequests { get; set; }
         public bool ExecuteBatchedRequestsInParallel { get; set; }
@@ -210,6 +215,11 @@ namespace GraphQL.Server.Transports.AspNetCore.Errors
     public class BatchedRequestsNotSupportedError : GraphQL.Execution.RequestError
     {
         public BatchedRequestsNotSupportedError() { }
+    }
+    public class CsrfProtectionError : GraphQL.Execution.RequestError
+    {
+        public CsrfProtectionError(System.Collections.Generic.IEnumerable<string> headersRequired) { }
+        public CsrfProtectionError(System.Collections.Generic.IEnumerable<string> headersRequired, System.Exception innerException) { }
     }
     public class FileCountExceededError : GraphQL.Execution.RequestError, GraphQL.Server.Transports.AspNetCore.Errors.IHasPreferredStatusCode
     {

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -99,6 +99,8 @@ namespace GraphQL.Server.Transports.AspNetCore
         protected virtual System.Threading.Tasks.Task HandleBatchRequestAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?> gqlRequests) { }
         protected virtual System.Threading.Tasks.Task HandleBatchedRequestsNotSupportedAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleContentTypeCouldNotBeParsedErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
+        protected virtual System.Threading.Tasks.ValueTask<bool> HandleCsrfProtectionAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
+        protected virtual System.Threading.Tasks.Task HandleCsrfProtectionErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.ValueTask<bool> HandleDeserializationErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, System.Exception exception) { }
         protected virtual System.Threading.Tasks.Task HandleInvalidContentTypeErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
         protected virtual System.Threading.Tasks.Task HandleInvalidHttpMethodErrorAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next) { }
@@ -115,6 +117,7 @@ namespace GraphQL.Server.Transports.AspNetCore
                 "BatchRequest"})]
         protected virtual System.Threading.Tasks.Task<System.ValueTuple<GraphQL.Transport.GraphQLRequest?, System.Collections.Generic.IList<GraphQL.Transport.GraphQLRequest?>?>?> ReadPostContentAsync(Microsoft.AspNetCore.Http.HttpContext context, Microsoft.AspNetCore.Http.RequestDelegate next, string? mediaType, System.Text.Encoding? sourceEncoding) { }
         protected virtual string SelectResponseContentType(Microsoft.AspNetCore.Http.HttpContext context) { }
+        protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, GraphQL.ExecutionError executionError) { }
         protected virtual System.Threading.Tasks.Task WriteErrorResponseAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, string errorMessage) { }
         protected virtual System.Threading.Tasks.Task WriteJsonResponseAsync<TResult>(Microsoft.AspNetCore.Http.HttpContext context, System.Net.HttpStatusCode httpStatusCode, TResult result) { }
@@ -126,6 +129,8 @@ namespace GraphQL.Server.Transports.AspNetCore
         public bool AuthorizationRequired { get; set; }
         public string? AuthorizedPolicy { get; set; }
         public System.Collections.Generic.List<string> AuthorizedRoles { get; set; }
+        public bool CsrfProtectionEnabled { get; set; }
+        public System.Collections.Generic.List<string> CsrfProtectionHeaders { get; set; }
         public Microsoft.Net.Http.Headers.MediaTypeHeaderValue DefaultResponseContentType { get; set; }
         public bool EnableBatchedRequests { get; set; }
         public bool ExecuteBatchedRequestsInParallel { get; set; }
@@ -192,6 +197,11 @@ namespace GraphQL.Server.Transports.AspNetCore.Errors
     public class BatchedRequestsNotSupportedError : GraphQL.Execution.RequestError
     {
         public BatchedRequestsNotSupportedError() { }
+    }
+    public class CsrfProtectionError : GraphQL.Execution.RequestError
+    {
+        public CsrfProtectionError(System.Collections.Generic.IEnumerable<string> headersRequired) { }
+        public CsrfProtectionError(System.Collections.Generic.IEnumerable<string> headersRequired, System.Exception innerException) { }
     }
     public class FileCountExceededError : GraphQL.Execution.RequestError, GraphQL.Server.Transports.AspNetCore.Errors.IHasPreferredStatusCode
     {

--- a/tests/Samples.AzureFunctions.Tests/EndToEndTests.cs
+++ b/tests/Samples.AzureFunctions.Tests/EndToEndTests.cs
@@ -17,6 +17,7 @@ public class EndToEndTests
         {
             request.Method = "GET";
             request.QueryString = new QueryString("?query={count}");
+            request.Headers.Add("GraphQL-Require-Preflight", "true");
         }, GraphQL.RunGraphQL);
 
         statusCode.ShouldBe(200);

--- a/tests/Samples.Tests/TestServerExtensions.cs
+++ b/tests/Samples.Tests/TestServerExtensions.cs
@@ -36,6 +36,7 @@ public static class TestServerExtensions
     {
         using var client = server.CreateClient();
         using var request = new HttpRequestMessage(HttpMethod.Get, url + "?query=" + Uri.EscapeDataString(query));
+        request.Headers.Add("GraphQL-Require-Preflight", "true");
         if (jwtToken != null)
             request.Headers.Authorization = new("Bearer", jwtToken);
         using var response = await client.SendAsync(request);

--- a/tests/Samples.Upload.Tests/EndToEndTests.cs
+++ b/tests/Samples.Upload.Tests/EndToEndTests.cs
@@ -67,6 +67,7 @@ public class EndToEndTests
         form.Add(triangleContent, "file0", "hello-world.txt");
         using var request = new HttpRequestMessage(HttpMethod.Post, "/graphql");
         request.Content = form;
+        request.Headers.Add("GraphQL-Require-Preflight", "true");
         using var response = await client.SendAsync(request);
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
         var ret = await response.Content.ReadAsStringAsync();

--- a/tests/Samples.Upload.Tests/EndToEndTests.cs
+++ b/tests/Samples.Upload.Tests/EndToEndTests.cs
@@ -33,6 +33,7 @@ public class EndToEndTests
         form.Add(triangleContent, "file0", "triangle.jpg");
         using var request = new HttpRequestMessage(HttpMethod.Post, "/graphql");
         request.Content = form;
+        request.Headers.Add("GraphQL-Require-Preflight", "true");
         using var response = await client.SendAsync(request);
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var ret = await response.Content.ReadAsStringAsync();

--- a/tests/Transports.AspNetCore.Tests/AuthorizationTests.cs
+++ b/tests/Transports.AspNetCore.Tests/AuthorizationTests.cs
@@ -759,7 +759,7 @@ public class AuthorizationTests : IDisposable
                 context.User = _principal;
                 return next(context);
             });
-            app.UseGraphQL();
+            app.UseGraphQL(configureMiddleware: c => c.CsrfProtectionEnabled = false);
         });
         using var server = new TestServer(hostBuilder);
 

--- a/tests/Transports.AspNetCore.Tests/BuilderMethodTests.cs
+++ b/tests/Transports.AspNetCore.Tests/BuilderMethodTests.cs
@@ -373,7 +373,7 @@ public class BuilderMethodTests
         _hostBuilder.Configure(app =>
         {
             app.UseWebSockets();
-            app.UseGraphQL<Schema2>();
+            app.UseGraphQL<Schema2>(configureMiddleware: c => c.CsrfProtectionEnabled = false);
         });
         using var server = new TestServer(_hostBuilder);
         var str = await server.ExecuteGet("/graphql?query={userInfo}");

--- a/tests/Transports.AspNetCore.Tests/Middleware/AuthorizationTests.cs
+++ b/tests/Transports.AspNetCore.Tests/Middleware/AuthorizationTests.cs
@@ -107,7 +107,9 @@ public class AuthorizationTests : IDisposable
     {
         _options.AuthorizationRequired = true;
         var client = _server.CreateClient();
-        using var response = await client.GetAsync("/graphql?query={ __typename }");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/graphql?query={ __typename }");
+        request.Headers.Add("GraphQL-Require-Preflight", "true");
+        using var response = await client.SendAsync(request);
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         var actual = await response.Content.ReadAsStringAsync();
         actual.ShouldBe("""{"errors":[{"message":"Access denied for schema.","extensions":{"code":"ACCESS_DENIED","codes":["ACCESS_DENIED"]}}]}""");

--- a/tests/Transports.AspNetCore.Tests/Middleware/Cors/EndpointTests.cs
+++ b/tests/Transports.AspNetCore.Tests/Middleware/Cors/EndpointTests.cs
@@ -90,7 +90,7 @@ public class EndpointTests
             httpMethod == "POST" ? HttpMethod.Post : httpMethod == "OPTIONS" ? HttpMethod.Options : httpMethod == "GET" ? HttpMethod.Get : throw new ArgumentOutOfRangeException(nameof(httpMethod)),
             configureCors: _ => { },
             configureCorsPolicy: _ => { },
-            configureGraphQl: _ => { },
+            configureGraphQl: o => o.CsrfProtectionEnabled = false,
             configureGraphQlEndpoint: _ => { },
             configureHeaders: headers =>
             {

--- a/tests/Transports.AspNetCore.Tests/Middleware/FileUploadTests.cs
+++ b/tests/Transports.AspNetCore.Tests/Middleware/FileUploadTests.cs
@@ -50,7 +50,10 @@ public class FileUploadTests : IDisposable
         var fileContent = new ByteArrayContent(fileData);
         fileContent.Headers.ContentType = new("application/octet-stream");
         content.Add(fileContent, "file", "filename.bin");
-        using var response = await client.PostAsync("/graphql", content);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/graphql");
+        request.Content = content;
+        request.Headers.Add("GraphQL-Require-Preflight", "true");
+        using var response = await client.SendAsync(request);
         if (withOtherVariables)
         {
             await response.ShouldBeAsync("""{"data":{"convertToBase64":"pre-filename.bin-YWJjZA=="}}""");

--- a/tests/Transports.AspNetCore.Tests/Middleware/GetTests.cs
+++ b/tests/Transports.AspNetCore.Tests/Middleware/GetTests.cs
@@ -155,6 +155,7 @@ public class GetTests : IDisposable
         }
         var client = _server.CreateClient();
         using var request = new HttpRequestMessage(HttpMethod.Get, "/graphql?query={count}");
+        request.Headers.Add("GraphQL-Require-Preflight", "true");
         request.Headers.Add("Accept", mediaType);
         using var response = await client.SendAsync(request);
         var contentType = response.Content.Headers.ContentType?.ToString();

--- a/tests/Transports.AspNetCore.Tests/Middleware/GetTests.cs
+++ b/tests/Transports.AspNetCore.Tests/Middleware/GetTests.cs
@@ -87,19 +87,21 @@ public class GetTests : IDisposable
     }
 
     [Theory]
-    [InlineData(null, false)]
-    [InlineData("Header1", true)]
-    [InlineData("Header2", true)]
-    [InlineData("Header3", false)]
-    [InlineData("GraphQL-Require-Preflight", false)]
-    public async Task CsrfCustomTests(string? header, bool success)
+    [InlineData(null, null, false)]
+    [InlineData("Header1", "true", true)]
+    [InlineData("Header1", "", false)]
+    [InlineData("Header1", null, false)]
+    [InlineData("Header2", "true", true)]
+    [InlineData("Header3", "true", false)]
+    [InlineData("GraphQL-Require-Preflight", "true", false)]
+    public async Task CsrfCustomTests(string? header, string? value, bool success)
     {
         _options.CsrfProtectionEnabled = true;
         _options.CsrfProtectionHeaders = ["Header1", "Header2"];
         var client = _server.CreateClient();
         using var request = new HttpRequestMessage(HttpMethod.Get, "/graphql?query={count}");
         if (header != null)
-            request.Headers.Add(header, "true");
+            request.Headers.Add(header, value);
         using var response = await client.SendAsync(request);
         if (!success)
             await response.ShouldBeAsync(true, """{"errors":[{"message":"This request requires a non-empty header from the following list: \u0027Header1\u0027, \u0027Header2\u0027.","extensions":{"code":"CSRF_PROTECTION","codes":["CSRF_PROTECTION"]}}]}""");

--- a/tests/Transports.AspNetCore.Tests/TestServerExtensions.cs
+++ b/tests/Transports.AspNetCore.Tests/TestServerExtensions.cs
@@ -5,7 +5,9 @@ internal static class TestServerExtensions
     public static async Task<string> ExecuteGet(this TestServer server, string url)
     {
         var client = server.CreateClient();
-        using var response = await client.GetAsync(url);
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("GraphQL-Require-Preflight", "true");
+        using var response = await client.SendAsync(request);
         response.EnsureSuccessStatusCode();
         var contentType = response.Content.Headers.ContentType;
         contentType.ShouldNotBeNull();

--- a/tests/Transports.AspNetCore.Tests/UserContextBuilderTests.cs
+++ b/tests/Transports.AspNetCore.Tests/UserContextBuilderTests.cs
@@ -107,7 +107,9 @@ public class UserContextBuilderTests : IDisposable
 
     private async Task Test(string name)
     {
-        using var response = await _client.GetAsync("/graphql?query={test}");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/graphql?query={test}");
+        request.Headers.Add("GraphQL-Require-Preflight", "true");
+        using var response = await _client.SendAsync(request);
         response.EnsureSuccessStatusCode();
         var actual = await response.Content.ReadAsStringAsync();
         actual.ShouldBe(@"{""data"":{""test"":""" + name + @"""}}");


### PR DESCRIPTION
Requires CORS preflight requests by ensuring that the requests are not 'simple' - e.g. GET request or form-POST requests - or that a specific header has been added to the request.

See similar logic: https://www.apollographql.com/docs/apollo-server/security/cors/#preventing-cross-site-request-forgery-csrf

The chosen default header was based on the current proposal by the GraphQL working group.  See:
- https://github.com/graphql/graphql-over-http/pull/303