### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,9 +17,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-         dotnet-version: 7.0.x
+         dotnet-version: 8.0.x
          source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
       env:
          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/samples/Samples.AzureFunctions/Samples.AzureFunctions.csproj
+++ b/samples/Samples.AzureFunctions/Samples.AzureFunctions.csproj
@@ -6,11 +6,6 @@
     <NoWarn>$(NoWarn);IDE0060</NoWarn>
   </PropertyGroup>
 
-  <!-- In-Process .NET 6 Azure Functions can't be built on Linux -->
-  <PropertyGroup Condition="'$(MSBuildRuntimeOS)'=='Linux'">
-    <SkipCompilation>true</SkipCompilation>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
@@ -28,11 +23,14 @@
     </None>
   </ItemGroup>
 
-  <!-- Skip this project on Linux -->
-  <ItemGroup Condition="'$(SkipCompilation)'=='true'">
+  <!-- In-Process .NET 6 Azure Functions can't be built on Linux -->
+  <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
     <Compile Remove="**/*.cs" />
     <PackageReference Remove="Microsoft.Azure.Functions.Extensions" />
     <PackageReference Remove="Microsoft.NET.Sdk.Functions" />
+    <ProjectReference Remove="..\..\src\Transports.AspNetCore\Transports.AspNetCore.csproj" />
+    <ProjectReference Remove="..\..\src\Ui.GraphiQL\Ui.GraphiQL.csproj" />
+    <ProjectReference Remove="..\Samples.Schemas.Chat\Samples.Schemas.Chat.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Samples.AzureFunctions/Samples.AzureFunctions.csproj
+++ b/samples/Samples.AzureFunctions/Samples.AzureFunctions.csproj
@@ -1,21 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <NoWarn>$(NoWarn);IDE0060</NoWarn>
   </PropertyGroup>
+
+  <!-- In-Process .NET 6 Azure Functions can't be built on Linux -->
+  <PropertyGroup Condition="'$(MSBuildRuntimeOS)'=='Linux'">
+    <SkipCompilation>true</SkipCompilation>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\Transports.AspNetCore\Transports.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Ui.GraphiQL\Ui.GraphiQL.csproj" />
     <ProjectReference Include="..\Samples.Schemas.Chat\Samples.Schemas.Chat.csproj" />
   </ItemGroup>
+  
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <!-- Skip this project on Linux -->
+  <ItemGroup Condition="'$(SkipCompilation)'=='true'">
+    <Compile Remove="**/*.cs" />
+    <PackageReference Remove="Microsoft.Azure.Functions.Extensions" />
+    <PackageReference Remove="Microsoft.NET.Sdk.Functions" />
+  </ItemGroup>
+
 </Project>

--- a/samples/Samples.Complex/Samples.Complex.csproj
+++ b/samples/Samples.Complex/Samples.Complex.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>GraphQL.Samples.Server</AssemblyName>
     <RootNamespace>GraphQL.Samples.Server</RootNamespace>
     <IsPackable>false</IsPackable>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Samples.AzureFunctions.Tests/Samples.AzureFunctions.Tests.csproj
+++ b/tests/Samples.AzureFunctions.Tests/Samples.AzureFunctions.Tests.csproj
@@ -7,18 +7,19 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildRuntimeOS)'=='Linux'">
-    <SkipBuild>true</SkipBuild>
+    <SkipCompilation>true</SkipCompilation>
   </PropertyGroup>
-
-  <!-- Override the CoreBuild target when building on Linux -->
-  <Target Name="CoreBuild" Condition="'$(SkipBuild)'=='true'">
-    <Message Text="Skipping test project build on Linux." Importance="high" />
-    <!-- No build actions are performed -->
-  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\..\samples\Samples.AzureFunctions\Samples.AzureFunctions.csproj" />
     <ProjectReference Include="..\Samples.Tests\Samples.Tests.csproj" />
+  </ItemGroup>
+
+  <!-- Skip this project on Linux -->
+  <ItemGroup Condition="'$(SkipCompilation)'=='true'">
+    <Compile Remove="**/*.cs" />
+    <ProjectReference Remove="..\..\samples\Samples.AzureFunctions\Samples.AzureFunctions.csproj" />
+    <ProjectReference Remove="..\Samples.Tests\Samples.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Samples.AzureFunctions.Tests/Samples.AzureFunctions.Tests.csproj
+++ b/tests/Samples.AzureFunctions.Tests/Samples.AzureFunctions.Tests.csproj
@@ -6,17 +6,13 @@
     <Description>End to end tests for the Samples.AzureFunctions project</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(MSBuildRuntimeOS)'=='Linux'">
-    <SkipCompilation>true</SkipCompilation>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\samples\Samples.AzureFunctions\Samples.AzureFunctions.csproj" />
     <ProjectReference Include="..\Samples.Tests\Samples.Tests.csproj" />
   </ItemGroup>
 
   <!-- Skip this project on Linux -->
-  <ItemGroup Condition="'$(SkipCompilation)'=='true'">
+  <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
     <Compile Remove="**/*.cs" />
     <ProjectReference Remove="..\..\samples\Samples.AzureFunctions\Samples.AzureFunctions.csproj" />
     <ProjectReference Remove="..\Samples.Tests\Samples.Tests.csproj" />

