### PR TITLE
Remove GraphiQL Explorer; fix headers property

### DIFF
--- a/samples/Samples.Basic/Program.cs
+++ b/samples/Samples.Basic/Program.cs
@@ -22,6 +22,7 @@ app.UseGraphQLGraphiQL(
     {
         GraphQLEndPoint = "/graphql",
         SubscriptionsEndPoint = "/graphql",
+        HeaderEditorEnabled = false,
     });
 
 await app.RunAsync();

--- a/samples/Samples.Basic/Program.cs
+++ b/samples/Samples.Basic/Program.cs
@@ -22,7 +22,6 @@ app.UseGraphQLGraphiQL(
     {
         GraphQLEndPoint = "/graphql",
         SubscriptionsEndPoint = "/graphql",
-        HeaderEditorEnabled = false,
     });
 
 await app.RunAsync();

--- a/src/Ui.GraphiQL/GraphiQLOptions.cs
+++ b/src/Ui.GraphiQL/GraphiQLOptions.cs
@@ -33,7 +33,6 @@ public class GraphiQLOptions
 
     /// <summary>
     /// Enables the header editor when <see langword="true"/>.
-    /// Not supported when <see cref="ExplorerExtensionEnabled"/> is <see langword="true"/>.
     /// </summary>
     /// <remarks>
     /// Original setting from <see href="https://github.com/graphql/graphiql/blob/08250feb6ee8335c3b1ca83a912911ae92a75722/packages/graphiql/src/components/GraphiQL.tsx#L186">GraphiQL</see>.
@@ -41,8 +40,9 @@ public class GraphiQLOptions
     public bool HeaderEditorEnabled { get; set; } = true;
 
     /// <summary>
-    /// Enables the explorer extension when <see langword="true"/>.
+    /// This property has no effect.
     /// </summary>
+    [Obsolete("This property has no effect and will be removed in a future version.")]
     public bool ExplorerExtensionEnabled { get; set; } = true;
 
     /// <summary>

--- a/src/Ui.GraphiQL/Internal/graphiql.cshtml
+++ b/src/Ui.GraphiQL/Internal/graphiql.cshtml
@@ -57,17 +57,6 @@
     crossorigin="anonymous"
   />
   <script
-    src="https://unpkg.com/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"
-    integrity="sha384-TqI6gT2PjmSrnEOTvGHLad1U4Vm5VoyzMmcKK0C/PLCWTnwPyXhCJY6NYhC/tp19"
-    crossorigin="anonymous"
-  ></script>
-  <link
-    rel="stylesheet"
-    href="https://unpkg.com/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.css"
-    integrity="sha384-GBqwox+q8UtVEyBLBKloN5QDlBDsQnuoSUfMeJH1ZtDiCrrk103D7Bg/WjIvl4ya"
-    crossorigin="anonymous"
-  />
-  <script
     src="https://unpkg.com/subscriptions-transport-ws@0.8.2/browser/client.js"
     integrity="sha384-Eqe2SG8kA+Au+rwrgfWJ+epqYAtKGW/As+WdcywebVKX7377xelWa+/il4CHiHXI"
     crossorigin="anonymous"
@@ -286,7 +275,7 @@
         onEditQuery: onEditQuery,
         onEditVariables: onEditVariables,
         onEditOperationName: onEditOperationName,
-        headerEditorEnabled: @Model.HeaderEditorEnabled,
+        isHeadersEditorEnabled: @Model.HeaderEditorEnabled,
       }),
       document.getElementById('graphiql'),
     );

--- a/tests/ApiApprovalTests/net80+netcoreapp31/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/net80+netcoreapp31/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -14,6 +14,7 @@ namespace GraphQL.Server.Ui.GraphiQL
     public class GraphiQLOptions
     {
         public GraphiQLOptions() { }
+        [System.Obsolete("This property has no effect and will be removed in a future version.")]
         public bool ExplorerExtensionEnabled { get; set; }
         public string GraphQLEndPoint { get; set; }
         public bool GraphQLWsSubscriptions { get; set; }

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.GraphiQL.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.GraphiQL.approved.txt
@@ -14,6 +14,7 @@ namespace GraphQL.Server.Ui.GraphiQL
     public class GraphiQLOptions
     {
         public GraphiQLOptions() { }
+        [System.Obsolete("This property has no effect and will be removed in a future version.")]
         public bool ExplorerExtensionEnabled { get; set; }
         public string GraphQLEndPoint { get; set; }
         public bool GraphQLWsSubscriptions { get; set; }


### PR DESCRIPTION
Changes:
- Removes GraphiQL Explorer due to incompatibility with GraphiQL 3.x
  - Fixes style problems due to conflicting CSS styles - see https://github.com/graphql-dotnet/server/discussions/1173
- Marks `ExplorerExtensionEnabled` (which did nothing) as obsolete
- Fixes `HeaderEditorEnabled` so it works properly
