### PR TITLE
Support [AllowAnonymous] along with [Authorize]

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,8 +404,8 @@ Both roles and policies are supported for output graph types, fields on output g
 and query arguments.  If multiple policies are specified, all must match; if multiple roles
 are specified, any one role must match.  You may also use `.Authorize()` and/or the
 `[Authorize]` attribute to validate that the user has authenticated.  You may also use
-`.AllowAnonymous()` and/or `[AllowAnonymous]` to allow fields to be returned to
-unauthenticated users within an graph that has an authorization requirement defined.
+`.AllowAnonymous()` and/or `[AllowAnonymous]` to allow fields to bypass authorization
+requirements defined on the type that contains the field.
 
 Please note that authorization rules do not apply to values returned within introspection requests,
 potentially leaking information about protected areas of the schema to unauthenticated users.

--- a/src/Transports.AspNetCore/AuthorizationVisitorBase.cs
+++ b/src/Transports.AspNetCore/AuthorizationVisitorBase.cs
@@ -65,10 +65,7 @@ public abstract partial class AuthorizationVisitorBase : INodeVisitor
                     _onlyAnonymousSelected.Push(ti);
 
                     // Fields, unlike types, are validated immediately.
-                    if (!fieldAnonymousAllowed)
-                    {
-                        await ValidateAsync(field, node, context);
-                    }
+                    await ValidateAsync(field, node, context);
                 }
 
                 // prep for descendants, if any

--- a/tests/Transports.AspNetCore.Tests/AuthorizationTests.cs
+++ b/tests/Transports.AspNetCore.Tests/AuthorizationTests.cs
@@ -783,7 +783,7 @@ public class AuthorizationTests : IDisposable
     [InlineData("Role1", true, false)]  // User with Role1, child requires Role2 and is anonymous - should fail
     [InlineData("Role2", true, true)]   // User with Role2, child requires Role2 and is anonymous - should pass
     [InlineData("Role1,Role2", true, true)] // User with both roles, child is anonymous - should pass
-    [InlineData(null, true, false)]     // Unauthenticated user, child is anonymous - should fail due as Role2 missing
+    [InlineData(null, true, false)]     // Unauthenticated user, child is anonymous - should fail as Role2 is missing
     public void BothAnonymousAndRequirements(string? userRoles, bool childIsAnonymous, bool expectedIsValid)
     {
         // Set up query to require Role1


### PR DESCRIPTION
This allows bypassing parent type's authorization while defining new requirements on the field. Previously any requirements on the field were ignored.

Sample:

```gql
# .AuthorizeWithRoles("Admin")
type Mutation {
  createUser(name: String!): String # requires Admin role

  # .AllowAnonymous()
  # .Authorize()
  updateOwnProfile(email: String!): Boolean # requires any authenticated user

  # .AllowAnonymous()
  submitFeedback(message: String!): Boolean # anonymous user
}
```

Recently I found that I had assumed that `.AllowAnonymous()` would stack with `.Authorize()`, but this was not the case.  So, is this a security bug fix, or a new feature?  Not sure, but I don't think it warrants a major version bump.  All prior tests pass.