### PR TITLE
Pin .NET SDK to v8

### DIFF
--- a/GraphQL.Server.sln
+++ b/GraphQL.Server.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solutio
 		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		global.json = global.json
 		graphql.snk = graphql.snk
 		LICENSE.md = LICENSE.md
 		README.md = README.md

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "allowPrerelease": false,
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Enables compatibility with the latest version of Visual Studio.

Todo later: bump .NET SDK to v9