--- a/tests/Samples.AzureFunctions.Tests/Samples.AzureFunctions.Tests.csproj
+++ b/tests/Samples.AzureFunctions.Tests/Samples.AzureFunctions.Tests.csproj
@@ -6,6 +6,16 @@
     <Description>End to end tests for the Samples.AzureFunctions project</Description>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MSBuildRuntimeOS)'=='Linux'">
+    <SkipBuild>true</SkipBuild>
+  </PropertyGroup>
+
+  <!-- Override the CoreBuild target when building on Linux -->
+  <Target Name="CoreBuild" Condition="'$(SkipBuild)'=='true'">
+    <Message Text="Skipping test project build on Linux." Importance="high" />
+    <!-- No build actions are performed -->
+  </Target>
+
   <ItemGroup>
     <ProjectReference Include="..\..\samples\Samples.AzureFunctions\Samples.AzureFunctions.csproj" />
     <ProjectReference Include="..\Samples.Tests\Samples.Tests.csproj" />

--- a/tests/Samples.AzureFunctions.Tests/Samples.AzureFunctions.Tests.csproj
+++ b/tests/Samples.AzureFunctions.Tests/Samples.AzureFunctions.Tests.csproj
@@ -12,6 +12,9 @@
   </ItemGroup>
 
   <!-- Skip this project on Linux -->
+  <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
   <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
     <Compile Remove="**/*.cs" />
     <ProjectReference Remove="..\..\samples\Samples.AzureFunctions\Samples.AzureFunctions.csproj" />

--- a/tests/Samples.Complex.Tests/Samples.Complex.Tests.csproj
+++ b/tests/Samples.Complex.Tests/Samples.Complex.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <Description>End to end tests for Samples.Server project</Description>
   </PropertyGroup>
 

--- a/tests/Samples.Net48.Tests/Samples.Net48.Tests.csproj
+++ b/tests/Samples.Net48.Tests/Samples.Net48.Tests.csproj
@@ -23,6 +23,9 @@
   </ItemGroup>
 
   <!-- Skip this project on Linux -->
+  <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
   <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
     <Compile Remove="**/*.cs" />
     <ProjectReference Remove="..\..\samples\Samples.Net48\Samples.Net48.csproj" />

--- a/tests/Samples.Net48.Tests/Samples.Net48.Tests.csproj
+++ b/tests/Samples.Net48.Tests/Samples.Net48.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework><!-- netcoreapp2.1 not testable on Linux anymore -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">

--- a/tests/Samples.Net48.Tests/Samples.Net48.Tests.csproj
+++ b/tests/Samples.Net48.Tests/Samples.Net48.Tests.csproj
@@ -22,4 +22,11 @@
     <ProjectReference Include="..\Samples.Tests\Samples.Tests.csproj" />
   </ItemGroup>
 
+  <!-- Skip this project on Linux -->
+  <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
+    <Compile Remove="**/*.cs" />
+    <ProjectReference Remove="..\..\samples\Samples.Net48\Samples.Net48.csproj" />
+    <ProjectReference Remove="..\Samples.Tests\Samples.Tests.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Samples.Tests/Samples.Tests.csproj
+++ b/tests/Samples.Tests/Samples.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <Description>End to end tests for sample projects</Description>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Samples.Tests/Samples.Tests.csproj
+++ b/tests/Samples.Tests/Samples.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>net8.0;net6.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">

--- a/tests/Samples.Tests/Samples.Tests.csproj
+++ b/tests/Samples.Tests/Samples.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">

--- a/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
+++ b/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">

--- a/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
+++ b/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">

--- a/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
+++ b/tests/Transports.AspNetCore.Tests/Transports.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Tests.props" />
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>netcoreapp2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">


### PR DESCRIPTION
It seems that GitHub Actions' Linux runner has been updated with new versions of `libssl` and `libicu` (perhaps inherited from a new version of Ubuntu).  However, .NET 2.1 and 3.1 are hard-coded to only support specific versions of those libraries.  Long story short, after about 4 hours of work, I finally got the CI tests running again.  In general:

- Disabled .NET 2.1 and 3.1 and 5.0 tests when run on Linux
- Disabled Azure Function library tests when run on Linux

Almost everything still gets tested on Windows and passes as before.  It's just Linux that is having an issue.  The Azure Function sample project is demonstrating the in-process configuration model.  This model only runs on .NET 6 under Windows and will go out of support late 2026.  Perhaps sometime we can update or add a sample for the out-of-process configuration model which supports .NET 8 and is the currently-recommended integration path for Azure Functions.  Either way I believe Azure Functions always run under Windows, and so the fact that it cannot be tested on Linux is irrelevant.

As a reminder, ASP.NET Core 2.1 is still fully supported by MS on Windows when run under supported versions of the .NET Framework.  I use this configuration for one of my projects.  As such, I think it important to retain testing for ASP.NET Core 2.1 on the .NET Framework under Windows.

I'm fine if we need to drop testing for unsupported STS releases such as .NET 5.0 or old unsupported LTS releases such as .NET 3.1.  However, to the degree that it is easy enough to configure the test runner to test these platforms, especially platforms that have recently fallen out of support, I feel there is no reason not to do so.  As such, I've configured testing on as many of these platforms as will still run correctly.

The solution does provide a way to configure local testing to only use a single platform - configure the `SingleTestPlatform` msbuild property to `true`.  Or just run the specific tests you require.