### PR TITLE
Ensure SendCompletedAsync is called only once

### DIFF
--- a/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.Observer.cs
+++ b/src/Transports.AspNetCore/WebSockets/BaseSubscriptionServer.Observer.cs
@@ -73,6 +73,8 @@ public abstract partial class BaseSubscriptionServer
                 await _server.SendDataAsync(_id, value);
                 if (_closeAfterAnyError && value.Errors?.Count > 0)
                 {
+                    if (Interlocked.Exchange(ref _done, 1) == 1)
+                        return;
                     await _server.SendCompletedAsync(_id);
                 }
             }


### PR DESCRIPTION
The change in this PR aligns the behavior with other calls to SendCompletedAsync, ensuring that SendCompletedAsync is called only once.  As the rest of the server code gracefully immediately disconnects the observer anyway, and as it does no harm to call SendCompletedAsync multiple times, this should not have any effect upon normal operation.