### PR TITLE
Update JWT sample code for subscriptions

### DIFF
--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -1,3 +1,10 @@
+// Parts of this code file are based on the JwtBearerHandler class in the Microsoft.AspNetCore.Authentication.JwtBearer package found at:
+//   https://github.com/dotnet/aspnetcore/blob/5493b413d1df3aaf00651bdf1cbd8135fa63f517/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs
+//
+// Those sections of code may be subject to the MIT license found at:
+//   https://github.com/dotnet/aspnetcore/blob/5493b413d1df3aaf00651bdf1cbd8135fa63f517/LICENSE.txt
+
+using System.Security.Claims;
 using GraphQL.Server.Transports.AspNetCore.WebSockets;
 using GraphQL.Transport;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -15,9 +22,10 @@ namespace GraphQL.Server.Samples.Jwt;
 /// <list type="bullet">
 /// <item>This class is not used when authenticating over GET/POST.</item>
 /// <item>
-/// This class pulls the <see cref="TokenValidationParameters"/> instance from the instance of
-/// <see cref="IOptionsMonitor{TOptions}">IOptionsMonitor</see>&lt;<see cref="JwtBearerOptions"/>&gt; registered
-/// by ASP.NET Core during the call to <see cref="JwtBearerExtensions.AddJwtBearer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder, Action{JwtBearerOptions})">AddJwtBearer</see>.
+/// This class pulls the <see cref="JwtBearerOptions"/> instance registered by ASP.NET Core during the call to
+/// <see cref="JwtBearerExtensions.AddJwtBearer(Microsoft.AspNetCore.Authentication.AuthenticationBuilder, Action{JwtBearerOptions})">AddJwtBearer</see>
+/// for the <see cref="JwtBearerDefaults.AuthenticationScheme">Bearer</see> scheme and authenticates the token
+/// based on simplified logic used by <see cref="JwtBearerHandler"/>.
 /// </item>
 /// <item>
 /// The expected format of the payload is <c>{"Authorization":"Bearer TOKEN"}</c> where TOKEN is the JSON Web Token (JWT),
@@ -25,10 +33,18 @@ namespace GraphQL.Server.Samples.Jwt;
 /// </item>
 /// </list>
 /// </summary>
+/// <remarks>
+/// This implementation only supports the "Bearer" scheme configured in ASP.NET Core. Any scheme configured via
+/// <see cref="Transports.AspNetCore.GraphQLHttpMiddlewareOptions.AuthenticationSchemes"/> property is
+/// ignored by this implementation.
+/// </remarks>
 public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
 {
     private readonly IGraphQLSerializer _graphQLSerializer;
     private readonly IOptionsMonitor<JwtBearerOptions> _jwtBearerOptionsMonitor;
+
+    // This implementation currently only supports the "Bearer" scheme configured in ASP.NET Core
+    private static string _scheme => JwtBearerDefaults.AuthenticationScheme;
 
     public JwtWebSocketAuthenticationService(IGraphQLSerializer graphQLSerializer, IOptionsMonitor<JwtBearerOptions> jwtBearerOptionsMonitor)
     {
@@ -36,13 +52,13 @@ public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
         _jwtBearerOptionsMonitor = jwtBearerOptionsMonitor;
     }
 
-    public Task AuthenticateAsync(IWebSocketConnection connection, string subProtocol, OperationMessage operationMessage)
+    public async Task AuthenticateAsync(IWebSocketConnection connection, string subProtocol, OperationMessage operationMessage)
     {
         try
         {
             // for connections authenticated via HTTP headers, no need to reauthenticate
             if (connection.HttpContext.User.Identity?.IsAuthenticated ?? false)
-                return Task.CompletedTask;
+                return;
 
             // attempt to read the 'Authorization' key from the payload object and verify it contains "Bearer XXXXXXXX"
             var authPayload = _graphQLSerializer.ReadNode<AuthPayload>(operationMessage.Payload);
@@ -50,15 +66,56 @@ public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
             {
                 // pull the token from the value
                 var token = authPayload.Authorization.Substring(7);
-                // parse the token in the same manner that the .NET AddJwtBearer() method does:
-                // JwtSecurityTokenHandler maps the 'name' and 'role' claims to the 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name'
-                // and 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role' claims;
-                // this mapping is not performed by Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler
-                var handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
-                var tokenValidationParameters = _jwtBearerOptionsMonitor.Get(JwtBearerDefaults.AuthenticationScheme).TokenValidationParameters;
-                var principal = handler.ValidateToken(token, tokenValidationParameters, out var securityToken);
-                // set the ClaimsPrincipal for the HttpContext; authentication will take place against this object
-                connection.HttpContext.User = principal;
+
+                var options = _jwtBearerOptionsMonitor.Get(_scheme);
+
+                // follow logic simplified from JwtBearerHandler.HandleAuthenticateAsync, as follows:
+                var tokenValidationParameters = await SetupTokenValidationParametersAsync(options, connection.HttpContext).ConfigureAwait(false);
+                if (!options.UseSecurityTokenValidators)
+                {
+                    foreach (var tokenHandler in options.TokenHandlers)
+                    {
+                        try
+                        {
+                            var tokenValidationResult = await tokenHandler.ValidateTokenAsync(token, tokenValidationParameters);
+                            if (tokenValidationResult.IsValid)
+                            {
+                                var principal = new ClaimsPrincipal(tokenValidationResult.ClaimsIdentity);
+                                // set the ClaimsPrincipal for the HttpContext; authentication will take place against this object
+                                connection.HttpContext.User = principal;
+                                return;
+                            }
+                        }
+                        catch
+                        {
+                            // no errors during authentication should throw an exception
+                            // specifically, attempting to validate an invalid JWT token will result in an exception, which may be logged or simply ignored to not generate an inordinate amount of logs without purpose
+                        }
+                    }
+                }
+                else
+                {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    foreach (var validator in options.SecurityTokenValidators)
+                    {
+                        if (validator.CanReadToken(token))
+                        {
+                            try
+                            {
+                                var principal = validator.ValidateToken(token, tokenValidationParameters, out _);
+                                // set the ClaimsPrincipal for the HttpContext; authentication will take place against this object
+                                connection.HttpContext.User = principal;
+                                return;
+                            }
+                            catch
+                            {
+                                // no errors during authentication should throw an exception
+                                // specifically, attempting to validate an invalid JWT token will result in an exception, which may be logged or simply ignored to not generate an inordinate amount of logs without purpose
+                            }
+                        }
+                    }
+#pragma warning restore CS0618 // Type or member is obsolete
+                }
             }
         }
         catch
@@ -66,8 +123,30 @@ public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
             // no errors during authentication should throw an exception
             // specifically, attempting to validate an invalid JWT token will result in an exception, which may be logged or simply ignored to not generate an inordinate amount of logs without purpose
         }
+    }
 
