### PR TITLE
Mark GraphQL Playground as obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Provides the following packages:
 | GraphQL.Server.All                                   | [![Nuget](https://img.shields.io/nuget/dt/GraphQL.Server.All)](https://www.nuget.org/packages/GraphQL.Server.All)                                                                     | [![Nuget](https://img.shields.io/nuget/v/GraphQL.Server.All)](https://www.nuget.org/packages/GraphQL.Server.All)                                                                     | Includes all the packages below, plus the `GraphQL.DataLoader` and `GraphQL.MemoryCache` packages |
 | GraphQL.Server.Transports.AspNetCore                 | [![Nuget](https://img.shields.io/nuget/dt/GraphQL.Server.Transports.AspNetCore)](https://www.nuget.org/packages/GraphQL.Server.Transports.AspNetCore)                                 | [![Nuget](https://img.shields.io/nuget/v/GraphQL.Server.Transports.AspNetCore)](https://www.nuget.org/packages/GraphQL.Server.Transports.AspNetCore)                                 | Provides GraphQL over HTTP/WebSocket server support on top of ASP.NET Core, plus authorization rule support |
 | GraphQL.Server.Ui.Altair                             | [![Nuget](https://img.shields.io/nuget/dt/GraphQL.Server.Ui.Altair)](https://www.nuget.org/packages/GraphQL.Server.Ui.Altair)                                                         | [![Nuget](https://img.shields.io/nuget/v/GraphQL.Server.Ui.Altair)](https://www.nuget.org/packages/GraphQL.Server.Ui.Altair)                                                         | Provides Altair UI middleware |
-| GraphQL.Server.Ui.Playground                         | [![Nuget](https://img.shields.io/nuget/dt/GraphQL.Server.Ui.Playground)](https://www.nuget.org/packages/GraphQL.Server.Ui.Playground)                                                 | [![Nuget](https://img.shields.io/nuget/v/GraphQL.Server.Ui.Playground)](https://www.nuget.org/packages/GraphQL.Server.Ui.Playground)                                                 | Provides Playground UI middleware |
+| GraphQL.Server.Ui.Playground :warning:               | [![Nuget](https://img.shields.io/nuget/dt/GraphQL.Server.Ui.Playground)](https://www.nuget.org/packages/GraphQL.Server.Ui.Playground)                                                 | [![Nuget](https://img.shields.io/nuget/v/GraphQL.Server.Ui.Playground)](https://www.nuget.org/packages/GraphQL.Server.Ui.Playground)                                                 | Provides Playground UI middleware (deprecated) |
 | GraphQL.Server.Ui.GraphiQL                           | [![Nuget](https://img.shields.io/nuget/dt/GraphQL.Server.Ui.GraphiQL)](https://www.nuget.org/packages/GraphQL.Server.Ui.GraphiQL)                                                     | [![Nuget](https://img.shields.io/nuget/v/GraphQL.Server.Ui.GraphiQL)](https://www.nuget.org/packages/GraphQL.Server.Ui.GraphiQL)                                                     | Provides GraphiQL UI middleware |
 | GraphQL.Server.Ui.Voyager                            | [![Nuget](https://img.shields.io/nuget/dt/GraphQL.Server.Ui.Voyager)](https://www.nuget.org/packages/GraphQL.Server.Ui.Voyager)                                                       | [![Nuget](https://img.shields.io/nuget/v/GraphQL.Server.Ui.Voyager)](https://www.nuget.org/packages/GraphQL.Server.Ui.Voyager)                                                       | Provides Voyager UI middleware |
 
@@ -81,7 +81,7 @@ Then update your `Program.cs` or `Startup.cs` to configure GraphQL, registering 
 and the serialization engine as a minimum.  Configure WebSockets and GraphQL in the HTTP
 pipeline by calling `UseWebSockets` and `UseGraphQL` at the appropriate point.
 Finally, you may also include some UI middleware for easy testing of your GraphQL endpoint
-by calling `UseGraphQLVoyager` or a similar method at the appropriate point.
+by calling `UseGraphQLGraphiQL` or a similar method at the appropriate point.
 
 Below is a complete sample of a .NET 6 console app that hosts a GraphQL endpoint at
 `http://localhost:5000/graphql`:
@@ -118,9 +118,9 @@ var app = builder.Build();
 app.UseDeveloperExceptionPage();
 app.UseWebSockets();
 app.UseGraphQL("/graphql");            // url to host GraphQL endpoint
-app.UseGraphQLPlayground(
-    "/",                               // url to host Playground at
-    new GraphQL.Server.Ui.Playground.PlaygroundOptions
+app.UseGraphQLGraphiQL(
+    "/",                               // url to host GraphiQL at
+    new GraphQL.Server.Ui.GraphiQL.GraphiQLOptions
     {
         GraphQLEndPoint = "/graphql",         // url of GraphQL endpoint
         SubscriptionsEndPoint = "/graphql",   // url of GraphQL endpoint
@@ -297,11 +297,11 @@ public static IActionResult RunGraphQL(
 4. Optionally, add a UI package to the project and configure it:
 
 ```csharp
-[FunctionName("Playground")]
-public static IActionResult RunGraphQL(
+[FunctionName("GraphiQL")]
+public static IActionResult RunGraphiQL(
     [HttpTrigger(AuthorizationLevel.Anonymous, "get"] HttpRequest req)
 {
-    return new PlaygroundActionResult(opts => opts.GraphQLEndPoint = "/api/graphql");
+    return new GraphiQLActionResult(opts => opts.GraphQLEndPoint = "/api/graphql");
 }
 ```
 
@@ -534,20 +534,21 @@ field authorization will perform role and policy checks against the same authent
 ### UI configuration
 
 There are four UI middleware projects included; Altair, GraphiQL, Playground and Voyager.
+Playground has not been updated since 2019 and is deprecated in favor of GraphiQL.
 See review the following methods for configuration options within each of the 4 respective
 NuGet packages:
 
 ```csharp
 app.UseGraphQLAltair();
 app.UseGraphQLGraphiQL();
-app.UseGraphQLPlayground();
+app.UseGraphQLPlayground();  // deprecated
 app.UseGraphQLVoyager();
 
 // or
 
 endpoints.MapGraphQLAltair();
 endpoints.MapGraphQLGraphiQL();
-endpoints.MapGraphQLPlayground();
+endpoints.MapGraphQLPlayground();  // deprecated
 endpoints.MapGraphQLVoyager();
 ```
 

--- a/samples/Samples.Authorization/Program.cs
+++ b/samples/Samples.Authorization/Program.cs
@@ -61,13 +61,13 @@ app.UseWebSockets();
 // configure the graphql endpoint at "/graphql"
 app.UseGraphQL("/graphql");
 // configure Playground at "/ui/graphql"
-app.UseGraphQLPlayground(
+app.UseGraphQLGraphiQL(
     "/ui/graphql",
-    new GraphQL.Server.Ui.Playground.PlaygroundOptions
+    new GraphQL.Server.Ui.GraphiQL.GraphiQLOptions
     {
         GraphQLEndPoint = "/graphql",
         SubscriptionsEndPoint = "/graphql",
-        RequestCredentials = GraphQL.Server.Ui.Playground.RequestCredentials.Include,
+        RequestCredentials = GraphQL.Server.Ui.GraphiQL.RequestCredentials.Include,
     });
 // -------------------------------------
 

--- a/samples/Samples.Authorization/Samples.Authorization.csproj
+++ b/samples/Samples.Authorization/Samples.Authorization.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Transports.AspNetCore\Transports.AspNetCore.csproj" />
-    <ProjectReference Include="..\..\src\Ui.Playground\Ui.Playground.csproj" />
+    <ProjectReference Include="..\..\src\Ui.GraphiQL\Ui.GraphiQL.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Samples.AzureFunctions/GraphQL.cs
+++ b/samples/Samples.AzureFunctions/GraphQL.cs
@@ -20,7 +20,7 @@ public class GraphQL
         return new GraphQLExecutionActionResult();
     }
 
-    [FunctionName("Playground")]
+    [FunctionName("GraphiQL")]
     public static IActionResult RunGraphiQL(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest request,
         ILogger log)

--- a/samples/Samples.AzureFunctions/GraphQL.cs
+++ b/samples/Samples.AzureFunctions/GraphQL.cs
@@ -1,5 +1,5 @@
 using GraphQL.Server.Transports.AspNetCore;
-using GraphQL.Server.Ui.Playground;
+using GraphQL.Server.Ui.GraphiQL;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
@@ -21,12 +21,12 @@ public class GraphQL
     }
 
     [FunctionName("Playground")]
-    public static IActionResult RunPlayground(
+    public static IActionResult RunGraphiQL(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest request,
         ILogger log)
     {
-        log.LogInformation("C# HTTP trigger function processed a request for the GraphQL Playground UI.");
+        log.LogInformation("C# HTTP trigger function processed a request for the GraphiQL UI.");
 
-        return new PlaygroundActionResult(opts => opts.GraphQLEndPoint = "/api/graphql"); // /api/graphql route will call RunGraphQL method
+        return new GraphiQLActionResult(opts => opts.GraphQLEndPoint = "/api/graphql"); // /api/graphql route will call RunGraphQL method
     }
 }

--- a/samples/Samples.AzureFunctions/Samples.AzureFunctions.csproj
+++ b/samples/Samples.AzureFunctions/Samples.AzureFunctions.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Transports.AspNetCore\Transports.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Ui.GraphiQL\Ui.GraphiQL.csproj" />
-    <ProjectReference Include="..\..\src\Ui.Playground\Ui.Playground.csproj" />
     <ProjectReference Include="..\Samples.Schemas.Chat\Samples.Schemas.Chat.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Samples.Basic/Program.cs
+++ b/samples/Samples.Basic/Program.cs
@@ -15,10 +15,10 @@ app.UseDeveloperExceptionPage();
 app.UseWebSockets();
 // configure the graphql endpoint at "/graphql"
 app.UseGraphQL("/graphql");
-// configure Playground at "/"
-app.UseGraphQLPlayground(
+// configure GraphiQL at "/"
+app.UseGraphQLGraphiQL(
     "/",
-    new GraphQL.Server.Ui.Playground.PlaygroundOptions
+    new GraphQL.Server.Ui.GraphiQL.GraphiQLOptions
     {
         GraphQLEndPoint = "/graphql",
         SubscriptionsEndPoint = "/graphql",

--- a/samples/Samples.Basic/Samples.Basic.csproj
+++ b/samples/Samples.Basic/Samples.Basic.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Transports.AspNetCore\Transports.AspNetCore.csproj" />
     <ProjectReference Include="..\Samples.Schemas.Chat\Samples.Schemas.Chat.csproj" />
-    <ProjectReference Include="..\..\src\Ui.Playground\Ui.Playground.csproj" />
+    <ProjectReference Include="..\..\src\Ui.GraphiQL\Ui.GraphiQL.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Samples.Complex/Startup.cs
+++ b/samples/Samples.Complex/Startup.cs
@@ -60,6 +60,7 @@ public class Startup
             ReadFormOnPost = true,
         });
 
+#pragma warning disable CS0618 // Type or member is obsolete
         app.UseGraphQLPlayground(options: new PlaygroundOptions
         {
             BetaUpdates = true,
@@ -87,6 +88,7 @@ public class Startup
                 ["MyHeader2"] = 42,
             },
         });
+#pragma warning restore CS0618 // Type or member is obsolete
 
         app.UseGraphQLGraphiQL(options: new GraphiQLOptions
         {

--- a/samples/Samples.Complex/StartupWithRouting.cs
+++ b/samples/Samples.Complex/StartupWithRouting.cs
@@ -65,6 +65,7 @@ public class StartupWithRouting
                 ReadFormOnPost = true,
             });
 
+#pragma warning disable CS0618 // Type or member is obsolete
             endpoints.MapGraphQLPlayground(options: new PlaygroundOptions
             {
                 BetaUpdates = true,
@@ -92,6 +93,7 @@ public class StartupWithRouting
                     ["MyHeader2"] = 42,
                 },
             });
+#pragma warning restore CS0618 // Type or member is obsolete
 
             endpoints.MapGraphQLGraphiQL(options: new GraphiQLOptions
             {

--- a/samples/Samples.Cors/Program.cs
+++ b/samples/Samples.Cors/Program.cs
@@ -29,7 +29,7 @@ app.UseEndpoints(endpoints =>
     // configure the graphql endpoint at "/graphql"
     endpoints.MapGraphQL("/graphql")
         .RequireCors("MyCorsPolicy");
-    // configure Playground at "/"
-    endpoints.MapGraphQLPlayground("/");
+    // configure GraphiQL at "/"
+    endpoints.MapGraphQLGraphiQL("/");
 });
 await app.RunAsync();

--- a/samples/Samples.Cors/Samples.Cors.csproj
+++ b/samples/Samples.Cors/Samples.Cors.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Transports.AspNetCore\Transports.AspNetCore.csproj" />
     <ProjectReference Include="..\Samples.Schemas.Chat\Samples.Schemas.Chat.csproj" />
-    <ProjectReference Include="..\..\src\Ui.Playground\Ui.Playground.csproj" />
+    <ProjectReference Include="..\..\src\Ui.GraphiQL\Ui.GraphiQL.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Samples.EndpointRouting/Program.cs
+++ b/samples/Samples.EndpointRouting/Program.cs
@@ -19,7 +19,7 @@ app.UseEndpoints(endpoints =>
 {
     // configure the graphql endpoint at "/graphql"
     endpoints.MapGraphQL("/graphql");
-    // configure Playground at "/"
-    endpoints.MapGraphQLPlayground("/");
+    // configure GraphiQL at "/"
+    endpoints.MapGraphQLGraphiQL("/");
 });
 await app.RunAsync();

--- a/samples/Samples.EndpointRouting/Samples.EndpointRouting.csproj
+++ b/samples/Samples.EndpointRouting/Samples.EndpointRouting.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Transports.AspNetCore\Transports.AspNetCore.csproj" />
     <ProjectReference Include="..\Samples.Schemas.Chat\Samples.Schemas.Chat.csproj" />
-    <ProjectReference Include="..\..\src\Ui.Playground\Ui.Playground.csproj" />
+    <ProjectReference Include="..\..\src\Ui.GraphiQL\Ui.GraphiQL.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Samples.MultipleSchemas/Program.cs
+++ b/samples/Samples.MultipleSchemas/Program.cs
@@ -16,18 +16,18 @@ app.UseWebSockets();
 app.UseGraphQL<MultipleSchema.Cats.CatsSchema>("/cats/graphql");
 // configure the graphql endpoint at "/dogs/graphql"
 app.UseGraphQL<MultipleSchema.Dogs.DogsSchema>("/dogs/graphql");
-// configure Playground at "/cats/ui/playground" with relative link to api
-app.UseGraphQLPlayground(
-    "/cats/ui/playground",
-    new GraphQL.Server.Ui.Playground.PlaygroundOptions
+// configure GraphiQL at "/cats/ui/graphiql" with relative link to api
+app.UseGraphQLGraphiQL(
+    "/cats/ui/graphiql",
+    new GraphQL.Server.Ui.GraphiQL.GraphiQLOptions
     {
         GraphQLEndPoint = "../graphql",
         SubscriptionsEndPoint = "../graphql",
     });
-// configure Playground at "/dogs/ui/playground" with relative link to api
-app.UseGraphQLPlayground(
-    "/dogs/ui/playground",
-    new GraphQL.Server.Ui.Playground.PlaygroundOptions
+// configure GraphiQL at "/dogs/ui/graphiql" with relative link to api
+app.UseGraphQLGraphiQL(
+    "/dogs/ui/graphiql",
+    new GraphQL.Server.Ui.GraphiQL.GraphiQLOptions
     {
         GraphQLEndPoint = "../graphql",
         SubscriptionsEndPoint = "../graphql",

--- a/samples/Samples.MultipleSchemas/Samples.MultipleSchemas.csproj
+++ b/samples/Samples.MultipleSchemas/Samples.MultipleSchemas.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Transports.AspNetCore\Transports.AspNetCore.csproj" />
-    <ProjectReference Include="..\..\src\Ui.Playground\Ui.Playground.csproj" />
+    <ProjectReference Include="..\..\src\Ui.GraphiQL\Ui.GraphiQL.csproj" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
     <Using Include="GraphQL" />
     <Using Include="GraphQL.Types" />

--- a/src/Ui.Playground/Extensions/PlaygroundApplicationBuilderExtensions.cs
+++ b/src/Ui.Playground/Extensions/PlaygroundApplicationBuilderExtensions.cs
@@ -13,6 +13,7 @@ public static class PlaygroundApplicationBuilderExtensions
     /// <param name="options"> Options to customize <see cref="PlaygroundMiddleware"/>. If not set, then the default values will be used. </param>
     /// <param name="path">The path to the GraphQL Playground endpoint which defaults to '/ui/playground'</param>
     /// <returns> The reference to provided <paramref name="app"/> instance. </returns>
+    [Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
     public static IApplicationBuilder UseGraphQLPlayground(this IApplicationBuilder app, string path = "/ui/playground", PlaygroundOptions? options = null)
     {
         return app.UseWhen(

--- a/src/Ui.Playground/Extensions/PlaygroundEndpointRouteBuilderExtensions.cs
+++ b/src/Ui.Playground/Extensions/PlaygroundEndpointRouteBuilderExtensions.cs
@@ -17,6 +17,7 @@ public static class PlaygroundEndpointRouteBuilderExtensions
     /// <param name="options">Options to customize <see cref="PlaygroundMiddleware"/>. If not set, then the default values will be used.</param>
     /// <param name="pattern">The route pattern.</param>
     /// <returns>The <see cref="IApplicationBuilder"/> received as parameter</returns>
+    [Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
     public static PlaygroundEndpointConventionBuilder MapGraphQLPlayground(this IEndpointRouteBuilder endpoints, string pattern = "ui/playground", PlaygroundOptions? options = null)
     {
         if (endpoints == null)

--- a/src/Ui.Playground/PlaygroundActionResult.cs
+++ b/src/Ui.Playground/PlaygroundActionResult.cs
@@ -5,6 +5,7 @@ namespace GraphQL.Server.Ui.Playground;
 /// <summary>
 /// An action result that returns a Playground user interface.
 /// </summary>
+[Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
 public class PlaygroundActionResult : IActionResult
 {
     private readonly PlaygroundMiddleware _middleware;

--- a/src/Ui.Playground/PlaygroundMiddleware.cs
+++ b/src/Ui.Playground/PlaygroundMiddleware.cs
@@ -7,6 +7,7 @@ namespace GraphQL.Server.Ui.Playground;
 /// <summary>
 /// A middleware for GraphQL Playground UI.
 /// </summary>
+[Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
 public class PlaygroundMiddleware
 {
     private readonly PlaygroundOptions _options;

--- a/tests/ApiApprovalTests/ApiApprovalTests.cs
+++ b/tests/ApiApprovalTests/ApiApprovalTests.cs
@@ -11,7 +11,9 @@ public class ApiApprovalTests
     [Theory]
     [InlineData(typeof(Server.Ui.Altair.AltairMiddleware))]
     [InlineData(typeof(Server.Ui.GraphiQL.GraphiQLMiddleware))]
+#pragma warning disable CS0618 // Type or member is obsolete
     [InlineData(typeof(Server.Ui.Playground.PlaygroundMiddleware))]
+#pragma warning restore CS0618 // Type or member is obsolete
     [InlineData(typeof(Server.Ui.Voyager.VoyagerMiddleware))]
     [InlineData(typeof(Server.Transports.AspNetCore.GraphQLHttpMiddleware<>))]
     public void public_api_should_not_change_unintentionally(Type type)

--- a/tests/ApiApprovalTests/net80+netcoreapp31/GraphQL.Server.Ui.Playground.approved.txt
+++ b/tests/ApiApprovalTests/net80+netcoreapp31/GraphQL.Server.Ui.Playground.approved.txt
@@ -11,12 +11,14 @@ namespace GraphQL.Server.Ui.Playground
         Dark = 0,
         Light = 1,
     }
+    [System.Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
     public class PlaygroundActionResult : Microsoft.AspNetCore.Mvc.IActionResult
     {
         public PlaygroundActionResult(GraphQL.Server.Ui.Playground.PlaygroundOptions options) { }
         public PlaygroundActionResult(System.Action<GraphQL.Server.Ui.Playground.PlaygroundOptions>? configure = null) { }
         public System.Threading.Tasks.Task ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext context) { }
     }
+    [System.Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
     public class PlaygroundMiddleware
     {
         public PlaygroundMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, GraphQL.Server.Ui.Playground.PlaygroundOptions options) { }
@@ -59,6 +61,7 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class PlaygroundApplicationBuilderExtensions
     {
+        [System.Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
         public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLPlayground(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/playground", GraphQL.Server.Ui.Playground.PlaygroundOptions? options = null) { }
     }
     public class PlaygroundEndpointConventionBuilder : Microsoft.AspNetCore.Builder.IEndpointConventionBuilder
@@ -67,6 +70,7 @@ namespace Microsoft.AspNetCore.Builder
     }
     public static class PlaygroundEndpointRouteBuilderExtensions
     {
+        [System.Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
         public static Microsoft.AspNetCore.Builder.PlaygroundEndpointConventionBuilder MapGraphQLPlayground(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "ui/playground", GraphQL.Server.Ui.Playground.PlaygroundOptions? options = null) { }
     }
 }

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Playground.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Playground.approved.txt
@@ -11,12 +11,14 @@ namespace GraphQL.Server.Ui.Playground
         Dark = 0,
         Light = 1,
     }
+    [System.Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
     public class PlaygroundActionResult : Microsoft.AspNetCore.Mvc.IActionResult
     {
         public PlaygroundActionResult(GraphQL.Server.Ui.Playground.PlaygroundOptions options) { }
         public PlaygroundActionResult(System.Action<GraphQL.Server.Ui.Playground.PlaygroundOptions>? configure = null) { }
         public System.Threading.Tasks.Task ExecuteResultAsync(Microsoft.AspNetCore.Mvc.ActionContext context) { }
     }
+    [System.Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
     public class PlaygroundMiddleware
     {
         public PlaygroundMiddleware(Microsoft.AspNetCore.Http.RequestDelegate next, GraphQL.Server.Ui.Playground.PlaygroundOptions options) { }
@@ -59,6 +61,7 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class PlaygroundApplicationBuilderExtensions
     {
+        [System.Obsolete("GraphQL Playground has not been updated since 2019. Please use GraphiQL instead.")]
         public static Microsoft.AspNetCore.Builder.IApplicationBuilder UseGraphQLPlayground(this Microsoft.AspNetCore.Builder.IApplicationBuilder app, string path = "/ui/playground", GraphQL.Server.Ui.Playground.PlaygroundOptions? options = null) { }
     }
 }

--- a/tests/Samples.Authorization.Tests/EndToEndTests.cs
+++ b/tests/Samples.Authorization.Tests/EndToEndTests.cs
@@ -12,8 +12,8 @@ public class EndToEndTests
     private const string ACCESS_DENIED_RESPONSE = @"{""errors"":" + ACCESS_DENIED_ERRORS + "}";
 
     [Fact]
-    public Task Playground()
-        => new ServerTests<Program>().VerifyPlaygroundAsync("/ui/graphql");
+    public Task GraphiQL()
+        => new ServerTests<Program>().VerifyGraphiQLAsync("/ui/graphql");
 
     [Fact]
     public Task GraphQLGet_Success()

--- a/tests/Samples.AzureFunctions.Tests/EndToEndTests.cs
+++ b/tests/Samples.AzureFunctions.Tests/EndToEndTests.cs
@@ -41,17 +41,17 @@ public class EndToEndTests
     }
 
     [Fact]
-    public async Task Playground()
+    public async Task GraphiQL()
     {
         var (statusCode, contentType, body) = await ExecuteRequest(request =>
         {
             request.Method = "GET";
-        }, GraphQL.RunPlayground);
+        }, GraphQL.RunGraphiQL);
 
         statusCode.ShouldBe(200);
         contentType.ShouldBe("text/html");
         body.ShouldContain("<!DOCTYPE html>", Case.Insensitive);
-        body.ShouldContain("playground", Case.Insensitive);
+        body.ShouldContain("GraphiQL", Case.Insensitive);
     }
 
     private async Task<(int statusCode, string? contentType, string body)> ExecuteRequest(Action<HttpRequest> configureRequest, Func<HttpRequest, ILogger, IActionResult> func)

--- a/tests/Samples.Basic.Tests/EndToEndTests.cs
+++ b/tests/Samples.Basic.Tests/EndToEndTests.cs
@@ -5,8 +5,8 @@ namespace Samples.Basic.Tests;
 public class EndToEndTests
 {
     [Fact]
-    public Task Playground()
-        => new ServerTests<Program>().VerifyPlaygroundAsync();
+    public Task GraphiQL()
+        => new ServerTests<Program>().VerifyGraphiQLAsync();
 
     [Fact]
     public Task GraphQLGet()

--- a/tests/Samples.Cors.Tests/EndToEndTests.cs
+++ b/tests/Samples.Cors.Tests/EndToEndTests.cs
@@ -5,8 +5,8 @@ namespace Samples.Cors.Tests;
 public class EndToEndTests
 {
     [Fact]
-    public Task Playground()
-        => new ServerTests<Program>().VerifyPlaygroundAsync();
+    public Task GraphiQL()
+        => new ServerTests<Program>().VerifyGraphiQLAsync();
 
     [Fact]
     public Task GraphQLGet()

--- a/tests/Samples.EndpointRouting.Tests/EndToEndTests.cs
+++ b/tests/Samples.EndpointRouting.Tests/EndToEndTests.cs
@@ -5,8 +5,8 @@ namespace Samples.EndpointRouting.Tests;
 public class EndToEndTests
 {
     [Fact]
-    public Task Playground()
-        => new ServerTests<Program>().VerifyPlaygroundAsync();
+    public Task GraphiQL()
+        => new ServerTests<Program>().VerifyGraphiQLAsync();
 
     [Fact]
     public Task GraphQLGet()

--- a/tests/Samples.MultipleSchemas.Tests/EndToEndTests.cs
+++ b/tests/Samples.MultipleSchemas.Tests/EndToEndTests.cs
@@ -10,12 +10,12 @@ public class EndToEndTests
     private const string DOG_RESPONSE = """{"data":{"dog":{"name":"Shadow"}}}""";
 
     [Fact]
-    public Task Cats_Playground()
-        => new ServerTests<Program>().VerifyPlaygroundAsync("/cats/ui/playground");
+    public Task Cats_GraphiQL()
+        => new ServerTests<Program>().VerifyGraphiQLAsync("/cats/ui/graphiql");
 
     [Fact]
-    public Task Dogs_Playground()
-        => new ServerTests<Program>().VerifyPlaygroundAsync("/dogs/ui/playground");
+    public Task Dogs_GraphiQL()
+        => new ServerTests<Program>().VerifyGraphiQLAsync("/dogs/ui/graphiql");
 
     [Fact]
     public Task Cats_GraphQLGet()


### PR DESCRIPTION
GraphQL Playground hasn't been updated since 2019, and has been out of support since 2022.  This PR marks the helper methods to install GraphQL Playground as obsolete in favor of GraphiQL.  All samples have been converted to use GraphiQL instead of Playground.