### PR TITLE
Add KeepAliveMode and SupportedWebSocketSubProtocols options

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,9 +838,9 @@ disconnect the client.  When the server forcibly disconnects the client, no grac
 of the WebSocket protocol occurs, and any queued messages are discarded.
 
 When using the `TimeoutWithPayload` keep-alive mode, you may wish to enforce that the
-`graphql-transport-ws` sub-protocol is in use by the client.  This can be done by setting
-the `SupportedWebSocketSubProtocols` property to only include the `graphql-transport-ws`
-sub-protocol.
+`graphql-transport-ws` sub-protocol is in use by the client, as the `graphql-ws` sub-protocol
+does not support bidirectional keep-alive packets.  This can be done by setting the
+`SupportedWebSocketSubProtocols` property to only include the `graphql-transport-ws` sub-protocol.
 
 ```csharp
 app.UseGraphQL("/graphql", options =>

--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ app.UseGraphQL("/graphql", options =>
 });
 ```
 
-Please note that some UI packages do not support the `graphql-transport-ws` sub-protocol.
+Please note that the included UI packages are configured to use the `graphql-ws` sub-protocol.
 
 ### Customizing middleware behavior
 

--- a/README.md
+++ b/README.md
@@ -730,10 +730,12 @@ methods allowing for different options for each configured endpoint.
 | Property                    | Description          | Default value |
 |-----------------------------|----------------------|---------------|
 | `ConnectionInitWaitTimeout` | The amount of time to wait for a GraphQL initialization packet before the connection is closed. | 10 seconds |
-| `KeepAliveTimeout`          | The amount of time to wait between sending keep-alive packets. | disabled |
 | `DisconnectionTimeout`      | The amount of time to wait to attempt a graceful teardown of the WebSockets protocol. | 10 seconds |
 | `DisconnectAfterErrorEvent` | Disconnects a subscription from the client if the subscription source dispatches an `OnError` event. | True |
 | `DisconnectAfterAnyError`   | Disconnects a subscription from the client if there are any GraphQL errors during a subscription. | False |
+| `KeepAliveMode`             | The mode to use for sending keep-alive packets. | protocol-dependent |
+| `KeepAliveTimeout`          | The amount of time to wait between sending keep-alive packets. | disabled |
+| `SupportedWebSocketSubProtocols` | A list of supported WebSocket sub-protocols. | `graphql-ws`, `graphql-transport-ws` |
 
 ### Multi-schema configuration
 
