### PR TITLE
Fix dependency within obsolete authorization package

### DIFF
--- a/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
+++ b/src/Authorization.AspNetCore/Authorization.AspNetCore.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GraphQL" Version="$(GraphQLVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Transports.AspNetCore\Transports.AspNetCore.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Limits GraphQL to compatible versions

Without this patch, 7.7.1 is dependent on any version of the server package, such as the new v8 which it is compatible with, but takes an indirect reference to graphql, and it is not compatible with graphql v8.  