### PR TITLE
Pin playground to v1.7.28 and add polyfill for mutation events

### DIFF
--- a/src/Ui.Playground/Internal/playground.cshtml
+++ b/src/Ui.Playground/Internal/playground.cshtml
@@ -4,9 +4,10 @@
   <meta charset=utf-8 />
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>Graphcool Playground</title>
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
-  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
-  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.28/build/static/css/index.css" integrity="sha384-xb+UHILNN4fV3NgQMTjXk0x9A80U0hmkraTFvucUYTILJymGT8E1Aq2278NSi5+3" crossorigin="anonymous">
+  <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.28/build/favicon.png" />
+  <script src="https://cdn.jsdelivr.net/npm/mutation-events@1.0.8/src/mutation_events.min.js" integrity="sha384-3WfzKl+0b7sgUYFL5hMJv2xX3pkwyJd8uywnpsInos6fjSNB2zYFlaSgMP3/Lgpq" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.28/build/static/js/middleware.js" integrity="sha384-ardaO17esJ2ZxvY24V1OE6X4j+Z3WKgGMptrlDLmD+2w/JC3nbQ5ZfKGY2zfOPEE" crossorigin="anonymous"></script>
 </head>
 <body>
   <div id="root">
@@ -41,7 +42,7 @@
         font-weight: 400;
       }
     </style>
-    <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
+    <img src='https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.28/build/logo.png' alt=''>
     <div class="loading">
       Loading <span class="title">GraphQL Playground</span>
     </div>


### PR DESCRIPTION
Closes:
- #1158 

See:
- https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
- https://developer.chrome.com/blog/mutation-events-deprecation
- https://github.com/mfreed7/mutation-events-polyfill#readme
- https://www.npmjs.com/package/mutation-events