@@ -799,6 +801,59 @@ public class MySchema : Schema
     }
 }
 ```
+
+### Keep-alive configuration
+
+By default, the middleware will not send keep-alive packets to the client.  As the underlying
+operating system may not detect a disconnected client until a message is sent, you may wish to
+enable keep-alive packets to be sent periodically.  The default mode for keep-alive packets
+differs depending on whether the client connected with the `graphql-ws` or `graphql-transport-ws`
+sub-protocol.  The `graphql-ws` sub-protocol will send a unidirectional keep-alive packet to the
+client on a fixed schedule, while the `graphql-transport-ws` sub-protocol will only send
+unidirectional keep-alive packets when the client has not sent a message within a certain time.
+The differing behavior is due to the default implementation of the `graphql-ws` sub-protocol
+client, which after receiving a single keep-alive packet, expects additional keep-alive packets
+to be sent sooner than every 20 seconds, regardless of the client's activity.
+
+To configure keep-alive packets, set the `KeepAliveMode` and `KeepAliveTimeout` properties
+within the `GraphQLWebSocketOptions` object.  Set the `KeepAliveTimeout` property to
+enable keep-alive packets, or use `TimeSpan.Zero` or `Timeout.InfiniteTimeSpan` to disable it.
+
+The `KeepAliveMode` property is only applicable to the `graphql-transport-ws` sub-protocol and
+can be set to the options listed below:
+
+| Keep-alive mode | Description |
+|-----------------|-------------|
+| `Default`       | Same as `Timeout`. |
+| `Timeout`       | Sends a unidirectional keep-alive message when no message has been received within the specified timeout period. |
+| `Interval`      | Sends a unidirectional keep-alive message at a fixed interval, regardless of message activity. |
+| `TimeoutWithPayload` | Sends a bidirectional keep-alive message with a payload on a fixed interval, and validates the payload matches in the response. |
+
+The `TimeoutWithPayload` model is particularly useful when the server may send messages to the
+client at a faster pace than the client can process them.  In this case queued messages will be
+limited to double the timeout period, as the keep-alive message is queued along with other
+packets sent from the server to the client.  The client will need to respond to process queued
+messages and respond to the keep-alive message within the timeout period or the server will
+disconnect the client.  When the server forcibly disconnects the client, no graceful teardown
+of the WebSocket protocol occurs, and any queued messages are discarded.
+
+When using the `TimeoutWithPayload` keep-alive mode, you may wish to enforce that the
+`graphql-transport-ws` sub-protocol is in use by the client.  This can be done by setting
+the `SupportedWebSocketSubProtocols` property to only include the `graphql-transport-ws`
+sub-protocol.
+
+```csharp
+app.UseGraphQL("/graphql", options =>
+{
+    // configure keep-alive packets
+    options.WebSockets.KeepAliveTimeout = TimeSpan.FromSeconds(10);
+    options.WebSockets.KeepAliveMode = KeepAliveMode.TimeoutWithPayload;
+    // set the supported sub-protocols to only include the graphql-transport-ws sub-protocol
+    options.WebSockets.SupportedWebSocketSubProtocols = [GraphQLWs.SubscriptionServer.SubProtocol];
+});
+```
+
+Please note that some UI packages do not support the `graphql-transport-ws` sub-protocol.
 
 ### Customizing middleware behavior
 

--- a/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
+++ b/src/Transports.AspNetCore/GraphQLHttpMiddleware.cs
@@ -1007,7 +1007,7 @@ public class GraphQLHttpMiddleware : IUserContextBuilder
     /// <summary>
     /// Gets a list of WebSocket sub-protocols supported.
     /// </summary>
-    protected virtual IEnumerable<string> SupportedWebSocketSubProtocols => _supportedSubProtocols;
+    protected virtual IEnumerable<string> SupportedWebSocketSubProtocols => _options.WebSockets.SupportedWebSocketSubProtocols;
 
     /// <summary>
     /// Creates an <see cref="IWebSocketConnection"/>, a WebSocket message pump.

--- a/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.cs
@@ -268,7 +268,7 @@ public abstract partial class BaseSubscriptionServer : IOperationMessageProcesso
             return;
         }
         await OnConnectionAcknowledgeAsync(message);
-        if (TryInitialize() == false)
+        if (!TryInitialize())
             return;
 
         _ = OnKeepAliveLoopAsync();

--- a/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.cs
@@ -259,10 +259,33 @@ public abstract partial class BaseSubscriptionServer : IOperationMessageProcesso
     /// <br/><br/>
     /// Otherwise, the connection is acknowledged via <see cref="OnConnectionAcknowledgeAsync(OperationMessage)"/>,
     /// <see cref="TryInitialize"/> is called to indicate that this WebSocket connection is ready to accept requests,
-    /// and keep-alive messages are sent via <see cref="OnSendKeepAliveAsync"/> if configured to do so.
-    /// Keep-alive messages are only sent if no messages have been sent over the WebSockets connection for the
-    /// length of time configured in <see cref="GraphQLWebSocketOptions.KeepAliveTimeout"/>.
+    /// and <see cref="OnSendKeepAliveAsync"/> is called to start sending keep-alive messages if configured to do so.
     /// </summary>
+    protected virtual async Task OnConnectionInitAsync(OperationMessage message)
+    {
+        if (!await AuthorizeAsync(message))
+        {
+            return;
+        }
+        await OnConnectionAcknowledgeAsync(message);
+        if (TryInitialize() == false)
+            return;
+
+        _ = OnKeepAliveLoopAsync();
+    }
+
+    /// <summary>
+    /// Executes when the client is attempting to initialize the connection.
+    /// <br/><br/>
+    /// By default, this first checks <see cref="AuthorizeAsync(OperationMessage)"/> to validate that the
+    /// request has passed authentication.  If validation fails, the connection is closed with an Access
+    /// Denied message.
+    /// <br/><br/>
+    /// Otherwise, the connection is acknowledged via <see cref="OnConnectionAcknowledgeAsync(OperationMessage)"/>,
+    /// <see cref="TryInitialize"/> is called to indicate that this WebSocket connection is ready to accept requests,
+    /// and <see cref="OnSendKeepAliveAsync"/> is called to start sending keep-alive messages if configured to do so.
+    /// </summary>
+    [Obsolete($"Please use the {nameof(OnConnectionInitAsync)}(message) and {nameof(OnKeepAliveLoopAsync)} methods instead. This method will be removed in a future version of this library.")]
     protected virtual async Task OnConnectionInitAsync(OperationMessage message, bool smartKeepAlive)
     {
         if (!await AuthorizeAsync(message))
@@ -277,12 +300,49 @@ public abstract partial class BaseSubscriptionServer : IOperationMessageProcesso
         if (keepAliveTimeout > TimeSpan.Zero)
         {
             if (smartKeepAlive)
-                _ = StartSmartKeepAliveLoopAsync();
+                _ = OnKeepAliveLoopAsync(keepAliveTimeout, KeepAliveMode.Timeout);
             else
-                _ = StartKeepAliveLoopAsync();
+                _ = OnKeepAliveLoopAsync(keepAliveTimeout, KeepAliveMode.Interval);
+        }
+    }
+
+    /// <summary>
+    /// Starts sending keep-alive messages if configured to do so. Inspects the configured
+    /// <see cref="GraphQLWebSocketOptions"/> and passes control to <see cref="OnKeepAliveLoopAsync(TimeSpan, KeepAliveMode)"/>
+    /// if keep-alive messages are enabled.
+    /// </summary>
+    protected virtual Task OnKeepAliveLoopAsync()
+    {
+        return OnKeepAliveLoopAsync(
+            _options.KeepAliveTimeout ?? DefaultKeepAliveTimeout,
+            _options.KeepAliveMode);
+    }
+
+    /// <summary>
+    /// Sends keep-alive messages according to the specified timeout period and method.
+    /// See <see cref="KeepAliveMode"/> for implementation details for each supported mode.
+    /// </summary>
+    protected virtual async Task OnKeepAliveLoopAsync(TimeSpan keepAliveTimeout, KeepAliveMode keepAliveMode)
+    {
+        if (keepAliveTimeout <= TimeSpan.Zero)
+            return;
+
+        switch (keepAliveMode)
+        {
+            case KeepAliveMode.Default:
+            case KeepAliveMode.Timeout:
+                await StartSmartKeepAliveLoopAsync();
+                break;
+            case KeepAliveMode.Interval:
+                await StartDumbKeepAliveLoopAsync();
+                break;
+            case KeepAliveMode.TimeoutWithPayload:
+                throw new NotImplementedException($"{nameof(KeepAliveMode.TimeoutWithPayload)} is not implemented within the {nameof(BaseSubscriptionServer)} class.");
+            default:
+                throw new ArgumentOutOfRangeException(nameof(keepAliveMode));
         }
 
-        async Task StartKeepAliveLoopAsync()
+        async Task StartDumbKeepAliveLoopAsync()
         {
             while (!CancellationToken.IsCancellationRequested)
             {

--- a/src/Transports.AspNetCore/WebSockets/GraphQLWebSocketOptions.cs
+++ b/src/Transports.AspNetCore/WebSockets/GraphQLWebSocketOptions.cs
@@ -26,6 +26,12 @@ public class GraphQLWebSocketOptions
     public TimeSpan? KeepAliveTimeout { get; set; }
 
     /// <summary>
+    /// Gets or sets the keep-alive mode used for websocket subscriptions.
+    /// This property is only applicable when using the GraphQLWs protocol.
+    /// </summary>
+    public KeepAliveMode KeepAliveMode { get; set; } = KeepAliveMode.Default;
+
+    /// <summary>
     /// The amount of time to wait to attempt a graceful teardown of the WebSockets protocol.
     /// A value of <see langword="null"/> indicates the default value defined by the implementation.
     /// The included implementations in this library have a default value of 10 seconds.
@@ -42,4 +48,17 @@ public class GraphQLWebSocketOptions
     /// Disconnects a subscription from the client in the event of any GraphQL errors during a subscription.  The default value is <see langword="false"/>.
     /// </summary>
     public bool DisconnectAfterAnyError { get; set; }
+
+    /// <summary>
+    /// The list of supported WebSocket sub-protocols.
+    /// Defaults to <see cref="GraphQLWs.SubscriptionServer.SubProtocol"/> and <see cref="SubscriptionsTransportWs.SubscriptionServer.SubProtocol"/>.
+    /// Adding other sub-protocols require the <see cref="GraphQLHttpMiddleware.CreateMessageProcessor(IWebSocketConnection, string)"/> method
+    /// to be overridden to handle the new sub-protocol.
+    /// </summary>
+    /// <remarks>
+    /// When the <see cref="KeepAliveMode"/> is set to <see cref="KeepAliveMode.TimeoutWithPayload"/>, you may wish to remove
+    /// <see cref="SubscriptionsTransportWs.SubscriptionServer.SubProtocol"/> from this list to prevent clients from using
+    /// protocols which do not support the <see cref="KeepAliveMode.TimeoutWithPayload"/> keep-alive mode.
+    /// </remarks>
+    public List<string> SupportedWebSocketSubProtocols { get; set; } = [GraphQLWs.SubscriptionServer.SubProtocol, SubscriptionsTransportWs.SubscriptionServer.SubProtocol];
 }

--- a/src/Transports.AspNetCore/WebSockets/GraphQLWs/PingPayload.cs
+++ b/src/Transports.AspNetCore/WebSockets/GraphQLWs/PingPayload.cs
@@ -1,0 +1,12 @@
+﻿namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs;
+
+/// <summary>
+/// The payload of the ping message.
+/// </summary>
+public class PingPayload
+{
+    /// <summary>
+    /// The unique identifier of the ping message.
+    /// </summary>
+    public string? id { get; set; }
+}

--- a/src/Transports.AspNetCore/WebSockets/GraphQLWs/PingPayload.cs
+++ b/src/Transports.AspNetCore/WebSockets/GraphQLWs/PingPayload.cs
@@ -1,4 +1,4 @@
-﻿namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs;
+namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs;
 
 /// <summary>
 /// The payload of the ping message.

--- a/src/Transports.AspNetCore/WebSockets/GraphQLWs/SubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/GraphQLWs/SubscriptionServer.cs
@@ -127,7 +127,7 @@ public class SubscriptionServer : BaseSubscriptionServer
     protected override Task OnConnectionInitAsync(OperationMessage message, bool smartKeepAlive)
     {
         if (smartKeepAlive)
-            return base.OnConnectionInitAsync(message);
+            return OnConnectionInitAsync(message);
         else
             return base.OnConnectionInitAsync(message, smartKeepAlive);
     }

--- a/src/Transports.AspNetCore/WebSockets/GraphQLWs/SubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/GraphQLWs/SubscriptionServer.cs
@@ -159,7 +159,7 @@ public class SubscriptionServer : BaseSubscriptionServer
                 {
                     lastPongReceivedUtc = _lastPongReceivedUtc;
                 }
-                var nextPing = _lastPongReceivedUtc.Add(pingInterval);
+                var nextPing = lastPongReceivedUtc.Add(pingInterval);
                 interval = nextPing.Subtract(now);
                 if (interval > TimeSpan.Zero) // could easily be zero or less, if pongInterval is equal or greater than pingInterval
                     await Task.Delay(interval, CancellationToken);

--- a/src/Transports.AspNetCore/WebSockets/KeepAliveMode.cs
+++ b/src/Transports.AspNetCore/WebSockets/KeepAliveMode.cs
@@ -1,0 +1,36 @@
+namespace GraphQL.Server.Transports.AspNetCore.WebSockets;
+
+/// <summary>
+/// Specifies the mode of keep-alive behavior.
+/// </summary>
+public enum KeepAliveMode
+{
+    /// <summary>
+    /// Same as <see cref="Timeout"/>: Sends a unidirectional keep-alive message when no message has been received within the specified timeout period.
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// Sends a unidirectional keep-alive message when no message has been received within the specified timeout period.
+    /// </summary>
+    Timeout = 1,
+
+    /// <summary>
+    /// Sends a unidirectional keep-alive message at a fixed interval, regardless of message activity.
+    /// </summary>
+    Interval = 2,
+
+    /// <summary>
+    /// Sends a Ping message with a payload after the specified timeout from the last received Pong,
+    /// and waits for a corresponding Pong response. Requires that the client reflects the payload
+    /// in the response. Forcibly disconnects the client if the client does not respond with a Pong
+    /// message within the specified timeout. This means that a dead connection will be closed after
+    /// a maximum of double the <see cref="GraphQLWebSocketOptions.KeepAliveTimeout"/> period.
+    /// </summary>
+    /// <remarks>
+    /// This mode is particularly useful when backpressure causes subscription messages to be delayed
+    /// due to a slow or unresponsive client connection. The server can detect that the client is not
+    /// processing messages in a timely manner and disconnect the client to free up resources.
+    /// </remarks>
+    TimeoutWithPayload = 3,
+}

--- a/src/Transports.AspNetCore/WebSockets/SubscriptionsTransportWs/SubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/SubscriptionsTransportWs/SubscriptionServer.cs
@@ -85,7 +85,9 @@ public class SubscriptionServer : BaseSubscriptionServer
             }
             else
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 await OnConnectionInitAsync(message, false);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             return;
         }
@@ -107,6 +109,26 @@ public class SubscriptionServer : BaseSubscriptionServer
                 break;
         }
     }
+
+    /// <inheritdoc/>
+    [Obsolete($"Please use the {nameof(OnConnectionInitAsync)} and {nameof(OnKeepAliveLoopAsync)} methods instead. This method will be removed in a future version of this library.")]
+    protected override Task OnConnectionInitAsync(OperationMessage message, bool smartKeepAlive)
+    {
+        if (!smartKeepAlive)
+            return base.OnConnectionInitAsync(message);
+        else
+            return base.OnConnectionInitAsync(message, smartKeepAlive);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// This implementation overrides <see cref="GraphQLWebSocketOptions.KeepAliveMode"/> to <see cref="KeepAliveMode.Interval"/>
+    /// as this protocol does not support the other modes. Override this method to support your own implementation.
+    /// </remarks>
+    protected override Task OnKeepAliveLoopAsync(TimeSpan keepAliveTimeout, KeepAliveMode keepAliveMode)
+        => base.OnKeepAliveLoopAsync(
+            keepAliveTimeout,
+            KeepAliveMode.Interval);
 
     private static readonly OperationMessage _keepAliveMessage = new() { Type = MessageType.GQL_CONNECTION_KEEP_ALIVE };
     /// <inheritdoc/>

--- a/src/Transports.AspNetCore/WebSockets/SubscriptionsTransportWs/SubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/SubscriptionsTransportWs/SubscriptionServer.cs
@@ -115,7 +115,7 @@ public class SubscriptionServer : BaseSubscriptionServer
     protected override Task OnConnectionInitAsync(OperationMessage message, bool smartKeepAlive)
     {
         if (!smartKeepAlive)
-            return base.OnConnectionInitAsync(message);
+            return OnConnectionInitAsync(message);
         else
             return base.OnConnectionInitAsync(message, smartKeepAlive);
     }

--- a/tests/ApiApprovalTests/net50+net60+net80/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net50+net60+net80/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -274,8 +274,13 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         public virtual System.Threading.Tasks.Task InitializeConnectionAsync() { }
         protected virtual System.Threading.Tasks.Task OnCloseConnectionAsync() { }
         protected abstract System.Threading.Tasks.Task OnConnectionAcknowledgeAsync(GraphQL.Transport.OperationMessage message);
+        protected virtual System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message) { }
+        [System.Obsolete("Please use the OnConnectionInitAsync(message) and OnKeepAliveLoopAsync methods in" +
+            "stead. This method will be removed in a future version of this library.")]
         protected virtual System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message, bool smartKeepAlive) { }
         protected virtual System.Threading.Tasks.Task OnConnectionInitWaitTimeoutAsync() { }
+        protected virtual System.Threading.Tasks.Task OnKeepAliveLoopAsync() { }
+        protected virtual System.Threading.Tasks.Task OnKeepAliveLoopAsync(System.TimeSpan keepAliveTimeout, GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode keepAliveMode) { }
         public abstract System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message);
         protected virtual System.Threading.Tasks.Task OnNotAuthenticatedAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnNotAuthorizedPolicyAsync(GraphQL.Transport.OperationMessage message, Microsoft.AspNetCore.Authorization.AuthorizationResult result) { }
@@ -300,7 +305,9 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         public bool DisconnectAfterAnyError { get; set; }
         public bool DisconnectAfterErrorEvent { get; set; }
         public System.TimeSpan? DisconnectionTimeout { get; set; }
+        public GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode KeepAliveMode { get; set; }
         public System.TimeSpan? KeepAliveTimeout { get; set; }
+        public System.Collections.Generic.List<string> SupportedWebSocketSubProtocols { get; set; }
     }
     public interface IOperationMessageProcessor : System.IDisposable
     {
@@ -320,6 +327,13 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         System.Threading.Tasks.Task CloseAsync(int eventId, string? description);
         System.Threading.Tasks.Task ExecuteAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IOperationMessageProcessor operationMessageProcessor);
         System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message);
+    }
+    public enum KeepAliveMode
+    {
+        Default = 0,
+        Timeout = 1,
+        Interval = 2,
+        TimeoutWithPayload = 3,
     }
     public sealed class SubscriptionList : System.IDisposable
     {
@@ -364,6 +378,11 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs
         public const string Pong = "pong";
         public const string Subscribe = "subscribe";
     }
+    public class PingPayload
+    {
+        public PingPayload() { }
+        public string? id { get; set; }
+    }
     public class SubscriptionServer : GraphQL.Server.Transports.AspNetCore.WebSockets.BaseSubscriptionServer
     {
         public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
@@ -377,6 +396,10 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs
         protected override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnCompleteAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task OnConnectionAcknowledgeAsync(GraphQL.Transport.OperationMessage message) { }
+        [System.Obsolete("Please use the OnConnectionInitAsync and OnKeepAliveLoopAsync methods instead. Th" +
+            "is method will be removed in a future version of this library.")]
+        protected override System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message, bool smartKeepAlive) { }
+        protected override System.Threading.Tasks.Task OnKeepAliveLoopAsync(System.TimeSpan keepAliveTimeout, GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode keepAliveMode) { }
         public override System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnPingAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnPongAsync(GraphQL.Transport.OperationMessage message) { }
@@ -415,6 +438,10 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.SubscriptionsTransport
         protected override System.Threading.Tasks.Task ErrorAccessDeniedAsync() { }
         protected override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task OnConnectionAcknowledgeAsync(GraphQL.Transport.OperationMessage message) { }
+        [System.Obsolete("Please use the OnConnectionInitAsync and OnKeepAliveLoopAsync methods instead. Th" +
+            "is method will be removed in a future version of this library.")]
+        protected override System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message, bool smartKeepAlive) { }
+        protected override System.Threading.Tasks.Task OnKeepAliveLoopAsync(System.TimeSpan keepAliveTimeout, GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode keepAliveMode) { }
         public override System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task OnSendKeepAliveAsync() { }
         protected virtual System.Threading.Tasks.Task OnStartAsync(GraphQL.Transport.OperationMessage message) { }

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -292,8 +292,13 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         public virtual System.Threading.Tasks.Task InitializeConnectionAsync() { }
         protected virtual System.Threading.Tasks.Task OnCloseConnectionAsync() { }
         protected abstract System.Threading.Tasks.Task OnConnectionAcknowledgeAsync(GraphQL.Transport.OperationMessage message);
+        protected virtual System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message) { }
+        [System.Obsolete("Please use the OnConnectionInitAsync(message) and OnKeepAliveLoopAsync methods in" +
+            "stead. This method will be removed in a future version of this library.")]
         protected virtual System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message, bool smartKeepAlive) { }
         protected virtual System.Threading.Tasks.Task OnConnectionInitWaitTimeoutAsync() { }
+        protected virtual System.Threading.Tasks.Task OnKeepAliveLoopAsync() { }
+        protected virtual System.Threading.Tasks.Task OnKeepAliveLoopAsync(System.TimeSpan keepAliveTimeout, GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode keepAliveMode) { }
         public abstract System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message);
         protected virtual System.Threading.Tasks.Task OnNotAuthenticatedAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnNotAuthorizedPolicyAsync(GraphQL.Transport.OperationMessage message, Microsoft.AspNetCore.Authorization.AuthorizationResult result) { }
@@ -318,7 +323,9 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         public bool DisconnectAfterAnyError { get; set; }
         public bool DisconnectAfterErrorEvent { get; set; }
         public System.TimeSpan? DisconnectionTimeout { get; set; }
+        public GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode KeepAliveMode { get; set; }
         public System.TimeSpan? KeepAliveTimeout { get; set; }
+        public System.Collections.Generic.List<string> SupportedWebSocketSubProtocols { get; set; }
     }
     public interface IOperationMessageProcessor : System.IDisposable
     {
@@ -338,6 +345,13 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         System.Threading.Tasks.Task CloseAsync(int eventId, string? description);
         System.Threading.Tasks.Task ExecuteAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IOperationMessageProcessor operationMessageProcessor);
         System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message);
+    }
+    public enum KeepAliveMode
+    {
+        Default = 0,
+        Timeout = 1,
+        Interval = 2,
+        TimeoutWithPayload = 3,
     }
     public sealed class SubscriptionList : System.IDisposable
     {
@@ -382,6 +396,11 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs
         public const string Pong = "pong";
         public const string Subscribe = "subscribe";
     }
+    public class PingPayload
+    {
+        public PingPayload() { }
+        public string? id { get; set; }
+    }
     public class SubscriptionServer : GraphQL.Server.Transports.AspNetCore.WebSockets.BaseSubscriptionServer
     {
         public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
@@ -395,6 +414,10 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs
         protected override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnCompleteAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task OnConnectionAcknowledgeAsync(GraphQL.Transport.OperationMessage message) { }
+        [System.Obsolete("Please use the OnConnectionInitAsync and OnKeepAliveLoopAsync methods instead. Th" +
+            "is method will be removed in a future version of this library.")]
+        protected override System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message, bool smartKeepAlive) { }
+        protected override System.Threading.Tasks.Task OnKeepAliveLoopAsync(System.TimeSpan keepAliveTimeout, GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode keepAliveMode) { }
         public override System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnPingAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnPongAsync(GraphQL.Transport.OperationMessage message) { }
@@ -433,6 +456,10 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.SubscriptionsTransport
         protected override System.Threading.Tasks.Task ErrorAccessDeniedAsync() { }
         protected override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task OnConnectionAcknowledgeAsync(GraphQL.Transport.OperationMessage message) { }
+        [System.Obsolete("Please use the OnConnectionInitAsync and OnKeepAliveLoopAsync methods instead. Th" +
+            "is method will be removed in a future version of this library.")]
+        protected override System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message, bool smartKeepAlive) { }
+        protected override System.Threading.Tasks.Task OnKeepAliveLoopAsync(System.TimeSpan keepAliveTimeout, GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode keepAliveMode) { }
         public override System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task OnSendKeepAliveAsync() { }
         protected virtual System.Threading.Tasks.Task OnStartAsync(GraphQL.Transport.OperationMessage message) { }

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -274,8 +274,13 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         public virtual System.Threading.Tasks.Task InitializeConnectionAsync() { }
         protected virtual System.Threading.Tasks.Task OnCloseConnectionAsync() { }
         protected abstract System.Threading.Tasks.Task OnConnectionAcknowledgeAsync(GraphQL.Transport.OperationMessage message);
+        protected virtual System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message) { }
+        [System.Obsolete("Please use the OnConnectionInitAsync(message) and OnKeepAliveLoopAsync methods in" +
+            "stead. This method will be removed in a future version of this library.")]
         protected virtual System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message, bool smartKeepAlive) { }
         protected virtual System.Threading.Tasks.Task OnConnectionInitWaitTimeoutAsync() { }
+        protected virtual System.Threading.Tasks.Task OnKeepAliveLoopAsync() { }
+        protected virtual System.Threading.Tasks.Task OnKeepAliveLoopAsync(System.TimeSpan keepAliveTimeout, GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode keepAliveMode) { }
         public abstract System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message);
         protected virtual System.Threading.Tasks.Task OnNotAuthenticatedAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnNotAuthorizedPolicyAsync(GraphQL.Transport.OperationMessage message, Microsoft.AspNetCore.Authorization.AuthorizationResult result) { }
@@ -300,7 +305,9 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         public bool DisconnectAfterAnyError { get; set; }
         public bool DisconnectAfterErrorEvent { get; set; }
         public System.TimeSpan? DisconnectionTimeout { get; set; }
+        public GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode KeepAliveMode { get; set; }
         public System.TimeSpan? KeepAliveTimeout { get; set; }
+        public System.Collections.Generic.List<string> SupportedWebSocketSubProtocols { get; set; }
     }
     public interface IOperationMessageProcessor : System.IDisposable
     {
@@ -320,6 +327,13 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         System.Threading.Tasks.Task CloseAsync(int eventId, string? description);
         System.Threading.Tasks.Task ExecuteAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IOperationMessageProcessor operationMessageProcessor);
         System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message);
+    }
+    public enum KeepAliveMode
+    {
+        Default = 0,
+        Timeout = 1,
+        Interval = 2,
+        TimeoutWithPayload = 3,
     }
     public sealed class SubscriptionList : System.IDisposable
     {
@@ -364,6 +378,11 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs
         public const string Pong = "pong";
         public const string Subscribe = "subscribe";
     }
+    public class PingPayload
+    {
+        public PingPayload() { }
+        public string? id { get; set; }
+    }
     public class SubscriptionServer : GraphQL.Server.Transports.AspNetCore.WebSockets.BaseSubscriptionServer
     {
         public SubscriptionServer(GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketConnection connection, GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWebSocketOptions options, GraphQL.Server.Transports.AspNetCore.IAuthorizationOptions authorizationOptions, GraphQL.IDocumentExecuter executer, GraphQL.IGraphQLSerializer serializer, Microsoft.Extensions.DependencyInjection.IServiceScopeFactory serviceScopeFactory, GraphQL.Server.Transports.AspNetCore.IUserContextBuilder userContextBuilder, GraphQL.Server.Transports.AspNetCore.WebSockets.IWebSocketAuthenticationService? authenticationService = null) { }
@@ -377,6 +396,10 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs
         protected override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnCompleteAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task OnConnectionAcknowledgeAsync(GraphQL.Transport.OperationMessage message) { }
+        [System.Obsolete("Please use the OnConnectionInitAsync and OnKeepAliveLoopAsync methods instead. Th" +
+            "is method will be removed in a future version of this library.")]
+        protected override System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message, bool smartKeepAlive) { }
+        protected override System.Threading.Tasks.Task OnKeepAliveLoopAsync(System.TimeSpan keepAliveTimeout, GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode keepAliveMode) { }
         public override System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnPingAsync(GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnPongAsync(GraphQL.Transport.OperationMessage message) { }
@@ -415,6 +438,10 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets.SubscriptionsTransport
         protected override System.Threading.Tasks.Task ErrorAccessDeniedAsync() { }
         protected override System.Threading.Tasks.Task<GraphQL.ExecutionResult> ExecuteRequestAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task OnConnectionAcknowledgeAsync(GraphQL.Transport.OperationMessage message) { }
+        [System.Obsolete("Please use the OnConnectionInitAsync and OnKeepAliveLoopAsync methods instead. Th" +
+            "is method will be removed in a future version of this library.")]
+        protected override System.Threading.Tasks.Task OnConnectionInitAsync(GraphQL.Transport.OperationMessage message, bool smartKeepAlive) { }
+        protected override System.Threading.Tasks.Task OnKeepAliveLoopAsync(System.TimeSpan keepAliveTimeout, GraphQL.Server.Transports.AspNetCore.WebSockets.KeepAliveMode keepAliveMode) { }
         public override System.Threading.Tasks.Task OnMessageReceivedAsync(GraphQL.Transport.OperationMessage message) { }
         protected override System.Threading.Tasks.Task OnSendKeepAliveAsync() { }
         protected virtual System.Threading.Tasks.Task OnStartAsync(GraphQL.Transport.OperationMessage message) { }

--- a/tests/Transports.AspNetCore.Tests/WebSockets/NewSubscriptionServerTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/NewSubscriptionServerTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs;
 
 namespace Tests.WebSockets;
 
@@ -67,6 +68,14 @@ public class NewSubscriptionServerTests : IDisposable
         else
         {
             _mockServer.Protected().Setup<Task>("OnConnectionInitAsync", message, true)
+                .CallBase().Verifiable();
+            _mockServer.Protected().Setup<Task>("OnConnectionInitAsync", message)
+                .CallBase().Verifiable();
+            _mockServer.Protected().Setup<ValueTask<bool>>("AuthorizeAsync", message)
+                .Returns(new ValueTask<bool>(true)).Verifiable();
+            _mockServer.Protected().Setup<Task>("OnConnectionAcknowledgeAsync", message)
+                .Returns(Task.CompletedTask).Verifiable();
+            _mockServer.Protected().Setup<Task>("OnKeepAliveLoopAsync")
                 .Returns(Task.CompletedTask).Verifiable();
         }
         _mockServer.Setup(x => x.OnMessageReceivedAsync(message)).CallBase().Verifiable();
@@ -99,11 +108,15 @@ public class NewSubscriptionServerTests : IDisposable
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Message_Ping(bool initialized)
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task Message_Ping(bool initialized, bool withPayload)
     {
         var message = new OperationMessage { Type = "ping" };
+        if (withPayload)
+            message.Payload = new PingPayload { id = Guid.NewGuid().ToString("N") };
         _mockServer.Protected().Setup<Task>("OnPingAsync", message)
             .Returns(Task.CompletedTask).Verifiable();
         if (initialized)
@@ -117,11 +130,15 @@ public class NewSubscriptionServerTests : IDisposable
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Message_Pong(bool initialized)
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task Message_Pong(bool initialized, bool withPayload)
     {
         var message = new OperationMessage { Type = "pong" };
+        if (withPayload)
+            message.Payload = new PingPayload { id = Guid.NewGuid().ToString("N") };
         _mockServer.Protected().Setup<Task>("OnPongAsync", message)
             .Returns(Task.CompletedTask).Verifiable();
         if (initialized)
@@ -180,14 +197,53 @@ public class NewSubscriptionServerTests : IDisposable
         _mockServer.VerifyNoOtherCalls();
     }
 
-    [Fact]
-    public async Task OnSendKeepAliveAsync()
+    [Theory]
+    [InlineData(KeepAliveMode.Default)]
+    [InlineData(KeepAliveMode.Interval)]
+    [InlineData(KeepAliveMode.Timeout)]
+    [InlineData(KeepAliveMode.TimeoutWithPayload)]
+    public async Task OnSendKeepAliveAsync(KeepAliveMode keepAliveMode)
     {
+        _options.WebSockets.KeepAliveMode = keepAliveMode;
         _mockStream.Setup(x => x.SendMessageAsync(It.IsAny<OperationMessage>()))
-            .Returns<OperationMessage>(o => o.Type == "pong" ? Task.CompletedTask : Task.FromException(new Exception()))
+            .Returns<OperationMessage>(async o =>
+            {
+                o.Id.ShouldBeNull();
+                if (keepAliveMode == KeepAliveMode.TimeoutWithPayload)
+                {
+                    o.Type.ShouldBe("ping");
+                    var payload = o.Payload.ShouldBeOfType<PingPayload>();
+                    var guid = Guid.ParseExact(payload.id.ShouldNotBeNull(), "N");
+                    guid.ShouldNotBe(Guid.Empty);
+                }
+                else
+                {
+                    o.Type.ShouldBe("pong");
+                    o.Payload.ShouldBeNull();
+                }
+            })
             .Verifiable();
         _mockServer.Protected().Setup<Task>("OnSendKeepAliveAsync").CallBase().Verifiable();
         await _server.Do_OnSendKeepAliveAsync();
+        _mockServer.Verify();
+        _mockServer.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(KeepAliveMode.Default)]
+    [InlineData(KeepAliveMode.Interval)]
+    [InlineData(KeepAliveMode.Timeout)]
+    [InlineData(KeepAliveMode.TimeoutWithPayload)]
+    public async Task OnKeepAliveLoopAsync(KeepAliveMode keepAliveMode)
+    {
+        _options.WebSockets.KeepAliveMode = keepAliveMode;
+        var defaultKeepAliveTimeout = TimeSpan.FromSeconds(10);
+        _mockServer.Protected().SetupGet<TimeSpan>("DefaultKeepAliveTimeout")
+            .Returns(defaultKeepAliveTimeout).Verifiable();
+        _mockServer.Protected().Setup<Task>("OnKeepAliveLoopAsync").CallBase().Verifiable();
+        _mockServer.Protected().Setup<Task>("OnKeepAliveLoopAsync", defaultKeepAliveTimeout, keepAliveMode)
+            .Returns(Task.CompletedTask).Verifiable();
+        await _server.Do_OnKeepAliveLoopAsync();
         _mockServer.Verify();
         _mockServer.VerifyNoOtherCalls();
     }
@@ -205,13 +261,28 @@ public class NewSubscriptionServerTests : IDisposable
         _mockServer.VerifyNoOtherCalls();
     }
 
-    [Fact]
-    public async Task OnPingAsync()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task OnPingAsync(bool withPayload)
     {
+        var payload = new { id = Guid.NewGuid().ToString("N") };
         _mockStream.Setup(x => x.SendMessageAsync(It.IsAny<OperationMessage>()))
-            .Returns<OperationMessage>(o => o.Type == "pong" ? Task.CompletedTask : Task.FromException(new Exception()))
+            .Returns<OperationMessage>(async o =>
+            {
+                o.Id.ShouldBeNull();
+                o.Type.ShouldBe("pong");
+                if (withPayload)
+                {
+                    o.Payload.ShouldBe(payload);
+                }
+                else
+                {
+                    o.Payload.ShouldBeNull();
+                }
+            })
             .Verifiable();
-        var message = new OperationMessage();
+        var message = new OperationMessage() { Payload = withPayload ? payload : null };
         _mockServer.Protected().Setup<Task>("OnPingAsync", message).CallBase().Verifiable();
         await _server.Do_OnPingAsync(message);
         _mockServer.Verify();

--- a/tests/Transports.AspNetCore.Tests/WebSockets/OldSubscriptionServerTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/OldSubscriptionServerTests.cs
@@ -87,6 +87,14 @@ public class OldSubscriptionServerTests : IDisposable
         else
         {
             _mockServer.Protected().Setup<Task>("OnConnectionInitAsync", message, false)
+                .CallBase().Verifiable();
+            _mockServer.Protected().Setup<Task>("OnConnectionInitAsync", message)
+                .CallBase().Verifiable();
+            _mockServer.Protected().Setup<ValueTask<bool>>("AuthorizeAsync", message)
+                .Returns(new ValueTask<bool>(true)).Verifiable();
+            _mockServer.Protected().Setup<Task>("OnConnectionAcknowledgeAsync", message)
+                .Returns(Task.CompletedTask).Verifiable();
+            _mockServer.Protected().Setup<Task>("OnKeepAliveLoopAsync")
                 .Returns(Task.CompletedTask).Verifiable();
         }
         _mockServer.Setup(x => x.OnMessageReceivedAsync(message)).CallBase().Verifiable();

--- a/tests/Transports.AspNetCore.Tests/WebSockets/TestBaseSubscriptionServer.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/TestBaseSubscriptionServer.cs
@@ -49,7 +49,9 @@ public class TestBaseSubscriptionServer : BaseSubscriptionServer
         => ErrorAccessDeniedAsync();
 
     public Task Do_OnConnectionInitAsync(OperationMessage message, bool smartKeepAlive)
+#pragma warning disable CS0618 // Type or member is obsolete
         => OnConnectionInitAsync(message, smartKeepAlive);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     public Task Do_SubscribeAsync(OperationMessage message, bool overwrite)
         => SubscribeAsync(message, overwrite);

--- a/tests/Transports.AspNetCore.Tests/WebSockets/TestNewSubscriptionServer.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/TestNewSubscriptionServer.cs
@@ -42,6 +42,9 @@ public class TestNewSubscriptionServer : SubscriptionServer
     public Task<ExecutionResult> Do_ExecuteRequestAsync(OperationMessage message)
         => ExecuteRequestAsync(message);
 
+    public Task Do_OnKeepAliveLoopAsync()
+        => OnKeepAliveLoopAsync();
+
     public SubscriptionList Get_Subscriptions
         => Subscriptions;
 
@@ -56,4 +59,6 @@ public class TestNewSubscriptionServer : SubscriptionServer
     public IDocumentExecuter Get_DocumentExecuter => DocumentExecuter;
 
     public IServiceScopeFactory Get_ServiceScopeFactory => ServiceScopeFactory;
+
+    public TimeSpan Get_DefaultKeepAliveTimeout => DefaultKeepAliveTimeout;
 }


### PR DESCRIPTION
Adds a 'secure' keep-alive mode where:
- A ping is sent on a timer from the last received pong
- Ping messages carry a unique payload (random guid)
- Received pong messages verify the payload
- If a pong is not received with the correctly id in a timely fashion, the client is forcibly disconnected

Reason:
- With subscriptions that continuously send lots of data, there is no way to determine if socket backpressure due to slow client connections is causing resource exhaustion.  This feature will validate that buffers are drained over the specified time period, as the client would not know what id to send with a pong if it did not process the incoming messages fast enough.

Consider:
- Name of KeepAliveMode enum values
- Adding separate timer property that represents the amount of time to wait for a corresponding pong after a sent ping.  Currently this just matches the ping timer.