### PR TITLE
Change FlushAsync to SendEndOfMessageAsync

### DIFF
--- a/src/Transports.AspNetCore/WebSockets/WebSocketConnection.cs
+++ b/src/Transports.AspNetCore/WebSockets/WebSocketConnection.cs
@@ -276,7 +276,7 @@ public class WebSocketConnection : IWebSocketConnection
     protected virtual async Task OnSendMessageAsync(OperationMessage message)
     {
         await _serializer.WriteAsync(_stream, message, RequestAborted);
-        await _stream.FlushAsync(RequestAborted);
+        await _stream.SendEndOfMessageAsync(RequestAborted);
     }
 
     /// <summary>

--- a/src/Transports.AspNetCore/WebSockets/WebSocketWriterStream.cs
+++ b/src/Transports.AspNetCore/WebSockets/WebSocketWriterStream.cs
@@ -19,10 +19,12 @@ internal class WebSocketWriterStream : Stream
 
     public override void Write(byte[] buffer, int offset, int count) => WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
 
-    public override Task FlushAsync(CancellationToken cancellationToken)
-        => _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>()), WebSocketMessageType.Text, true, cancellationToken);
+    public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-    public override void Flush() => FlushAsync().GetAwaiter().GetResult();
+    public override void Flush() { }
+
+    public Task SendEndOfMessageAsync(CancellationToken cancellationToken)
+        => _webSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>()), WebSocketMessageType.Text, true, cancellationToken);
 
     public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 

--- a/tests/Transports.AspNetCore.Tests/WebSockets/WebSocketWriterStreamTests.cs
+++ b/tests/Transports.AspNetCore.Tests/WebSockets/WebSocketWriterStreamTests.cs
@@ -57,10 +57,18 @@ public class WebSocketWriterStreamTests : IDisposable
     }
 
     [Fact]
-    public async Task FlushAsync()
+    public async Task SendEndOfMessageAsync()
     {
         _mockWebSocket.Setup(x => x.SendAsync(new ArraySegment<byte>(Array.Empty<byte>(), 0, 0), WebSocketMessageType.Text, true, default))
             .Returns(Task.CompletedTask).Verifiable();
+        await _stream.SendEndOfMessageAsync(default);
+        _mockWebSocket.Verify();
+        _mockWebSocket.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task FlushAsync()
+    {
         await _stream.FlushAsync();
         _mockWebSocket.Verify();
         _mockWebSocket.VerifyNoOtherCalls();
@@ -69,8 +77,6 @@ public class WebSocketWriterStreamTests : IDisposable
     [Fact]
     public void Flush()
     {
-        _mockWebSocket.Setup(x => x.SendAsync(new ArraySegment<byte>(Array.Empty<byte>(), 0, 0), WebSocketMessageType.Text, true, default))
-            .Returns(Task.CompletedTask).Verifiable();
         _stream.Flush();
         _mockWebSocket.Verify();
         _mockWebSocket.VerifyNoOtherCalls();


### PR DESCRIPTION
This prevents the possibility that System.Text.Json calls Flush and send an end-of-message mark when it should not.