### PR TITLE
Allow pinning altair-static package version via AltairOptions

### DIFF
--- a/src/Ui.Altair/AltairOptions.cs
+++ b/src/Ui.Altair/AltairOptions.cs
@@ -41,4 +41,11 @@ public class AltairOptions
     /// Gets or sets a delegate that is called after all transformations of the Altair GraphQL UI page.
     /// </summary>
     public Func<AltairOptions, string, string> PostConfigure { get; set; } = (options, result) => result;
+
+    /// <summary>
+    /// Optional parameter to pin altair-static package version, e.g. "8.5.1".
+    /// Will be used to access a specific cdn version e.g.: "https://cdn.jsdelivr.net/npm/altair-static@8.5.1/build/dist".
+    /// If empty (default value), automatic version resolution is used where no version pinning is utilized (latest).
+    /// </summary>
+    public string AltairVersion { get; set; } = string.Empty;
 }

--- a/src/Ui.Altair/Internal/AltairPageModel.cs
+++ b/src/Ui.Altair/Internal/AltairPageModel.cs
@@ -41,7 +41,11 @@ internal sealed class AltairPageModel
                 .Replace("@Model.SubscriptionsEndPoint", StringEncode(_options.SubscriptionsEndPoint))
                 .Replace("@Model.Headers", JsonSerialize(headers))
                 .Replace("@Model.SubscriptionsPayload", JsonSerialize(_options.SubscriptionsPayload))
-                .Replace("@Model.Settings", JsonSerialize(_options.Settings));
+                .Replace("@Model.Settings", JsonSerialize(_options.Settings))
+                .Replace("@Model.AltairStaticBaseUrl",
+                    string.IsNullOrEmpty(_options.AltairVersion)
+                        ? "//cdn.jsdelivr.net/npm/altair-static/build/dist"
+                        : $"//cdn.jsdelivr.net/npm/altair-static@{_options.AltairVersion}/build/dist");
 
             // Here, fully-qualified, absolute and relative URLs are supported for both the
             // GraphQLEndPoint and SubscriptionsEndPoint.  Those paths can be passed unmodified

--- a/src/Ui.Altair/Internal/altair.cshtml
+++ b/src/Ui.Altair/Internal/altair.cshtml
@@ -4,10 +4,10 @@
 <head>
   <meta charset="utf-8">
   <title>Altair</title>
-  <base href="//cdn.jsdelivr.net/npm/altair-static/build/dist/">
+  <base href="@Model.AltairStaticBaseUrl/">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="//cdn.jsdelivr.net/npm/altair-static/build/dist/favicon.ico">
-  <link href="//cdn.jsdelivr.net/npm/altair-static/build/dist/styles.css" rel="stylesheet" />
+  <link rel="icon" type="image/x-icon" href="@Model.AltairStaticBaseUrl/favicon.ico">
+  <link href="@Model.AltairStaticBaseUrl/styles.css" rel="stylesheet" />
 </head>
 
 <body>
@@ -31,8 +31,8 @@
       </div>
     </div>
   </app-root>
-  <script type="module" src="//cdn.jsdelivr.net/npm/altair-static/build/dist/polyfills.js"></script>
-  <script type="module" src="//cdn.jsdelivr.net/npm/altair-static/build/dist/main.js"></script>
+  <script type="module" src="@Model.AltairStaticBaseUrl/polyfills.js"></script>
+  <script type="module" src="@Model.AltairStaticBaseUrl/main.js"></script>
 
   <script type="module">
     function getSubscriptionsEndPoint() {

--- a/tests/ApiApprovalTests/net80+netcoreapp31/GraphQL.Server.Ui.Altair.approved.txt
+++ b/tests/ApiApprovalTests/net80+netcoreapp31/GraphQL.Server.Ui.Altair.approved.txt
@@ -14,6 +14,7 @@ namespace GraphQL.Server.Ui.Altair
     public class AltairOptions
     {
         public AltairOptions() { }
+        public string AltairVersion { get; set; }
         public string GraphQLEndPoint { get; set; }
         public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.Altair.AltairOptions, System.IO.Stream> IndexStream { get; set; }

--- a/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Altair.approved.txt
+++ b/tests/ApiApprovalTests/netstandard20/GraphQL.Server.Ui.Altair.approved.txt
@@ -14,6 +14,7 @@ namespace GraphQL.Server.Ui.Altair
     public class AltairOptions
     {
         public AltairOptions() { }
+        public string AltairVersion { get; set; }
         public string GraphQLEndPoint { get; set; }
         public System.Collections.Generic.Dictionary<string, string>? Headers { get; set; }
         public System.Func<GraphQL.Server.Ui.Altair.AltairOptions, System.IO.Stream> IndexStream { get; set; }


### PR DESCRIPTION
This PR introduces the ability for users of graphql-dotnet to explicitly pin the version of altair-static used by the Altair UI integration.
Previously, the middleware always relied on loading the latest version of Altair from a CDN. While convenient, this caused a number of issues when upstream Altair releases introduced breaking changes or unexpected behavior—changes that were immediately reflected in running applications without any modification by the user.

## Why This Matters
Relying on a moving/latest CDN target can result in:

- Sudden UI breakages after upstream releases
- Hard-to-debug regressions when the Altair team publishes updates
- Inconsistent environments between development, testing, and production

By enabling version pinning, applications get:

- Full control over the exact Altair version used
- Stable and deterministic deployments
- Separation between application updates and external frontend changes

## What This PR Does

- Adds support for specifying the exact altair-static version to load
- Falls back to the previous CDN behavior when no version is specified
- Keeps the default experience simple while giving advanced users control and stability

```
app.UseGraphQLAltair(new AltairOptions
{
    AltairVersion = "8.5.1"; // Pin a specific version (optional parameter; if not set previous CDN behaviour is used)
});
```