### PR TITLE
Allow accessing send queue count from WebSocketConnection

### DIFF
--- a/src/Transports.AspNetCore/WebSockets/AsyncMessagePump.cs
+++ b/src/Transports.AspNetCore/WebSockets/AsyncMessagePump.cs
@@ -23,6 +23,21 @@ internal class AsyncMessagePump<T>
     private readonly Queue<ValueTask<T>> _queue = new();
 
     /// <summary>
+    /// Returns the number of messages in the queue.
+    /// This count includes any message currently being processed.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (_queue)
+            {
+                return _queue.Count;
+            }
+        }
+    }
+
+    /// <summary>
     /// Initializes a new instance with the specified asynchronous callback delegate.
     /// </summary>
     public AsyncMessagePump(Func<T, Task> callback)

--- a/src/Transports.AspNetCore/WebSockets/WebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/WebSocketConnection.cs
@@ -44,6 +44,13 @@ public class WebSocketConnection : IWebSocketConnection
     public HttpContext HttpContext { get; }
 
     /// <summary>
+    /// Returns the number of packets waiting in the send queue, including
+    /// messages, keep-alive packets, and the close message.
+    /// This count includes any packet currently being processed.
+    /// </summary>
+    protected int SendQueueCount => _pump.Count;
+
+    /// <summary>
     /// Initializes an instance with the specified parameters.
     /// </summary>
     public WebSocketConnection(HttpContext httpContext, WebSocket webSocket, IGraphQLSerializer serializer, GraphQLWebSocketOptions options, CancellationToken requestAborted)
@@ -218,7 +225,7 @@ public class WebSocketConnection : IWebSocketConnection
     /// <remarks>
     /// The message is posted to a queue and execution returns immediately.
     /// </remarks>
-    public Task SendMessageAsync(OperationMessage message)
+    public virtual Task SendMessageAsync(OperationMessage message)
     {
         _pump.Post(new Message { OperationMessage = message });
         return Task.CompletedTask;

--- a/tests/ApiApprovalTests/net50+net60+net80/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/net50+net60+net80/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -340,6 +340,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         public Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }
         public System.DateTime LastMessageSentAt { get; }
         public System.Threading.CancellationToken RequestAborted { get; }
+        protected int SendQueueCount { get; }
         public System.Threading.Tasks.Task CloseAsync() { }
         public System.Threading.Tasks.Task CloseAsync(int eventId, string? description) { }
         public virtual void Dispose() { }
@@ -348,7 +349,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         protected virtual System.Threading.Tasks.Task OnDispatchMessageAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IOperationMessageProcessor operationMessageProcessor, GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnNonGracefulShutdownAsync(bool receivedCloseMessage, bool sentCloseMessage) { }
         protected virtual System.Threading.Tasks.Task OnSendMessageAsync(GraphQL.Transport.OperationMessage message) { }
-        public System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message) { }
+        public virtual System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message) { }
     }
 }
 namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs

--- a/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp21+netstandard20/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -358,6 +358,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         public Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }
         public System.DateTime LastMessageSentAt { get; }
         public System.Threading.CancellationToken RequestAborted { get; }
+        protected int SendQueueCount { get; }
         public System.Threading.Tasks.Task CloseAsync() { }
         public System.Threading.Tasks.Task CloseAsync(int eventId, string? description) { }
         public virtual void Dispose() { }
@@ -366,7 +367,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         protected virtual System.Threading.Tasks.Task OnDispatchMessageAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IOperationMessageProcessor operationMessageProcessor, GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnNonGracefulShutdownAsync(bool receivedCloseMessage, bool sentCloseMessage) { }
         protected virtual System.Threading.Tasks.Task OnSendMessageAsync(GraphQL.Transport.OperationMessage message) { }
-        public System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message) { }
+        public virtual System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message) { }
     }
 }
 namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs

--- a/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
+++ b/tests/ApiApprovalTests/netcoreapp31/GraphQL.Server.Transports.AspNetCore.approved.txt
@@ -340,6 +340,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         public Microsoft.AspNetCore.Http.HttpContext HttpContext { get; }
         public System.DateTime LastMessageSentAt { get; }
         public System.Threading.CancellationToken RequestAborted { get; }
+        protected int SendQueueCount { get; }
         public System.Threading.Tasks.Task CloseAsync() { }
         public System.Threading.Tasks.Task CloseAsync(int eventId, string? description) { }
         public virtual void Dispose() { }
@@ -348,7 +349,7 @@ namespace GraphQL.Server.Transports.AspNetCore.WebSockets
         protected virtual System.Threading.Tasks.Task OnDispatchMessageAsync(GraphQL.Server.Transports.AspNetCore.WebSockets.IOperationMessageProcessor operationMessageProcessor, GraphQL.Transport.OperationMessage message) { }
         protected virtual System.Threading.Tasks.Task OnNonGracefulShutdownAsync(bool receivedCloseMessage, bool sentCloseMessage) { }
         protected virtual System.Threading.Tasks.Task OnSendMessageAsync(GraphQL.Transport.OperationMessage message) { }
-        public System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message) { }
+        public virtual System.Threading.Tasks.Task SendMessageAsync(GraphQL.Transport.OperationMessage message) { }
     }
 }
 namespace GraphQL.Server.Transports.AspNetCore.WebSockets.GraphQLWs

--- a/tests/Transports.AspNetCore.Tests/WebSockets/TestWebSocketConnection.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/TestWebSocketConnection.cs
@@ -25,4 +25,6 @@ public class TestWebSocketConnection : WebSocketConnection
 
     public TimeSpan Get_DefaultDisconnectionTimeout
         => DefaultDisconnectionTimeout;
+
+    public int Get_SendQueueCount => base.SendQueueCount;
 }


### PR DESCRIPTION
Allows derived classes to check the send queue count and override SendMessageAsync in case the number of messages in the outbound queue is growing out of control.  Perhaps in the future backpressure options will be available as a built-in feature, but with #1154 it should not be necessary.