-        return Task.CompletedTask;
+    private static async ValueTask<TokenValidationParameters> SetupTokenValidationParametersAsync(JwtBearerOptions options, HttpContext httpContext)
+    {
+        // Clone to avoid cross request race conditions for updated configurations.
+        var tokenValidationParameters = options.TokenValidationParameters.Clone();
+
+        if (options.ConfigurationManager is BaseConfigurationManager baseConfigurationManager)
+        {
+            tokenValidationParameters.ConfigurationManager = baseConfigurationManager;
+        }
+        else
+        {
+            if (options.ConfigurationManager != null)
+            {
+                // GetConfigurationAsync has a time interval that must pass before new http request will be issued.
+                var configuration = await options.ConfigurationManager.GetConfigurationAsync(httpContext.RequestAborted);
+                var issuers = new[] { configuration.Issuer };
+                tokenValidationParameters.ValidIssuers = (tokenValidationParameters.ValidIssuers == null ? issuers : tokenValidationParameters.ValidIssuers.Concat(issuers));
+                tokenValidationParameters.IssuerSigningKeys = (tokenValidationParameters.IssuerSigningKeys == null ? configuration.SigningKeys : tokenValidationParameters.IssuerSigningKeys.Concat(configuration.SigningKeys));
+            }
+        }
+
+        return tokenValidationParameters;
     }
 
     private class AuthPayload

--- a/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
+++ b/samples/Samples.Jwt/JwtWebSocketAuthenticationService.cs
@@ -31,13 +31,16 @@ namespace GraphQL.Server.Samples.Jwt;
 /// The expected format of the payload is <c>{"Authorization":"Bearer TOKEN"}</c> where TOKEN is the JSON Web Token (JWT),
 /// mirroring the format of the 'Authorization' HTTP header.
 /// </item>
-/// </list>
-/// </summary>
-/// <remarks>
+/// <item>
 /// This implementation only supports the "Bearer" scheme configured in ASP.NET Core. Any scheme configured via
 /// <see cref="Transports.AspNetCore.GraphQLHttpMiddlewareOptions.AuthenticationSchemes"/> property is
 /// ignored by this implementation.
-/// </remarks>
+/// </item>
+/// <item>
+/// Events configured in <see cref="JwtBearerOptions.Events"/> are not raised by this implementation.
+/// </item>
+/// </list>
+/// </summary>
 public class JwtWebSocketAuthenticationService : IWebSocketAuthenticationService
 {
     private readonly IGraphQLSerializer _graphQLSerializer;


### PR DESCRIPTION
The previous sample handler decoded the parsed JWT token directly using `JwtSecurityTokenHandler`.  This works fine when the `TokenValidationParameters` were all configured (including the security keys).  However, when using OIDC, the `TokenValidationParameters` should be generated from the `ConfigurationManager`, as it needs to download the keys from the OIDC endpoint before the `TokenValidationParameter` instance contains the keys.  The revised code now is a copy (without much of the event and error handling) of the `JwtBearerHandler` logic, so that validation will work similarly to however it is configured within ASP.NET Core.  Events are still not implemented at this time.

Keep in mind that while this code can be used as a guide for to how to write authorization logic for subscriptions, it is the user's responsibility to ensure that their endpoint is secure.  Perhaps in the future we may publish this code in a NuGet package, but for now it is still sample code.