### PR TITLE
Add test for request decompression

### DIFF
--- a/tests/Transports.AspNetCore.Tests/Middleware/CompressionTests.cs
+++ b/tests/Transports.AspNetCore.Tests/Middleware/CompressionTests.cs
@@ -62,6 +62,55 @@ public class CompressionTests
     {
         public static string Hello => "world";
     }
+
+#if NET7_0_OR_GREATER
+    [Fact]
+    public async Task RequestDecompression_Supported()
+    {
+        // Arrange
+        var hostBuilder = new WebHostBuilder();
+        hostBuilder.ConfigureServices(services =>
+        {
+            services.AddGraphQL(b => b
+                .AddAutoSchema<Query>()
+                .AddSystemTextJson());
+            services.AddRouting();
+            services.AddRequestDecompression();
+        });
+        hostBuilder.Configure(app =>
+        {
+            app.UseRequestDecompression();
+            app.UseGraphQL();
+        });
+
+        using var server = new TestServer(hostBuilder);
+        using var client = server.CreateClient();
+
+        // Act
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/graphql");
+        var originalContent = "{hello}";
+        var compressedContentStream = new MemoryStream();
+        using (var gzipStream = new GZipStream(compressedContentStream, CompressionMode.Compress, true))
+        {
+            using var writer = new StreamWriter(gzipStream);
+            writer.Write(originalContent);
+        }
+        compressedContentStream.Seek(0, SeekOrigin.Begin);
+        request.Content = new StreamContent(compressedContentStream);
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/graphql");
+        request.Content.Headers.ContentEncoding.Add("gzip");
+
+        using var response = await client.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        // verify content
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        responseContent.ShouldBe("""{"data":{"hello":"world"}}""");
+    }
+#endif
 }
 
 #endif


### PR DESCRIPTION
I considered adding a section to the readme as follows:

> ### Request decompression
>
> ASP.NET Core supports request decompression independently of GraphQL.  Please see the [Microsoft documentation](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/request-decompression) for details on how to configure your application for request decompression.  Browsers do not normally compress requests, so this is typically only useful for non-browser clients.

However, I decided that it was such a rare need that it was not worth adding to the readme.