### PR TITLE
GraphQLWs: Ping messages reflect the payload in the pong response

### DIFF
--- a/src/Transports.AspNetCore/WebSockets/GraphQLWs/SubscriptionServer.cs
+++ b/src/Transports.AspNetCore/WebSockets/GraphQLWs/SubscriptionServer.cs
@@ -123,7 +123,9 @@ public class SubscriptionServer : BaseSubscriptionServer
     /// Executes when a ping message is received.
     /// </summary>
     protected virtual Task OnPingAsync(OperationMessage message)
-        => Connection.SendMessageAsync(_pongMessage);
+        => message.Payload == null
+        ? Connection.SendMessageAsync(_pongMessage)
+        : Connection.SendMessageAsync(new OperationMessage { Type = MessageType.Pong, Payload = message.Payload });
 
     /// <summary>
     /// Executes when a pong message is received.


### PR DESCRIPTION
This behavior is currently implemented by the reference graphql-js library.